### PR TITLE
Add required yaml and conditional dynamixel sdk

### DIFF
--- a/body/setup.py
+++ b/body/setup.py
@@ -26,5 +26,5 @@ setuptools.setup(
                       'inputs', 'drawnow', 'rplidar-roboticia', 'snakeviz', 'pyusb', 'SpeechRecognition', 'pixel-ring',
                       'click', 'cma', 'opencv-contrib-python', 'colorama', 'llvmlite==0.31.0', 'numba',
                       'scikit-image', 'open3d', 'pyrealsense2', 'pathlib', 'jsonschema==2.6.0', 'qtconsole==4.7.7',
-                      'gitpython', 'urdfpy', 'hello-robot-stretch-body-tools','hello-robot-stretch-factory']
+                      'gitpython', 'urdfpy', 'dynamixel-sdk >= 3.1; python_version >= "3.2.0"', 'pyyaml>=5.1', 'hello-robot-stretch-body-tools','hello-robot-stretch-factory']
 )


### PR DESCRIPTION
Python3 on Ubuntu 18.04 [requires yaml >= 5.1](https://stackoverflow.com/questions/55551191/module-yaml-has-no-attribute-fullloader)

Python3 uses the dynamixel-sdk directly, instead of borrowing ROS's (sdk not available for py2). We use [environment markers](https://stackoverflow.com/questions/21082091/install-requires-based-on-python-version/32643122#32643122) to let pip know to include dynamixel-sdk as a dependency only for python3.2 and above