### PR TITLE
Fixes the order in which third party tool / user params are applied

### DIFF
--- a/body/stretch_body/robot_collision_models.py
+++ b/body/stretch_body/robot_collision_models.py
@@ -112,19 +112,6 @@ class CollisionStretchGripper(RobotCollisionModel):
             else:
                 arm_retract_limit=self.params['arm_palm_beyond_base']
 
-        if 0:
-            print '--------------------------'
-            print 'Lift',status['lift']['pos']
-            print 'Arm',status['arm']['pos']
-            print 'Arm reach required',arm_reach_required
-            print 'Dist gripper forward',dist_gripper_past_forward
-
-            print 'Tool over base',tool_over_base
-            print '--'
-            print 'Arm retract limit', arm_retract_limit
-            print 'Lift limit',lift_lower_limit
-            print 'Wrist yaw limit',wrist_yaw_limit
-
         w={ 'lift':[lift_lower_limit, None], 'arm': [arm_retract_limit,None], 'wrist_yaw':wrist_yaw_limit}
 
         return w

--- a/body/stretch_body/robot_params.py
+++ b/body/stretch_body/robot_params.py
@@ -161,9 +161,9 @@ class RobotParams:
     _user_params = hello_utils.read_fleet_yaml('stretch_re1_user_params.yaml')
     _robot_params = factory_params
     hello_utils.overwrite_dict(_robot_params, hello_utils.read_fleet_yaml(_user_params.get('factory_params', '')))
-    hello_utils.overwrite_dict(_robot_params, _user_params)
     for external_params_module in _user_params.get('params', []):
         hello_utils.overwrite_dict(_robot_params, getattr(importlib.import_module(external_params_module), 'params'))
+    hello_utils.overwrite_dict(_robot_params, _user_params)
 
     @classmethod
     def get_params(cls):


### PR DESCRIPTION
The error was that user params could be overridden by third party tools' params. The user params should have the final set of overriding params.