### PR TITLE
Bugfix/dxl thread starve

### DIFF
--- a/body/stretch_body/dynamixel_XL430.py
+++ b/body/stretch_body/dynamixel_XL430.py
@@ -102,6 +102,9 @@ BAUD_MAP = {
     4500000: 7
 }
 
+class DynamixelCommError(Exception):
+    pass
+
 
 class DynamixelXL430():
     """
@@ -220,7 +223,8 @@ class DynamixelXL430():
         self.comm_errors = self.comm_errors + 1
         self.logger.debug('DXL Comm Error on %s ID %d. Attempted %s. Result %d. Error %d. Code %s. Total Errors %d.' %
             (self.usb, self.dxl_id, fx, dxl_comm_result, dxl_error, COMM_CODES[dxl_comm_result], self.comm_errors))
-        return False
+        raise DynamixelCommError
+
 
     def get_comm_errors(self):
         return self.comm_errors
@@ -310,7 +314,7 @@ class DynamixelXL430():
     #Hello Robot Specific
     def is_calibrated(self):
         if not self.hw_valid:
-            False
+            return False
         with self.pt_lock:
             p, dxl_comm_result, dxl_error = self.packet_handler.read1ByteTxRx(self.port_handler, self.dxl_id, XL430_ADDR_HELLO_CALIBRATED)
         self.handle_comm_result('XL430_ADDR_HELLO_CALIBRATED', dxl_comm_result, dxl_error)

--- a/body/stretch_body/dynamixel_X_chain.py
+++ b/body/stretch_body/dynamixel_X_chain.py
@@ -6,6 +6,7 @@ import time
 # /opt/ros/melodic/lib/python2.7/dist-packages/dynamixel_sdk/
 from dynamixel_sdk.robotis_def import *
 from stretch_body.dynamixel_XL430 import *
+from stretch_body.dynamixel_hello_XL430 import DynamixelCommErrorStats
 import dynamixel_sdk.port_handler as prh
 import dynamixel_sdk.packet_handler as pch
 import dynamixel_sdk.group_sync_read as gsr
@@ -23,6 +24,7 @@ class DynamixelXChain(Device):
         self.pt_lock = threading.RLock()
 
         try:
+            prh.LATENCY_TIMER = self.params['dxl_latency_timer']
             self.port_handler = prh.PortHandler(usb)
             self.port_handler.openPort()
             self.port_handler.setBaudRate(int(self.params['baud']))
@@ -38,29 +40,42 @@ class DynamixelXChain(Device):
         self.motors = {}
         self.readers={}
         self.runstop_last=None
-
+        self.comm_errors = DynamixelCommErrorStats(name, logger=self.logger)
 
     def add_motor(self,m):
         self.motors[m.name]=m
 
     def startup(self):
         if not self.hw_valid:
+            for mk in self.motors.keys(): #Provide nop data
+                self.status[mk] = self.motors[mk].status
             return False
         if len(self.motors.keys()):
-            if self.params['use_group_sync_read']:
-                self.readers['pos']=gsr.GroupSyncRead(self.port_handler, self.packet_handler, XL430_ADDR_PRESENT_POSITION,4)
-                self.readers['effort']=gsr.GroupSyncRead(self.port_handler, self.packet_handler, XL430_ADDR_PRESENT_LOAD,2)
-                self.readers['vel'] = gsr.GroupSyncRead(self.port_handler, self.packet_handler, XL430_ADDR_PRESENT_VELOCITY,4)
-                self.readers['temp'] = gsr.GroupSyncRead(self.port_handler, self.packet_handler, XL430_ADDR_PRESENT_TEMPERATURE,1)
-                self.readers['hardware_error'] = gsr.GroupSyncRead(self.port_handler, self.packet_handler, XL430_ADDR_HARDWARE_ERROR_STATUS, 1)
+            try:
+                if self.params['use_group_sync_read']:
+                    self.readers['pos'] = gsr.GroupSyncRead(self.port_handler, self.packet_handler,
+                                                            XL430_ADDR_PRESENT_POSITION, 4)
+                    self.readers['effort'] = gsr.GroupSyncRead(self.port_handler, self.packet_handler,
+                                                               XL430_ADDR_PRESENT_LOAD, 2)
+                    self.readers['vel'] = gsr.GroupSyncRead(self.port_handler, self.packet_handler,
+                                                            XL430_ADDR_PRESENT_VELOCITY, 4)
+                    self.readers['temp'] = gsr.GroupSyncRead(self.port_handler, self.packet_handler,
+                                                             XL430_ADDR_PRESENT_TEMPERATURE, 1)
+                    self.readers['hardware_error'] = gsr.GroupSyncRead(self.port_handler, self.packet_handler,
+                                                                       XL430_ADDR_HARDWARE_ERROR_STATUS, 1)
+                    for mk in self.motors.keys():
+                        for k in self.readers.keys():
+                            if not self.readers[k].addParam(self.motors[mk].motor.dxl_id):
+                                self.logger.error('Dynamixel X sync read initialization failed.')
+                                raise DynamixelCommError
                 for mk in self.motors.keys():
-                    for k in self.readers.keys():
-                        if not self.readers[k].addParam(self.motors[mk].motor.dxl_id):
-                            raise IOError('Dynamixel X sync read initialization failed.')
-            for mk in self.motors.keys():
-                self.motors[mk].startup()
-                self.status[mk] = self.motors[mk].status
-            self.pull_status()
+                    self.motors[mk].startup()
+                    self.status[mk] = self.motors[mk].status
+                self.pull_status()
+            except DynamixelCommError:
+                self.comm_errors.add_error(rx=True,gsr=True)
+                self.hw_valid = False
+                return False
         return True
 
     def stop(self):
@@ -77,23 +92,18 @@ class DynamixelXChain(Device):
         try:
             ts = time.time()
             if self.params['use_group_sync_read']:
-
                 pos = self.sync_read(self.readers['pos'])
                 if pos==None and self.params['retry_on_comm_failure']:
                     pos = self.sync_read(self.readers['pos'])
-
                 effort = self.sync_read(self.readers['effort'])
                 if effort == None and self.params['retry_on_comm_failure']:
                     effort = self.sync_read(self.readers['effort'])
-
                 vel = self.sync_read(self.readers['vel'])
                 if vel == None and self.params['retry_on_comm_failure']:
                     vel = self.sync_read(self.readers['vel'])
-
                 temp = self.sync_read(self.readers['temp'])
                 if temp == None and self.params['retry_on_comm_failure']:
                     temp = self.sync_read(self.readers['temp'])
-
                 hardware_error = self.sync_read(self.readers['hardware_error'])
                 if hardware_error == None and self.params['retry_on_comm_failure']:
                     hardware_error = self.sync_read(self.readers['hardware_error'])
@@ -104,14 +114,16 @@ class DynamixelXChain(Device):
                         data = {'x':pos[idx], 'v': vel[idx],'eff': effort[idx], 'ts': ts, 'temp': temp[idx], 'err':hardware_error[idx]}
                         self.motors[mk].pull_status(data)
                         idx=idx+1
-                #else:
-                #    print("Communication error. Failed to pull status on %s"%self.usb)
+                else:
+                    raise DynamixelCommError
             else:
                 for m in self.motors:
                     with self.pt_lock:
                         self.motors[m].pull_status()
-        except IOError:
-            self.logger.error('Pull Status IOError on: %s'%self.usb)
+        except(DynamixelCommError, IOError):
+            self.comm_errors.add_error(rx=True, gsr=True)
+            self.port_handler.ser.reset_output_buffer()
+            self.port_handler.ser.reset_input_buffer()
 
     def pretty_print(self):
         print('--- Dynamixel X Chain ---')
@@ -125,8 +137,8 @@ class DynamixelXChain(Device):
         with self.pt_lock:
             result = reader.txRxPacket()
         if result != COMM_SUCCESS:
-            raise IOError('Dynamixel X sync read txRxPacket failed with error code = ' + str(result))
-
+            self.logger.debug('Dynamixel X sync read txRxPacket failed with error code = ' + str(result))
+            raise DynamixelCommError
 
         def get_val(id_num):
             b = reader.getData(id_num, reader.start_address, reader.data_length)

--- a/body/stretch_body/dynamixel_hello_XL430.py
+++ b/body/stretch_body/dynamixel_hello_XL430.py
@@ -4,6 +4,49 @@ from stretch_body.device import Device
 import time
 from stretch_body.hello_utils import *
 import termios
+import numpy
+
+class DynamixelCommErrorStats(Device):
+    def __init__(self, name, logger):
+        Device.__init__(self, name='dxl_comm_errors')
+        self.name=name
+        self.status={'n_rx':0, 'n_tx':0, 'n_gsr': 0, 'error_rate_avg_hz':0}
+        self.rate_log=None
+        self.n_log=10
+        self.log_idx =0
+        self.ts_error_last=time.time()
+        self.ts_warn_last=time.time()
+        self.logger=logger
+
+    def add_error(self,rx=True, gsr=False):
+        t = time.time()
+        if type(self.rate_log)==type(None): #First error
+            self.rate_log=numpy.array([0.0] * self.n_log)
+        self.rate_log[self.log_idx]=1/(t-self.ts_error_last)
+        self.log_idx = (self.log_idx + 1) % self.n_log
+        self.status['error_rate_avg_hz'] = numpy.average(self.rate_log)
+        if rx:
+            self.status['n_rx']+=1
+        else:
+            self.status['n_tx'] += 1
+        if gsr:
+            self.status['n_gsr'] += 1
+        if t-self.ts_warn_last>self.params['warn_every_s']:
+            self.ts_warn_last=t
+            if self.status['error_rate_avg_hz']>self.params['warn_above_rate']:
+                self.logger.warning('Device %s generating %f errors per minute'%(self.name,(self.status['error_rate_avg_hz']*60)))
+        if self.params['verbose']:
+            self.pretty_print()
+
+    def pretty_print(self):
+        print('---- Dynamixel Comm Errors %s ----'%self.name)
+        print('Rate (Hz): %f' % self.status['error_rate_avg_hz'])
+        print('Rate (errors per minute): %f'%(self.status['error_rate_avg_hz']*60))
+        print('Num TX: %f'%self.status['n_tx'])
+        print('Num RX: %f' % self.status['n_rx'])
+        print('Num Group Sync RX: %f' % self.status['n_gsr'])
+
+
 
 class DynamixelHelloXL430(Device):
     """
