### PR TITLE
fix issue where user soft limits overwritten by collision model

### DIFF
--- a/body/stretch_body/dynamixel_hello_XL430.py
+++ b/body/stretch_body/dynamixel_hello_XL430.py
@@ -70,6 +70,7 @@ class DynamixelHelloXL430(Device):
         self.ts_over_eff_start=None
         self.hw_valid=False
         self.is_calibrated=False
+        self.soft_motion_limits = [None, None]
         self.set_soft_motion_limits(None, None)
         self.is_homing=False
         self.comm_errors = DynamixelCommErrorStats(name,logger=self.logger)

--- a/body/stretch_body/robot_collision.py
+++ b/body/stretch_body/robot_collision.py
@@ -62,9 +62,12 @@ class RobotCollision(Device):
         #Then compute the limits for each from each model
         #Take the most conservative limit for each and pass it to the controller
         status=self.robot.get_status()
-        limits= { 'head_pan': [None, None],'head_tilt': [None, None],'lift': [None, None],'arm': [None, None]}
+        limits= { 'head_pan': self.robot.head.motors['head_pan'].soft_motion_limits[:],
+                  'head_tilt': self.robot.head.motors['head_tilt'].soft_motion_limits[:],
+                  'lift': self.robot.lift.soft_motion_limits[:],
+                  'arm': self.robot.arm.soft_motion_limits[:]}
         for j in self.robot.end_of_arm.joints:
-            limits[j]=[None,None]
+            limits[j]=self.robot.end_of_arm.motors[j].soft_motion_limits[:]
 
         for m in self.models:
             new_limits=m.step(status)


### PR DESCRIPTION
The RobotCollision class was setting the joint soft limits to 'None' (eg, physical hardstop) if the collision model didn't limit the range of motion. This had the side effect of overwriting an user limits set via the `set_soft_limit` API.

This fix initializes the values of the collision system with the current values of each joint. This should resolve the issue. It hasn't yet been tested and requires a unittest.