### PR TITLE
llvmlite and jsonschema shouldn't be hardcoded

### DIFF
--- a/body/setup.py
+++ b/body/setup.py
@@ -25,6 +25,6 @@ setuptools.setup(
     install_requires=['numpy', 'scipy', 'matplotlib', 'ipython', 'jupyter', 'pandas', 'sympy', 'nose', 'PyYaml',
                       'inputs', 'drawnow', 'rplidar-roboticia', 'snakeviz', 'pyusb', 'SpeechRecognition', 'pixel-ring',
                       'click', 'cma', 'opencv-contrib-python', 'colorama', 'numba',
-                      'scikit-image', 'open3d', 'pyrealsense2', 'pathlib', 'psutil', 'jsonschema==2.6.0', 'qtconsole==4.7.7',
-                      'gitpython', 'urdfpy', 'dynamixel-sdk >= 3.1; python_version >= "3.2.0"', 'pyyaml>=5.1', 'hello-robot-stretch-body-tools','hello-robot-stretch-factory']
+                      'scikit-image', 'open3d', 'pyrealsense2', 'pathlib', 'psutil', 'jsonschema>=2.6.0', 'qtconsole>=4.7.7',
+                      'gitpython', 'urdfpy', 'dynamixel-sdk >= 3.1; python_version >= "3.2.0"', 'pyyaml>=5.1', 'hello-robot-stretch-factory']
 )

--- a/body/setup.py
+++ b/body/setup.py
@@ -25,6 +25,7 @@ setuptools.setup(
     install_requires=['numpy', 'scipy', 'matplotlib', 'ipython', 'jupyter', 'pandas', 'sympy', 'nose', 'PyYaml',
                       'inputs', 'drawnow', 'rplidar-roboticia', 'snakeviz', 'pyusb', 'SpeechRecognition', 'pixel-ring',
                       'click', 'cma', 'opencv-contrib-python', 'colorama', 'numba',
-                      'scikit-image', 'open3d', 'pyrealsense2', 'pathlib', 'psutil', 'jsonschema>=2.6.0', 'qtconsole>=4.7.7',
+                      'scikit-image', 'open3d', 'pyrealsense2', 'pathlib', 'psutil',
+                      'jsonschema>=2.6.0', 'qtconsole>=4.7.7', 'llvmlite == 0.31.0; python_version < "3.0"',
                       'gitpython', 'urdfpy', 'dynamixel-sdk >= 3.1; python_version >= "3.2.0"', 'pyyaml>=5.1', 'hello-robot-stretch-factory']
 )

--- a/body/setup.py
+++ b/body/setup.py
@@ -24,7 +24,7 @@ setuptools.setup(
     ],
     install_requires=['numpy', 'scipy', 'matplotlib', 'ipython', 'jupyter', 'pandas', 'sympy', 'nose', 'PyYaml',
                       'inputs', 'drawnow', 'rplidar-roboticia', 'snakeviz', 'pyusb', 'SpeechRecognition', 'pixel-ring',
-                      'click', 'cma', 'opencv-contrib-python', 'colorama', 'llvmlite==0.31.0', 'numba',
+                      'click', 'cma', 'opencv-contrib-python', 'colorama', 'numba',
                       'scikit-image', 'open3d', 'pyrealsense2', 'pathlib', 'psutil', 'jsonschema==2.6.0', 'qtconsole==4.7.7',
                       'gitpython', 'urdfpy', 'dynamixel-sdk >= 3.1; python_version >= "3.2.0"', 'pyyaml>=5.1', 'hello-robot-stretch-body-tools','hello-robot-stretch-factory']
 )

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -27,7 +27,7 @@ setuptools.setup(
     ],
     install_requires=['numpy', 'scipy', 'matplotlib', 'ipython', 'jupyter', 'pandas', 'sympy', 'nose', 'PyYaml',
                       'inputs', 'drawnow', 'rplidar-roboticia', 'snakeviz', 'pyusb', 'SpeechRecognition', 'pixel-ring',
-                      'click', 'cma', 'opencv-contrib-python', 'colorama', 'llvmlite==0.31.0', 'numba',
+                      'click', 'cma', 'opencv-contrib-python', 'colorama', 'numba',
                       'scikit-image', 'open3d', 'pyrealsense2', 'hello-robot-stretch-body', 'jsonschema==2.6.0']
 )
 

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -27,7 +27,8 @@ setuptools.setup(
     ],
     install_requires=['numpy', 'scipy', 'matplotlib', 'ipython', 'jupyter', 'pandas', 'sympy', 'nose', 'PyYaml',
                       'inputs', 'drawnow', 'rplidar-roboticia', 'snakeviz', 'pyusb', 'SpeechRecognition', 'pixel-ring',
-                      'click', 'cma', 'opencv-contrib-python', 'colorama', 'numba',
+                      'click', 'cma', 'opencv-contrib-python', 'colorama',
+                      'numba', 'llvmlite == 0.31.0; python_version < "3.0"',
                       'scikit-image', 'open3d', 'pyrealsense2', 'hello-robot-stretch-body', 'jsonschema>=2.6.0']
 )
 

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -28,7 +28,7 @@ setuptools.setup(
     install_requires=['numpy', 'scipy', 'matplotlib', 'ipython', 'jupyter', 'pandas', 'sympy', 'nose', 'PyYaml',
                       'inputs', 'drawnow', 'rplidar-roboticia', 'snakeviz', 'pyusb', 'SpeechRecognition', 'pixel-ring',
                       'click', 'cma', 'opencv-contrib-python', 'colorama', 'numba',
-                      'scikit-image', 'open3d', 'pyrealsense2', 'hello-robot-stretch-body', 'jsonschema==2.6.0']
+                      'scikit-image', 'open3d', 'pyrealsense2', 'hello-robot-stretch-body', 'jsonschema>=2.6.0']
 )
 
 #classifiers = [


### PR DESCRIPTION
right now llvmlite is hardcoded to 0.31.0 and jsonschema is also hardcoded.

but latest numba now requires llvmlite 0.36, and the latest jupyter-server requires a newer jsonschema.

So, letting llvmlite be transitively be pulled by numba is better, and jsonschema with a `>=` is better.

Separately, there is a circular dependency of `hello-robot-stretch-body` depending on `hello-robot-stretch-body-tools`, and `hello-robot-stretch-body-tools` depends on `hello-robot-stretch-body`.

I removed the dependency of `hello-robot-stretch-body` on `hello-robot-stretch-body-tools` to remove circular dependencies.