@@ -29,6 +72,7 @@ class DynamixelHelloXL430(Device):
         self.is_calibrated=False
         self.set_soft_motion_limits(None, None)
         self.is_homing=False
+        self.comm_errors = DynamixelCommErrorStats(name,logger=self.logger)
 
     # ###########  Device Methods #############
     def set_soft_motion_limits(self,x_min=None,x_max=None):
@@ -130,11 +174,13 @@ class DynamixelHelloXL430(Device):
 
 
                 if not pos_valid or not vel_valid or not eff_valid or not temp_valid or not err_valid:
-                    self.logger.debug('Failed status communication on %s: POS %d VEL %d EFF %d TEMP %d ERR %d '%(self.name,pos_valid,vel_valid,eff_valid,temp_valid,err_valid))
-
+                    raise DynamixelCommError
                 ts = time.time()
-            except termios.error:
-                self.logger.error('Dynamixel communication error on %s: '%self.name)
+            except(termios.error, DynamixelCommError):
+                #self.logger.warning('Dynamixel communication error on %s: '%self.name)
+                self.port_handler.ser.reset_output_buffer()
+                self.port_handler.ser.reset_input_buffer()
+                self.comm_errors.add_error(rx=True,gsr=False)
                 return
         else:
             x = data['x']
@@ -255,8 +301,9 @@ class DynamixelHelloXL430(Device):
             t_des = self.world_rad_to_ticks(x_des)
             t_des = max(self.params['range_t'][0], min(self.params['range_t'][1], t_des))
             self.motor.go_to_pos(t_des)
