### PR TITLE
Fix dynamixel and file bugs, add regression tests

### DIFF
--- a/body/stretch_body/dynamixel_hello_XL430.py
+++ b/body/stretch_body/dynamixel_hello_XL430.py
@@ -42,8 +42,8 @@ class DynamixelHelloXL430(Device):
                 self.motor.enable_multiturn()
             else:
                 self.motor.enable_pos()
-                if self.params['range_t'][0]<0 or self.params['range_t']>4095:
-                    print('Warning: Invalid position rannge for %s'%self.name)
+                if self.params['range_t'][0]<0 or self.params['range_t'][1]>4095:
+                    print('Warning: Invalid position range for %s'%self.name)
             self.motor.set_pwm_limit(self.params['pwm_limit'])
             self.motor.set_temperature_limit(self.params['temperature_limit'])
             self.motor.set_min_voltage_limit(self.params['min_voltage_limit'])

--- a/body/stretch_body/hello_utils.py
+++ b/body/stretch_body/hello_utils.py
@@ -33,12 +33,12 @@ def get_fleet_directory():
     return os.environ['HELLO_FLEET_PATH']+'/'+get_fleet_id()+'/'
 
 def read_fleet_yaml(fn):
-    s = open(get_fleet_directory()+fn, 'r')
-    p = yaml.load(s,Loader=yaml.FullLoader)
-    if p is None:
-        return {}
-    else:
-        return p
+    with open(get_fleet_directory()+fn, 'r') as s:
+        p = yaml.load(s,Loader=yaml.FullLoader)
+        if p is None:
+            return {}
+        else:
+            return p
 
 def write_fleet_yaml(fn,rp):
     with open(get_fleet_directory()+fn, 'w') as yaml_file:

--- a/body/test/test_dynamixel_hello_XL430.py
+++ b/body/test/test_dynamixel_hello_XL430.py
@@ -1,0 +1,11 @@
+import unittest
+import stretch_body.dynamixel_hello_XL430
+
+
+class TestDynamixelHelloXL430(unittest.TestCase):
+
+    def test_startup_wo_multiturn(self):
+        servo = stretch_body.dynamixel_hello_XL430.DynamixelHelloXL430(name="head_tilt", chain=None, verbose=True)
+        servo.params['use_multiturn'] = False
+        self.assertTrue(servo.startup())
+        servo.stop()

--- a/body/test/test_hello_utils.py
+++ b/body/test/test_hello_utils.py
@@ -1,0 +1,13 @@
+import unittest
+import warnings
+import stretch_body.hello_utils
+
+
+class TestHelloUtils(unittest.TestCase):
+
+    def test_yaml_file_released(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            # read yaml, generating a ResourceWarning if the file is not released
+            yaml = stretch_body.hello_utils.read_fleet_yaml('stretch_re1_user_params.yaml')
+            self.assertTrue(len(w) == 0)


### PR DESCRIPTION
 - Dynamixel range is a tuple, so it can't be compared against an int
 - An open filed was never released
 - Regression tests introduced for both of these bugs

Tested on:
 - Python 3.8.5