### PR TITLE
Collision avoidance tutorial fix

### DIFF
--- a/docs/collision_avoidance_tutorial.md
+++ b/docs/collision_avoidance_tutorial.md
@@ -181,8 +181,7 @@ class CollisionArmTable(RobotCollisionModel):
             limits['lift']=[None,table_height+safety_margin]        
         return limits
 ```
-Note that if the file is not created within the stretch_body directory then the following 
-command should be run in order to add the working directory to the PYTHONPATH env , This can also be added to our bashrc to permanently edit the path: 
+The following command should be run in order to add the working directory to the PYTHONPATH env , This can also be added to our bashrc to permanently edit the path: 
 
 ```bash
 >>$ export PYTHONPATH=$PYTHONPATH:/<path_to_modules>
@@ -200,19 +199,6 @@ collision_arm_table:
   enabled: 1
   py_class_name: 'CollisionArmTable'
   py_module_name: 'collision_arm_table'
-
-```
-However if we create our custom class within the 'stretch_body' directoy the yaml file should be configured as follows:
-
-```yaml
-robot_collision:
-  models:
-  - collision_arm_table
-
-collision_arm_table:
-  enabled: 1
-  py_class_name: 'CollisionArmTable'
-  py_module_name: 'stretch_body.collision_arm_table'
 
 ```
 

--- a/docs/collision_avoidance_tutorial.md
+++ b/docs/collision_avoidance_tutorial.md
@@ -181,6 +181,13 @@ class CollisionArmTable(RobotCollisionModel):
             limits['lift']=[None,table_height+safety_margin]        
         return limits
 ```
+Note that if the file is not created within the stretch_body directory then the following 
+command should be run in order to add the working directory to the PYTHONPATH env , This can also be added to our bashrc to permanently edit the path: 
+
+```bash
+>>$ export PYTHONPATH=$PYTHONPATH:/<path_to_modules>
+```
+
 
 Next we configure RobotCollision to use our CollisionArmTable model in `stretch_re1_user_yaml`:
 
@@ -193,6 +200,19 @@ collision_arm_table:
   enabled: 1
   py_class_name: 'CollisionArmTable'
   py_module_name: 'collision_arm_table'
+
+```
+However if we create our custom class within the 'stretch_body' directoy the yaml file should be configured as follows:
+
+```yaml
+robot_collision:
+  models:
+  - collision_arm_table
+
+collision_arm_table:
+  enabled: 1
+  py_class_name: 'CollisionArmTable'
+  py_module_name: 'stretch_body.collision_arm_table'
 
 ```
 


### PR DESCRIPTION
Edited tutorial to include fix related to where the custom collision model module is created. This is to avoid import errors.