-        except termios.error:
-            self.logger.error('Dynamixel communication error at time: %f' % time.time())
+        except (termios.error, DynamixelCommError):
+            #self.logger.warning('Dynamixel communication error on: %s' % self.name)
+            self.comm_errors.add_error(rx=False, gsr=False)
 
 
     def set_range(self,x_min=None,x_max=None):
@@ -273,63 +320,85 @@ class DynamixelHelloXL430(Device):
         self.range=[t_min,t_max]
 
     def set_motion_params(self,v_des=None,a_des=None):
-        if not self.hw_valid:
-            return
-        if v_des is not None:
-            v_des = min(self.params['motion']['max']['vel'], v_des)
+        try:
+            if not self.hw_valid:
+                return
+            if v_des is not None:
+                v_des = min(self.params['motion']['max']['vel'], v_des)
 
-            if v_des != self.v_des:
-                self.motor.set_profile_velocity(self.rad_per_sec_to_ticks(v_des))
-                self.v_des = v_des
-        if a_des is not None:
-            a_des = min(self.params['motion']['max']['accel'], a_des)
-            if a_des != self.a_des:
-                self.motor.set_profile_acceleration(self.rad_per_sec_sec_to_ticks(a_des))
-                self.a_des = a_des
+                if v_des != self.v_des:
+                    self.motor.set_profile_velocity(self.rad_per_sec_to_ticks(v_des))
+                    self.v_des = v_des
+            if a_des is not None:
+                a_des = min(self.params['motion']['max']['accel'], a_des)
+                if a_des != self.a_des:
+                    self.motor.set_profile_acceleration(self.rad_per_sec_sec_to_ticks(a_des))
+                    self.a_des = a_des
+        except (termios.error, DynamixelCommError):
+            #self.logger.warning('Dynamixel communication error on: %s' % self.name)
+            self.comm_errors.add_error(rx=False, gsr=False)
+
 
     def move_by(self,x_des, v_des=None, a_des=None):
         if not self.hw_valid:
             return
