### PR TITLE
WIP: Unit tests for non-multiturn servos

### DIFF
--- a/body/stretch_body/device.py
+++ b/body/stretch_body/device.py
@@ -31,7 +31,10 @@ class Device:
         self.verbose=verbose
         self.user_params=hello_utils.read_fleet_yaml('stretch_re1_user_params.yaml')
         self.robot_params=hello_utils.read_fleet_yaml(self.user_params['factory_params'])
-        self.robot_params.update(hello_utils.read_fleet_yaml(self.user_params['tool_params']))
+        try: #May not be present
+            self.robot_params.update(hello_utils.read_fleet_yaml(self.user_params['tool_params']))
+        except KeyError:
+            pass
         self.overwrite_params(self.robot_params,self.user_params)
         self.timestamp = DeviceTimestamp()
 

--- a/body/stretch_body/dynamixel_XL430.py
+++ b/body/stretch_body/dynamixel_XL430.py
@@ -586,12 +586,10 @@ class DynamixelXL430(Device):
         if verbose:
             print('Previous HOMING_OFFSET in EEPROM', self.get_homing_offset())
         self.set_homing_offset(0)
-        x=self.get_pos()
-        h=-1*x
+        h=-1*self.get_pos()
         if verbose:
             print('Setting homing offset to',h)
         self.set_homing_offset(h)
-        p = self.read_int32_t(XL430_ADDR_HOMING_OFFSET)
         if verbose:
             print('New HOMING_OFFSET in EEPROM', self.get_homing_offset())
             print('Current position after homing',self.get_pos())

--- a/body/stretch_body/dynamixel_hello_XL430.py
+++ b/body/stretch_body/dynamixel_hello_XL430.py
@@ -232,7 +232,6 @@ class DynamixelHelloXL430(Device):
             self.motor.enable_multiturn()
         else:
             self.motor.enable_pos()
-            sf=self.motor.get_pos()
         self.motor.set_profile_velocity(self.rad_per_sec_to_ticks(self.v_des))
         self.motor.set_profile_acceleration(self.rad_per_sec_sec_to_ticks(self.a_des))
         self.motor.enable_torque()

--- a/body/test/README.md
+++ b/body/test/README.md
@@ -1,0 +1,2 @@
+To run a test:
+python -m unittest test_x

--- a/body/test/test_dynamixel_hello_XL430.py
+++ b/body/test/test_dynamixel_hello_XL430.py
@@ -31,8 +31,10 @@ class TestDynamixelHelloXL430(unittest.TestCase):
     def test_non_multiturn_move_after_home(self):
         """Verify non-multiturn servo responds to move_to commands after homing.
         """
-        servo = stretch_body.dynamixel_hello_XL430.DynamixelHelloXL430(name="wrist_yaw", chain=None, verbose=True)
+        servo = stretch_body.dynamixel_hello_XL430.DynamixelHelloXL430(name="head_tilt", chain=None, verbose=True)
         servo.params['use_multiturn'] = False
+        servo.params['req_calibration']=True
+        servo.params['pwm_homing']=[-200,200]
         self.assertTrue(servo.startup())
 
         servo.home(single_stop=True) # calls servo.enable_pos() internally

--- a/body/test/test_dynamixel_hello_XL430.py
+++ b/body/test/test_dynamixel_hello_XL430.py
@@ -1,11 +1,43 @@
+import math
+import time
 import unittest
 import stretch_body.dynamixel_hello_XL430
 
 
 class TestDynamixelHelloXL430(unittest.TestCase):
 
-    def test_startup_wo_multiturn(self):
+    def test_non_multiturn_move_after_enable_pos(self):
+        """Verify non-multiturn servo responds to move_to commands after enable_pos.
+        """
         servo = stretch_body.dynamixel_hello_XL430.DynamixelHelloXL430(name="head_tilt", chain=None, verbose=True)
         servo.params['use_multiturn'] = False
         self.assertTrue(servo.startup())
+        servo.enable_pos()
+
+        goal_rad = -math.pi / 2
+        servo.move_to(goal_rad)
+        time.sleep(1)
+        servo.pull_status()
+        self.assertAlmostEqual(servo.status['pos'], goal_rad, places=1)
+
+        goal_rad = 0.0
+        servo.move_to(goal_rad)
+        time.sleep(1)
+        servo.pull_status()
+        self.assertAlmostEqual(servo.status['pos'], goal_rad, places=1)
+
+        servo.stop()
+
+    def test_non_multiturn_move_after_home(self):
+        """Verify non-multiturn servo responds to move_to commands after homing.
+        """
+        servo = stretch_body.dynamixel_hello_XL430.DynamixelHelloXL430(name="wrist_yaw", chain=None, verbose=True)
+        servo.params['use_multiturn'] = False
+        self.assertTrue(servo.startup())
+
+        servo.home(single_stop=True) # calls servo.enable_pos() internally
+        time.sleep(2)
+        servo.pull_status()
+        self.assertAlmostEqual(servo.status['pos'], 0.0, places=1)
+
         servo.stop()


### PR DESCRIPTION
@aedsinger Wrote a unit test called "test_non_multiturn_move_after_home" that replicates the issue described in #12. Still seeing the wrong behavior, where the servo doesn't respond to move_to(0) at the end of homing. Could you take a look at this?