### PR TITLE
adjusted param so is_moving flags not subject to encoder noise

### DIFF
--- a/body/stretch_body/robot_params.py
+++ b/body/stretch_body/robot_params.py
@@ -18,6 +18,18 @@ factory_params = {
     "robot_collision": {
         'models': ['collision_arm_camera']
     },
+    'hello-motor-arm':{
+    'gains':{'vel_near_setpoint_d': 3.5}
+    },
+    'hello-motor-lift':{
+    'gains':{'vel_near_setpoint_d': 3.5}
+    },
+    'hello-motor-right-wheel':{
+    'gains':{'vel_near_setpoint_d': 3.5}
+    },
+    'hello-motor-left-wheel':{
+    'gains':{'vel_near_setpoint_d': 3.5}
+    },
     "head": {
         "use_group_sync_read": 1,
         "retry_on_comm_failure": 1,

--- a/body/test/test_steppers.py
+++ b/body/test/test_steppers.py
@@ -1,0 +1,26 @@
+# Logging level must be set before importing any stretch_body class
+import stretch_body.robot_params
+stretch_body.robot_params.RobotParams.set_logging_level("DEBUG")
+
+import unittest
+import stretch_body.stepper
+
+import time
+
+
+class TestSteppers(unittest.TestCase):
+
+    def test_is_moving(self):
+        """Test that is_moving is False when no motion
+        """
+        motors=['/dev/hello-motor-left-wheel','/dev/hello-motor-right-wheel','/dev/hello-motor-arm','/dev/hello-motor-lift']
+        for m in motors:
+            print('Testing is moving for %s'%m)
+            s = stretch_body.stepper.Stepper(m)
+            self.assertTrue(s.startup())
+            for i in range(50):
+                s.pull_status()
+                self.assertFalse(s.status['is_moving'])
+                time.sleep(0.1)
+            s.stop()
+


### PR DESCRIPTION
This adjusts the factory settings for the `is_moving` status flags of the steppers (in robot_params). Also adds a unittest for to check that `is_moving` is False when the robot is stationary. 

Also see https://github.com/hello-robot/stretch_body/issues/47
