### PR TITLE
Mitigation for Dynamixel thread crash

### DIFF
--- a/body/stretch_body/dynamixel_X_chain.py
+++ b/body/stretch_body/dynamixel_X_chain.py
@@ -112,6 +112,8 @@ class DynamixelXChain(Device):
                         self.motors[m].pull_status()
         except IOError:
             self.logger.error('Pull Status IOError on: %s'%self.usb)
+        except IndexError:
+            self.logger.error('Pull Status IndexError on: %s'%self.usb)
 
     def pretty_print(self):
         print('--- Dynamixel X Chain ---')


### PR DESCRIPTION
This mitigates the issue reported in https://github.com/hello-robot/stretch_body/issues/44

I am not experienced with dynamixel servos to know if this is a permanent fix, or if there's a better way to handle the error codes from dynamixel more correctly.