### PR TITLE
Update error handling for dxl servos for when bad hardware on bus

### DIFF
--- a/body/local_install.sh
+++ b/body/local_install.sh
@@ -1,0 +1,4 @@
+#! /bin/bash
+mkdir -p $HOME/.local/lib/python2.7/site-packages/stretch_body/
+cp stretch_body/*.py $HOME/.local/lib/python2.7/site-packages/stretch_body/
+echo "Copied python to $HOME/.local/lib/python2.7/site-packages/stretch_body/"

--- a/body/local_install.sh
+++ b/body/local_install.sh
@@ -1,4 +1,0 @@
-#! /bin/bash
-mkdir -p $HOME/.local/lib/python2.7/site-packages/stretch_body/
-cp stretch_body/*.py $HOME/.local/lib/python2.7/site-packages/stretch_body/
-echo "Copied python to $HOME/.local/lib/python2.7/site-packages/stretch_body/"

--- a/body/stretch_body/dynamixel_XL430.py
+++ b/body/stretch_body/dynamixel_XL430.py
@@ -244,17 +244,21 @@ class DynamixelXL430():
     def do_ping(self,verbose=True):
         if not self.hw_valid:
             return False
-        with self.pt_lock:
-            dxl_model_number, dxl_comm_result, dxl_error = self.packet_handler.ping(self.port_handler, self.dxl_id)
-        if self.handle_comm_result('XL430_PING', dxl_comm_result, dxl_error):
-            self.logger.debug("[Dynamixel ID:%03d] ping Succeeded. Dynamixel model number : %d" % (self.dxl_id, dxl_model_number))
-            if verbose:
-                print("[Dynamixel ID:%03d] ping Succeeded. Dynamixel model number : %d" % (self.dxl_id, dxl_model_number))
-            return True
-        else:
-            self.logger.debug("[Dynamixel ID:%03d] ping Failed." % (self.dxl_id))
-            if verbose:
-                print("[Dynamixel ID:%03d] ping Failed." % (self.dxl_id))
+        try:
+            with self.pt_lock:
+                dxl_model_number, dxl_comm_result, dxl_error = self.packet_handler.ping(self.port_handler, self.dxl_id)
+            if self.handle_comm_result('XL430_PING', dxl_comm_result, dxl_error):
+                self.logger.debug("[Dynamixel ID:%03d] ping Succeeded. Dynamixel model number : %d" % (self.dxl_id, dxl_model_number))
+                if verbose:
+                    print("[Dynamixel ID:%03d] ping Succeeded. Dynamixel model number : %d" % (self.dxl_id, dxl_model_number))
+                return True
+            else:
+                self.logger.debug("[Dynamixel ID:%03d] ping Failed." % (self.dxl_id))
+                if verbose:
+                    print("[Dynamixel ID:%03d] ping Failed." % (self.dxl_id))
+                return False
+        except DynamixelCommError:
+            self.logger.debug("[Dynamixel ID:%03d] Comm Error. Ping Failed." % (self.dxl_id))
             return False
 
     def get_id(self):

--- a/body/stretch_body/dynamixel_X_chain.py
+++ b/body/stretch_body/dynamixel_X_chain.py
@@ -45,9 +45,9 @@ class DynamixelXChain(Device):
         self.motors[m.name]=m
 
     def startup(self):
+        for mk in self.motors.keys():  # Provide nop data in case comm failures
+            self.status[mk] = self.motors[mk].status
         if not self.hw_valid:
-            for mk in self.motors.keys(): #Provide nop data
-                self.status[mk] = self.motors[mk].status
             return False
         if len(self.motors.keys()):
             try:

--- a/tools/bin/stretch_robot_system_check.py
+++ b/tools/bin/stretch_robot_system_check.py
@@ -77,12 +77,12 @@ if robot_devices['hello-dynamixel-wrist']:
         for mk in w.motors.keys():
             if w.motors[mk].do_ping():
                 print(Fore.GREEN +'[Pass] Ping of: '+mk)
+                if w.motors[mk].motor.is_calibrated():
+                    print(Fore.GREEN + '[Pass] Calibrated: ' + mk)
+                else:
+                    print(Fore.RED + '[Fail] Not Calibrated: ' + mk)
             else:
                 print(Fore.RED + '[Fail] Ping of: ' + mk)
-            if w.motors[mk].motor.is_calibrated():
-                print(Fore.GREEN +'[Pass] Calibrated: '+mk)
-            else:
-                print(Fore.RED + '[Fail] Not Calibrated: ' + mk)
             print(Style.RESET_ALL)
     except IOError:
         print(Fore.RED + '[Fail] Startup of EndOfArm')


### PR DESCRIPTION
When bad hardware is on the DXL bus (eg, broken DexWrist) the stretch_robot_system_check.py and other tools can crash on DXLCommErrors (in particular, those that use DynamixelXL430 directly and not HelloDynamixelXL430). This fix allows the tools to exit gracefully.

Tested by configuring a DexWrist to be on the robot when one does not exist.