### PR TITLE
Added ability to disable runstop on individual DXL servos

### DIFF
--- a/body/stretch_body/dynamixel_X_chain.py
+++ b/body/stretch_body/dynamixel_X_chain.py
@@ -39,7 +39,6 @@ class DynamixelXChain(Device):
         self.status={}
         self.motors = {}
         self.readers={}
-        self.runstop_last=None
         self.comm_errors = DynamixelCommErrorStats(name, logger=self.logger)
 
     def add_motor(self,m):
@@ -171,18 +170,3 @@ class DynamixelXChain(Device):
         """
         for k in self.motors.keys():
             self.motors[k].step_sentry(robot)
-
-        if self.hw_valid and self.robot_params['robot_sentry']['dynamixel_stop_on_runstop']:
-            runstop=robot.pimu.status['runstop_event']
-            if runstop is not self.runstop_last:
-                if runstop:
-                    for mk in self.motors.keys():
-                        if self.motor[mk].params['enable_runstop']:
-                            self.motors[mk].disable_torque()
-                        else:
-                            self.motors[mk].enable_torque()
-                else:
-                    for mk in self.motors.keys():
-                        self.motors[mk].enable_torque()
-            self.runstop_last=runstop
-

--- a/body/stretch_body/dynamixel_X_chain.py
+++ b/body/stretch_body/dynamixel_X_chain.py
@@ -177,10 +177,12 @@ class DynamixelXChain(Device):
             if runstop is not self.runstop_last:
                 if runstop:
                     for mk in self.motors.keys():
-                        self.motors[mk].disable_torque()
+                        if self.motor[mk].params['enable_runstop']:
+                            self.motors[mk].disable_torque()
+                        else:
+                            self.motors[mk].enable_torque()
                 else:
                     for mk in self.motors.keys():
                         self.motors[mk].enable_torque()
             self.runstop_last=runstop
-
 

--- a/body/stretch_body/dynamixel_hello_XL430.py
+++ b/body/stretch_body/dynamixel_hello_XL430.py
@@ -72,6 +72,7 @@ class DynamixelHelloXL430(Device):
         self.is_calibrated=False
         self.set_soft_motion_limits(None, None)
         self.is_homing=False
+        self.was_runstopped = False
         self.comm_errors = DynamixelCommErrorStats(name,logger=self.logger)
 
     # ###########  Device Methods #############
@@ -270,6 +271,16 @@ class DynamixelHelloXL430(Device):
         print('Stall Overload',self.status['stall_overload'])
         print('Is Calibrated',self.is_calibrated)
         #self.motor.pretty_print()
+
+    def step_sentry(self, robot):
+        if self.hw_valid and self.robot_params['robot_sentry']['dynamixel_stop_on_runstop'] and self.params['enable_runstop']:
+            is_runstopped = robot.pimu.status['runstop_event']
+            if is_runstopped is not self.was_runstopped:
+                if is_runstopped:
+                    self.disable_torque()
+                else:
+                    self.enable_torque()
+            self.was_runstopped = is_runstopped
 
     # #####################################
 

--- a/body/stretch_body/robot_params.py
+++ b/body/stretch_body/robot_params.py
@@ -58,18 +58,22 @@ factory_params = {
     "head_pan": {
         "retry_on_comm_failure": 1,
         "baud": 57600,
+        "enable_runstop": 1
     },
     "head_tilt": {
         "retry_on_comm_failure": 1,
         "baud": 57600,
+        "enable_runstop": 1
     },
     "wrist_yaw": {
         "retry_on_comm_failure": 1,
         "baud": 57600,
+        "enable_runstop": 1
     },
     "stretch_gripper": {
         "retry_on_comm_failure": 1,
         "baud": 57600,
+        "enable_runstop": 1
     },
     "base": {
         "sentry_max_velocity": {

--- a/body/stretch_body/stepper.py
+++ b/body/stretch_body/stepper.py
@@ -229,7 +229,7 @@ class Stepper(Device):
         print('Firmware version:', self.board_info['firmware_version'])
 
     def step_sentry(self, robot):
-        if self.robot_params['robot_sentry']['stepper_is_moving_filter']:
+        if self.hw_valid and self.robot_params['robot_sentry']['stepper_is_moving_filter']:
             self.is_moving_history.pop(0)
             self.is_moving_history.append(self.status['is_moving'])
             self.status['is_moving_filtered'] = max(set(self.is_moving_history), key=self.is_moving_history.count)

--- a/body/stretch_body/stretch_gripper.py
+++ b/body/stretch_body/stretch_gripper.py
@@ -75,6 +75,7 @@ class StretchGripper(DynamixelHelloXL430):
         position (slightly opening the grasp). This reduces the PID steady state error and lowers the
         commanded current. The gripper's spring design allows it to retain its grasp despite the backoff.
         """
+        DynamixelHelloXL430.step_sentry(self, robot)
         if self.hw_valid and self.robot_params['robot_sentry']['stretch_gripper_overload'] and not self.is_homing:
             if self.status['stall_overload']:
                 if self.status['effort'] < 0: #Only backoff in open direction

