### PR TITLE
Fix how negative dynamixel velocities are calculated

### DIFF
--- a/body/stretch_body/dynamixel_XL430.py
+++ b/body/stretch_body/dynamixel_XL430.py
@@ -553,6 +553,8 @@ class DynamixelXL430():
         with self.pt_lock:
             v, dxl_comm_result, dxl_error = self.packet_handler.read4ByteTxRx(self.port_handler, self.dxl_id, XL430_ADDR_PRESENT_VELOCITY)
         self.handle_comm_result('XL430_ADDR_PRESENT_VELOCITY', dxl_comm_result, dxl_error)
+        if v > 2 ** 24:
+            v = v - 2 ** 32
         return v
 
     def get_P_gain(self):

--- a/body/stretch_body/dynamixel_hello_XL430.py
+++ b/body/stretch_body/dynamixel_hello_XL430.py
@@ -198,7 +198,7 @@ class DynamixelHelloXL430(Device):
             self.status['pos'] = self.ticks_to_world_rad(float(x))
         if vel_valid:
             self.status['vel_ticks'] = v
-            self.status['vel'] = self.ticks_to_rad_per_sec(float(v))
+            self.status['vel'] = self.ticks_to_world_rad_per_sec(float(v))
         if eff_valid:
             self.status['effort_ticks'] = eff
             self.status['effort'] = self.ticks_to_pct_load(float(eff))

--- a/body/test/test_dynamixel_hello_XL430.py
+++ b/body/test/test_dynamixel_hello_XL430.py
@@ -109,7 +109,7 @@ class TestDynamixelHelloXL430(unittest.TestCase):
             r = R()
             while to_save['do_interrupt']:
                 servo.pull_status()
-                if servo.status['vel'] > 0.0:
+                if abs(servo.status['vel']) > 0.0:
                     time.sleep(1.0)
                     print('interrupt at {0} rad/s'.format(servo.status['vel']))
                     to_save['interrupts'] += 1


### PR DESCRIPTION
`DynamixelHelloXL430.ticks_to_world_rad_per_sec` makes sense over `DynamixelHelloXL430.ticks_to_rad_per_sec` since it agrees with how the position is changing. However, what appears to be equal velocities in both directions shows a higher positive velocity than negative. The `TestDynamixelHelloXL430.test_runstop` test shows this.

TODO:

 * Unit tests