-        if abs(x_des) > 0.00002: #Avoid drift
-            x=self.motor.get_pos()
-            if not self.motor.last_comm_success and self.params['retry_on_comm_failure']:
-                x = self.motor.get_pos()
+        try:
+            if abs(x_des) > 0.00002: #Avoid drift
+                x=self.motor.get_pos()
+                if not self.motor.last_comm_success and self.params['retry_on_comm_failure']:
+                    x = self.motor.get_pos()
 
-            if self.motor.last_comm_success:
-                cx=self.ticks_to_world_rad(x)
-                self.move_to(cx + x_des, v_des, a_des)
-            else:
-                self.logger.debug('Move_By comm failure on %s' % self.name)
+                if self.motor.last_comm_success:
+                    cx=self.ticks_to_world_rad(x)
+                    self.move_to(cx + x_des, v_des, a_des)
+                else:
+                    self.logger.debug('Move_By comm failure on %s' % self.name)
+        except (termios.error, DynamixelCommError):
+            #self.logger.warning('Dynamixel communication error on: %s' % self.name)
+            self.comm_errors.add_error(rx=False, gsr=False)
 
     def quick_stop(self):
         if not self.hw_valid:
             return
-        self.motor.disable_torque()
-        self.motor.enable_torque()
+        try:
+            self.motor.disable_torque()
+            self.motor.enable_torque()
+        except (termios.error, DynamixelCommError):
+            self.comm_errors.add_error(rx=False, gsr=False)
 
     def enable_pos(self):
         if not self.hw_valid:
             return
-        self.motor.disable_torque()
-        if self.params['use_multiturn']:
-            self.motor.enable_multiturn()
-        else:
-            self.motor.enable_pos()
-        self.motor.set_profile_velocity(self.rad_per_sec_to_ticks(self.v_des))
-        self.motor.set_profile_acceleration(self.rad_per_sec_sec_to_ticks(self.a_des))
-        self.motor.enable_torque()
+        try:
+            self.motor.disable_torque()
+            if self.params['use_multiturn']:
+                self.motor.enable_multiturn()
+            else:
+                self.motor.enable_pos()
+            self.motor.set_profile_velocity(self.rad_per_sec_to_ticks(self.v_des))
+            self.motor.set_profile_acceleration(self.rad_per_sec_sec_to_ticks(self.a_des))
+            self.motor.enable_torque()
+        except (termios.error, DynamixelCommError):
+            self.comm_errors.add_error(rx=False, gsr=False)
 
     def enable_pwm(self):
         if not self.hw_valid:
             return
-        self.motor.disable_torque()
-        self.motor.enable_pwm()
-        self.motor.enable_torque()
+        try:
+            self.motor.disable_torque()
+            self.motor.enable_pwm()
+            self.motor.enable_torque()
+        except (termios.error, DynamixelCommError):
+            self.comm_errors.add_error(rx=False, gsr=False)
+
 
     def set_pwm(self,x):
         if not self.hw_valid:
             return
