### PR TITLE
Adds a filtered version of is_moving for the stepper status

### DIFF
--- a/body/stretch_body/robot_params.py
+++ b/body/stretch_body/robot_params.py
@@ -19,21 +19,22 @@ factory_params = {
         "base_max_velocity": 1,
         "stretch_gripper_overload": 1,
         "wrist_yaw_overload": 1,
+        "stepper_is_moving_filter": 1,
     },
     "robot_collision": {
         'models': ['collision_arm_camera']
     },
     'hello-motor-arm':{
-    'gains':{'vel_near_setpoint_d': 3.5}
+        'gains': {'vel_near_setpoint_d': 3.5}
     },
     'hello-motor-lift':{
-    'gains':{'vel_near_setpoint_d': 3.5}
+        'gains': {'vel_near_setpoint_d': 3.5}
     },
     'hello-motor-right-wheel':{
-    'gains':{'vel_near_setpoint_d': 3.5}
+        'gains': {'vel_near_setpoint_d': 3.5}
     },
     'hello-motor-left-wheel':{
-    'gains':{'vel_near_setpoint_d': 3.5}
+        'gains': {'vel_near_setpoint_d': 3.5}
     },
     "head": {
         "use_group_sync_read": 1,

--- a/body/stretch_body/robot_params.py
+++ b/body/stretch_body/robot_params.py
@@ -174,17 +174,17 @@ class RobotParams:
     """Build the parameter dictionary that is availale as stretch_body.Device().robot_params.
 
     Overwrite dictionaries in order of ascending priorty
-    1. stretch_body.robot_params.factory_params | Factory Python settings (Common across robots. Factory may modify these via Pip updates)
-    2. stretch_re1_factory_params.yaml | Factory YAML settings that shipped with the robot. (Including robot specific calibrations)
-    4. stretch_re1_user_params.yaml | Place to override factory defaults
+    1. stretch_re1_factory_params.yaml | Factory YAML settings that shipped with the robot. (Including robot specific calibrations)
+    2. stretch_body.robot_params.factory_params | Factory Python settings (Common across robots. Factory may modify these via Pip updates)
     3. Outside parameters | (eg, from stretch_tool_share.stretch_dex_wrist.params)
+    4. stretch_re1_user_params.yaml | Place to override factory defaults
     """
     _user_params = hello_utils.read_fleet_yaml('stretch_re1_user_params.yaml')
-    _robot_params = factory_params
-    hello_utils.overwrite_dict(_robot_params, hello_utils.read_fleet_yaml(_user_params.get('factory_params', '')))
-    hello_utils.overwrite_dict(_robot_params, _user_params)
+    _robot_params = hello_utils.read_fleet_yaml(_user_params.get('factory_params', ''))
+    hello_utils.overwrite_dict(_robot_params, factory_params)
     for external_params_module in _user_params.get('params', []):
         hello_utils.overwrite_dict(_robot_params, getattr(importlib.import_module(external_params_module), 'params'))
+    hello_utils.overwrite_dict(_robot_params, _user_params)
 
     @classmethod
     def get_params(cls):

--- a/body/test/test_steppers.py
+++ b/body/test/test_steppers.py
@@ -24,3 +24,17 @@ class TestSteppers(unittest.TestCase):
                 time.sleep(0.1)
             s.stop()
 
+    def test_is_moving_filtered(self):
+        """Test that is_moving_filtered is False when no motion
+        """
+        motors=['/dev/hello-motor-left-wheel','/dev/hello-motor-right-wheel','/dev/hello-motor-arm','/dev/hello-motor-lift']
+        for m in motors:
+            print('Testing is moving filtered for %s'%m)
+            s = stretch_body.stepper.Stepper(m)
+            self.assertTrue(s.startup())
+            for i in range(50):
+                s.pull_status()
+                s.step_sentry(robot=None)
+                self.assertFalse(s.status['is_moving_filtered'])
+                time.sleep(0.1)
+            s.stop()


### PR DESCRIPTION
As reported in #47 and forum [post 221](https://forum.hello-robot.com/t/221/5), a low `vel_near_setpoint_d` threshold causes the `is_moving` field of each stepper's status dict to flicker. I tried values up to 8.0 and still saw occasional flickering. This PR introduces a mode filter that should smooth out noise from the hall effect sensors. A new field called `is_moving_filtered` is introduced to the status dict. A unit test is added; the non-filtered one still fails at a threshold of 3.5 on my robot.

The other thing this PR does in 3c04d3a is order factory YAML params to be overridden by the python factory params (it was the other way around before). This allows the new threshold of 3.5 (from python params) to override the old value of 1.5 (from YAML factory). This was confirmed with the robot_params.py tool. This ordering change shouldn't break anything unless users have modified the YAML factory params.