--- a/body/stretch_body/wrist_yaw.py
+++ b/body/stretch_body/wrist_yaw.py
@@ -35,6 +35,7 @@ class WristYaw(DynamixelHelloXL430):
         the commanded position from the current position, so as to lower the steady
         state error of the PID controller.
         """
+        DynamixelHelloXL430.step_sentry(self, robot)
         if self.hw_valid and self.robot_params['robot_sentry']['wrist_yaw_overload']:
             if self.status['stall_overload']:
                 if self.status['effort']>0:

--- a/body/test/test_dynamixel_hello_XL430.py
+++ b/body/test/test_dynamixel_hello_XL430.py
@@ -7,6 +7,7 @@ import stretch_body.dynamixel_hello_XL430
 
 import math
 import time
+from concurrent.futures import ThreadPoolExecutor
 
 
 class TestDynamixelHelloXL430(unittest.TestCase):
@@ -57,5 +58,80 @@ class TestDynamixelHelloXL430(unittest.TestCase):
         servo.home(single_stop=False, move_to_zero=True)
         servo.pull_status()
         self.assertAlmostEqual(servo.status['pos'], 0.0, places=1)
+
+        servo.stop()
+
+    def test_runstop(self):
+        """Verify dynamixel_hello respect runstop via step_sentry
+        """
+        servo = stretch_body.dynamixel_hello_XL430.DynamixelHelloXL430(name="head_pan", chain=None)
+        self.assertTrue(servo.startup())
+        servo.robot_params['robot_sentry']['dynamixel_stop_on_runstop'] = True
+        servo.params['enable_runstop'] = True
+        servo.move_to(0.0)
+        time.sleep(2)
+        to_save = {'do_interrupt': None, 'pos1': None, 'pos2': None, 'pos3': None, 'pos4': None, 'vel1': None, 'vel2': None, 'interrupts': 0}
+
+        def swivel(to_save):
+            print('interrupted swivel 1')
+            to_save['do_interrupt'] = True
+            servo.move_to(servo.soft_motion_limits[0])
+            time.sleep(3)
+            servo.pull_status()
+            to_save['pos1'] = servo.status['pos']
+
+            print('interrupted swivel 2')
+            to_save['do_interrupt'] = True
+            servo.move_to(servo.soft_motion_limits[1])
+            time.sleep(3)
+            servo.pull_status()
+            to_save['pos2'] = servo.status['pos']
+
+            print('uninterrupted swivel 3')
+            to_save['do_interrupt'] = False
+            servo.move_to(servo.soft_motion_limits[0])
+            time.sleep(3)
+            servo.pull_status()
+            to_save['pos3'] = servo.status['pos']
+
+            print('uninterrupted swivel 4')
+            to_save['do_interrupt'] = False
+            servo.move_to(0.0)
+            time.sleep(3)
+            servo.pull_status()
+            to_save['pos4'] = servo.status['pos']
+
+        def runstop_interrupter(to_save):
+            class R():
+                class P():
+                    status = {'runstop_event': False}
+                pimu = P()
+            r = R()
+            while to_save['do_interrupt']:
+                servo.pull_status()
+                if servo.status['vel'] > 0.0:
+                    time.sleep(1.0)
+                    print('interrupt at {0} rad/s'.format(servo.status['vel']))
+                    to_save['interrupts'] += 1
+                    to_save['vel1'] = servo.status['vel']
+                    r.pimu.status['runstop_event'] = True
+                    servo.step_sentry(robot=r)
+                    time.sleep(0.5) # TODO: value of 0.1 fails
+                    servo.pull_status()
+                    to_save['vel2'] = servo.status['vel']
+                    r.pimu.status['runstop_event'] = False
+                    servo.step_sentry(robot=r)
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            executor.submit(swivel, to_save)
+            executor.submit(runstop_interrupter, to_save)
+
+        self.assertEqual(to_save['interrupts'], 2)
+        self.assertNotAlmostEqual(to_save['pos1'], servo.soft_motion_limits[0], places=1)
+        self.assertNotAlmostEqual(to_save['pos2'], servo.soft_motion_limits[1], places=1)
+        self.assertAlmostEqual(to_save['pos3'], servo.soft_motion_limits[0], places=1)
+        self.assertAlmostEqual(to_save['pos4'], 0.0, places=1)
+        self.assertNotAlmostEqual(to_save['vel1'], 0.0, places=2)
+        self.assertAlmostEqual(to_save['vel2'], 0.0, places=2)
 
         servo.stop()

--- a/body/test/test_robot.py
+++ b/body/test/test_robot.py
@@ -6,6 +6,7 @@ import unittest
 import stretch_body.robot
 
 import time
+import math
 
 
 class TestRobot(unittest.TestCase):
@@ -72,4 +73,37 @@ class TestRobot(unittest.TestCase):
         # Remove custom stowing
         r.robot_params[r.params['tool']]['stow'].pop('lift', None)
         r.robot_params[r.params['tool']]['stow'].pop('arm', None)
+        r.stop()
+
+    def test_dynamixel_runstop(self):
+        """Test end_of_arm respects runstop from pimu
+        """
+        r = stretch_body.robot.Robot()
+        r.startup()
+        if not r.is_calibrated():
+            self.fail("test requires robot to be homed")
+
+        # Move robot to starting position
+        r.end_of_arm.move_to('wrist_yaw', 0.0)
+        r.end_of_arm.move_to('stretch_gripper', 100.0)
+        time.sleep(4.0)
+
+        # Begin moving to stow position
+        r.end_of_arm.move_to('wrist_yaw', math.pi)
+        r.end_of_arm.move_to('stretch_gripper', 0.0)
+        time.sleep(1.0)
+
+        # Interrupt moving to stow position
+        r.pimu.runstop_event_trigger()
+        r.push_command()
+        time.sleep(0.1)
+        r.pimu.runstop_event_reset()
+        r.push_command()
+        time.sleep(0.1)
+
+        # Verify not at stow position
+        r.pull_status()
+        self.assertNotAlmostEqual(r.status['end_of_arm']['wrist_yaw']['pos'], math.pi, places=2)
+        self.assertNotAlmostEqual(r.status['end_of_arm']['stretch_gripper']['pos'], 0.0, places=2)
+
         r.stop()


### PR DESCRIPTION
This adds the filed 'enable_runstop' to the Dynamixel params. This field then can be set on/off to allow individual servos to respect the runstop or not.