-        self.motor.set_pwm(x)
+        try:
+            self.motor.set_pwm(x)
+        except (termios.error, DynamixelCommError):
+            self.comm_errors.add_error(rx=False, gsr=False)
 
 # ##########################################
     """

--- a/body/stretch_body/hello_utils.py
+++ b/body/stretch_body/hello_utils.py
@@ -114,6 +114,8 @@ def pretty_print_dict(title, d):
         if type(d[k]) == dict:
             pretty_print_dict(k, d[k])
 
+
+
 class LoopStats():
     """
     Track timing statistics for control loops

--- a/body/stretch_body/robot_params.py
+++ b/body/stretch_body/robot_params.py
@@ -4,6 +4,11 @@ import logging
 
 # Do not override factory params here
 factory_params = {
+    "dxl_comm_errors":{
+        "warn_every_s":1.0,
+        "warn_above_rate":0.1,
+        'verbose':0
+    },
     "robot": {
         "tool": "tool_stretch_gripper",
         "use_collision_manager": 0,
@@ -22,11 +27,13 @@ factory_params = {
         "use_group_sync_read": 1,
         "retry_on_comm_failure": 1,
         "baud": 57600,
+        "dxl_latency_timer":64
     },
     "end_of_arm": {
         "use_group_sync_read": 1,
         "retry_on_comm_failure": 1,
         "baud": 57600,
+        "dxl_latency_timer": 64,
         'stow': {'wrist_yaw': 3.4},
         'devices': {
             'wrist_yaw': {
@@ -64,6 +71,7 @@ factory_params = {
         'use_group_sync_read': 1,
         'retry_on_comm_failure': 1,
         'baud':57600,
+        "dxl_latency_timer": 64,
         'py_class_name': 'ToolNone',
         'py_module_name': 'stretch_body.end_of_arm_tools',
         'stow': {'wrist_yaw': 3.4},
@@ -78,6 +86,7 @@ factory_params = {
         'use_group_sync_read': 1,
         'retry_on_comm_failure': 1,
         'baud':57600,
+        "dxl_latency_timer": 64,
         'py_class_name': 'ToolStretchGripper',
         'py_module_name': 'stretch_body.end_of_arm_tools',
         'stow': {'stretch_gripper': 0, 'wrist_yaw': 3.4},

--- a/body/test/test_dxl_comms.py
+++ b/body/test/test_dxl_comms.py
@@ -1,0 +1,26 @@
+# Logging level must be set before importing any stretch_body class
+import stretch_body.robot_params
+#stretch_body.robot_params.RobotParams.set_logging_level("DEBUG")
+
+import unittest
+import stretch_body.device
+import stretch_body.robot as robot
+import numpy as np
+
+class TestTimingStats(unittest.TestCase):
+    def test_thread_starvation_group_sync_read(self):
+        robot = stretch_body.robot.Robot()
+        robot.end_of_arm.params['use_group_sync_read']=1
+        print('Starting test_thread_starvation')
+        print('Latency timer of %f'%robot.end_of_arm.params['dxl_latency_timer'])
+        print('Testing on tool %s'%robot.params['tool'])
+        robot.startup()
+        try:
+            for itr in range(100): #Make large CPU load
+                x = np.random.rand(3, 1000, 1000)
+                x.tolist()
+        except (IndexError, IOError) as e:
+            self.fail("IndexError or IOError failure in comms")
+        self.assertTrue(robot.end_of_arm.comm_errors.status['n_rx']<2)
+        robot.end_of_arm.comm_errors.pretty_print()
+        robot.stop()


### PR DESCRIPTION
This adds the parameter dxl_latency_timer to the DynamixelXChain, allowing YAML configuration of the serial read timeout. It resolves the following issue: 

https://github.com/hello-robot/stretch_body/issues/44

In addition, it provides improved exception handling around Dynamixel communication errors, as well as a class to track error rates (DynamixelCommErrorStats)

This was branched from feature/loop_timing branch which also adds LoopStats and instrumentation to track the update rates of the Robot threads.
