### PR TITLE
Bugfix/trajectories active

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 ![](./docs/images/banner.png)
 
+
 # Overview
 
 The stretch_body repository includes Python packages that allow a developer to interact with the hardware of the Stretch RE1 robot. These packages are:

--- a/body/stretch_body/hello_utils.py
+++ b/body/stretch_body/hello_utils.py
@@ -205,3 +205,24 @@ def thread_service_shutdown(signum, frame):
     print('Caught signal %d' % signum)
     raise ThreadServiceExit
 
+def evaluate_polynomial_at(poly, t):
+    """Evaluate a quintic polynomial at a given time.
+
+    Parameters
+    ----------
+    poly : List(float)
+        Represents a quintic polynomial as a coefficients array [a0, a1, a2, a3, a4, a5].
+        The polynomial is f(t) = a0 + a1*t + a2*t^2 + a3*t^3 + a4*t^4 + a5*t^5
+    t : float
+        the time in seconds at which to evaluate the polynomial
+
+    Returns
+    -------
+    Tuple(float)
+        array with three elements: evaluated position, velocity, and acceleration.
+    """
+    a = poly
+    pos = a[0] + (a[1]*t) + (a[2]*t**2) + (a[3]*t**3) + (a[4]*t**4) + (a[5]*t**5)
+    vel = a[1] + (2*a[2]*t) + (3*a[3]*t**2) + (4*a[4]*t**3) + (5*a[5]*t**4)
+    accel = (2*a[2]) + (6*a[3]*t) + (12*a[4]*t**2) + (20*a[5]*t**3)
+    return (pos, vel, accel)

--- a/body/stretch_body/pimu.py
+++ b/body/stretch_body/pimu.py
@@ -144,7 +144,7 @@ class Pimu(Device):
             self.cliff_event_reset()
 
         self.board_info = {'board_version': None, 'firmware_version': None, 'protocol_version': None}
-        self.valid_firmware_protocol = 'p0'
+        self.valid_firmware_protocol = 'p1'
         self.hw_valid = False
 
     # ###########  Device Methods #############

--- a/body/stretch_body/stepper.py
+++ b/body/stretch_body/stepper.py
@@ -579,6 +579,9 @@ class Stepper(Device):
             six coefficients (a0-a5) fill the first seven elements of the list. A segment ID, always
             2 for the first segment, fills the last element of the list.
         """
+        if first_segment[7]!=2:
+            self.logger.warning('Invalid waypoint segment ID for %s'%self.name)
+            return False
         self.waypoint_traj_segment = first_segment
         with self.lock:
             if self.waypoint_traj_segment is not None:
@@ -606,6 +609,9 @@ class Stepper(Device):
             coefficients are calculated to smoothly transition across a spline. The segment ID, always
             1 higher than the prior segment's ID, fills the last element of the list.
         """
+        if next_segment[7]<3:
+            self.logger.warning('Invalid waypoint segment ID for %s' % self.name)
+            return False
         self.waypoint_traj_segment = next_segment
         with self.lock:
             if self.waypoint_traj_segment is not None:

--- a/body/stretch_body/stepper.py
+++ b/body/stretch_body/stepper.py
@@ -95,7 +95,7 @@ class Stepper(Device):
         self._trigger=0
         self._trigger_data=0
         self.load_test_payload = arr.array('B', range(256)) * 4
-        self.valid_firmware_protocol='p0'
+        self.valid_firmware_protocol='p1'
         self.hw_valid=False
         self.gains = self.params['gains'].copy()
 

--- a/body/stretch_body/stepper.py
+++ b/body/stretch_body/stepper.py
@@ -477,7 +477,7 @@ class Stepper(Device):
             return
         #This will take a few seconds. Blocks until complete.
         if len(data)!=16384:
-            self.logger.debug('Bad encoder data')
+            self.logger.warning('Bad encoder data')
         else:
             self.logger.debug('Writing encoder calibration...')
             for p in range(256):
@@ -493,7 +493,7 @@ class Stepper(Device):
                 # self.logger.debug('Sending encoder calibration rpc of size',sidx)
                 self.transport.queue_rpc(sidx, self.rpc_enc_calib_reply)
                 self.transport.step()
-            self.logger.debug('')
+
     def rpc_enc_calib_reply(self,reply):
         if reply[0] != RPC_REPLY_ENC_CALIB:
             self.logger.debug('Error RPC_REPLY_ENC_CALIB', reply[0])

--- a/body/stretch_body/stepper.py
+++ b/body/stretch_body/stepper.py
@@ -71,6 +71,8 @@ DIAG_IN_GUARDED_EVENT = 512     # Guarded event occured during motion
 DIAG_IN_SAFETY_EVENT = 1024      #Is it forced into safety mode
 DIAG_WAITING_ON_SYNC = 2048     #Command received but no sync yet
 DIAG_TRAJ_ACTIVE     = 4096     # Whether a waypoint trajectory is actively executing
+DIAG_TRAJ_WAITING_ON_SYNC = 8192
+DIAG_IN_SYNC_MODE=16384
 
 CONFIG_SAFETY_HOLD =1           #Hold position in safety mode? Otherwise freewheel
 CONFIG_ENABLE_RUNSTOP =2        #Recognize runstop signal?
@@ -100,12 +102,15 @@ class Stepper(Device):
         self.status = {'mode': 0, 'effort': 0, 'current':0,'pos': 0, 'vel': 0, 'err':0,'diag': 0,'timestamp': 0, 'debug':0,'guarded_event':0,
                        'transport': self.transport.status,'pos_calibrated':0,'runstop_on':0,'near_pos_setpoint':0,'near_vel_setpoint':0,
                        'is_moving':0,'is_moving_filtered':0,'at_current_limit':0,'is_mg_accelerating':0,'is_mg_moving':0,'calibration_rcvd': 0,'in_guarded_event':0,
-                       'in_safety_event':0,'waiting_on_sync':0,'waypoint_setpoint':None,'trajectory_active':0}
+                       'in_safety_event':0,
+                       'waypoint_traj':{'state':'idle','setpoint':None, 'segment_id':0,}}
         self.board_info={'board_version':None, 'firmware_version':None,'protocol_version':None}
         self.motion_limits=[0,0]
         self.is_moving_history = [False] * 10
+
         self.waypoint_traj_segment = [0] * 8
-        self.waypoint_traj_id = None
+        self._waypoint_traj_start_success = False
+        self._waypoint_traj_set_next_traj_success = False
 
         self._dirty_command = False
         self._dirty_gains = False
@@ -228,7 +233,6 @@ class Stepper(Device):
         print('Effort', self.status['effort'])
         print('Current (A)', self.status['current'])
         print('Error (deg)', rad_to_deg(self.status['err']))
-        print('Waypoint Setpoint (rad)', self.status['waypoint_setpoint'], '(deg)', rad_to_deg(self.status['waypoint_setpoint']))
         print('Debug', self.status['debug'])
         print('Guarded Events:', self.status['guarded_event'])
         print('Diag', self.status['diag'])
@@ -245,7 +249,11 @@ class Stepper(Device):
         print('       In Guarded Event:', self.status['in_guarded_event'])
         print('       In Safety Event:', self.status['in_safety_event'])
         print('       Waiting on Sync:', self.status['waiting_on_sync'])
-        print('       Waypoint Trajectory Active:', self.status['trajectory_active'])
+        print('Waypoint Trajectory')
+        print('       State:', self.status['waypoint_traj']['state'])
+        print('       Setpoint: (rad) %s | (deg) %s'%(self.status['waypoint_traj']['setpoint'],  rad_to_deg(self.status['waypoint_traj']['setpoint'])))
+        print('       Segment ID:', self.status['waypoint_traj']['segment_id'])
+
         print('Timestamp (s)', self.status['timestamp'])
         print('Read error', self.transport.status['read_error'])
         print('Board version:', self.board_info['board_version'])
@@ -562,7 +570,7 @@ class Stepper(Device):
     # ################Waypoint Trajectory Interface #####################
     def start_waypoint_trajectory(self, first_segment):
         """Starts execution of a waypoint trajectory on hardware
-
+        Return True if uC successfully initiated a new trajectory
         Parameters
         ----------
         first_segment : list
@@ -578,13 +586,17 @@ class Stepper(Device):
                 sidx = self.pack_trajectory_segment(self.transport.payload_out, 1)
                 self.transport.queue_rpc2(sidx, self.rpc_start_new_traj_reply)
             self.transport.step2()
+            return self._waypoint_traj_start_success
 
     def set_next_trajectory_segment(self, next_segment):
         """Sets the next segment for the hardware to execute
+        Return True if uC successfully queued next trajectory
 
         This method is generally called multiple times while the prior segment is executing. This
         provides the hardware with the next segment to gracefully transition across the entire spline,
         while allowing users to preempt or modify the future trajectory in real time.
+
+        This will return False if there is not already an segment executing on the uC
 
         Parameters
         ----------
@@ -601,6 +613,7 @@ class Stepper(Device):
                 sidx = self.pack_trajectory_segment(self.transport.payload_out, 1)
                 self.transport.queue_rpc2(sidx, self.rpc_set_next_traj_seg_reply)
             self.transport.step2()
+            return self._waypoint_traj_set_next_traj_success
 
     def stop_waypoint_trajectory(self):
         """Stops execution of the waypoint trajectory running in hardware
@@ -635,7 +648,9 @@ class Stepper(Device):
             timestamp_line_sync = unpack_uint64_t(s[sidx:]);sidx += 8
             self.status['debug'] = unpack_float_t(s[sidx:]);sidx += 4
             self.status['guarded_event'] = unpack_uint32_t(s[sidx:]);sidx += 4
-            self.status['waypoint_setpoint'] = unpack_float_t(s[sidx:]);sidx += 4
+            self.status['waypoint_traj']['setpoint'] = unpack_float_t(s[sidx:]);sidx += 4
+            self.status['waypoint_traj']['segment_id'] = unpack_uint16_t(s[sidx:]);sidx += 2
+
             self.status['pos_calibrated'] =self.status['diag'] & DIAG_POS_CALIBRATED > 0
             self.status['runstop_on'] =self.status['diag'] & DIAG_RUNSTOP_ON > 0
             self.status['near_pos_setpoint'] =self.status['diag'] & DIAG_NEAR_POS_SETPOINT > 0
@@ -648,9 +663,16 @@ class Stepper(Device):
             self.status['in_guarded_event'] = self.status['diag'] & DIAG_IN_GUARDED_EVENT > 0
             self.status['in_safety_event'] = self.status['diag'] & DIAG_IN_SAFETY_EVENT > 0
             self.status['waiting_on_sync'] = self.status['diag'] & DIAG_WAITING_ON_SYNC > 0
-            self.status['trajectory_active'] = self.status['diag'] & DIAG_TRAJ_ACTIVE > 0
-            # in_sync_mode = self.status['diag'] & DIAG_IN_SYNC_MODE > 0
+            self.status['in_sync_mode'] = self.status['diag'] & DIAG_IN_SYNC_MODE > 0
+
+            if self.status['diag'] & DIAG_TRAJ_WAITING_ON_SYNC > 0:
+                self.status['waypoint_traj']['state']='waiting_on_snyc'
+            elif self.status['diag'] & DIAG_TRAJ_ACTIVE > 0:
+                self.status['waypoint_traj']['state']='active'
+            else:
+                self.status['waypoint_traj']['state']='idle'
             return sidx
+
 
 
     def unpack_gains(self,s):
@@ -821,14 +843,14 @@ class Stepper(Device):
     def rpc_start_new_traj_reply(self, reply):
         if reply[0] == RPC_REPLY_START_NEW_TRAJECTORY:
             with self.lock:
-                self.waypoint_traj_id = unpack_uint8_t(reply[1:])
+                self._waypoint_traj_start_success = unpack_uint8_t(reply[1:])
         else:
             self.logger.error('RPC_REPLY_START_NEW_TRAJECTORY replied {0}'.format(reply[0]))
 
     def rpc_set_next_traj_seg_reply(self, reply):
         if reply[0] == RPC_REPLY_SET_NEXT_TRAJECTORY_SEG:
             with self.lock:
-                self.waypoint_traj_id = unpack_uint8_t(reply[1:])
+                self._waypoint_traj_set_next_traj_success = unpack_uint8_t(reply[1:])
         else:
             self.logger.error('RPC_REPLY_SET_NEXT_TRAJECTORY_SEG replied {0}'.format(reply[0]))
 

--- a/body/stretch_body/stepper.py
+++ b/body/stretch_body/stepper.py
@@ -70,8 +70,7 @@ class Stepper(Device):
     API to the Stretch RE1 stepper board
     """
     def __init__(self, usb):
-        name = usb[5:]
-        Device.__init__(self, name)
+        Device.__init__(self, name=usb[5:])
         self.usb=usb
         self.lock=threading.RLock()
         self.transport = Transport(usb=self.usb, logger=self.logger)
@@ -223,7 +222,7 @@ class Stepper(Device):
         print('       In Guarded Event:', self.status['in_guarded_event'])
         print('       In Safety Event:', self.status['in_safety_event'])
         print('       Waiting on Sync:', self.status['waiting_on_sync'])
-        print('Timestamp', self.status['timestamp'])
+        print('Timestamp (s)', self.status['timestamp'])
         print('Read error', self.transport.status['read_error'])
         print('Board version:', self.board_info['board_version'])
         print('Firmware version:', self.board_info['firmware_version'])
@@ -555,9 +554,11 @@ class Stepper(Device):
             self.status['vel'] = unpack_float_t(s[sidx:]);sidx+=4
             self.status['err'] = unpack_float_t(s[sidx:]);sidx += 4
             self.status['diag'] = unpack_uint32_t(s[sidx:]);sidx += 4
-            self.status['timestamp'] = self.timestamp.set(unpack_uint32_t(s[sidx:]));sidx += 4
+            self.status['timestamp'] = self.timestamp.set(unpack_uint64_t(s[sidx:]));sidx += 8
+            timestamp_line_sync = unpack_uint64_t(s[sidx:]);sidx += 8
             self.status['debug'] = unpack_float_t(s[sidx:]);sidx += 4
             self.status['guarded_event'] = unpack_uint32_t(s[sidx:]);sidx += 4
+            waypoint_setpoint = unpack_float_t(s[sidx:]);sidx += 4
             self.status['pos_calibrated'] =self.status['diag'] & DIAG_POS_CALIBRATED > 0
             self.status['runstop_on'] =self.status['diag'] & DIAG_RUNSTOP_ON > 0
             self.status['near_pos_setpoint'] =self.status['diag'] & DIAG_NEAR_POS_SETPOINT > 0
@@ -662,6 +663,7 @@ class Stepper(Device):
                 config=config | CONFIG_SAFETY_HOLD
             if self.gains['enable_runstop']:
                 config=config | CONFIG_ENABLE_RUNSTOP
+            self.gains['enable_sync_mode'] = 0 # TODO: hardcoded disabled until fixed
             if self.gains['enable_sync_mode']:
                 config=config | CONFIG_ENABLE_SYNC_MODE
             if self.gains['enable_guarded_mode']:

--- a/body/stretch_body/wacc.py
+++ b/body/stretch_body/wacc.py
@@ -47,7 +47,7 @@ class Wacc(Device):
                        'transport': self.transport.status}
         self.ts_last=None
         self.board_info = {'board_version': None, 'firmware_version': None, 'protocol_version': None}
-        self.valid_firmware_protocol = 'p0'
+        self.valid_firmware_protocol = 'p1'
         self.hw_valid = False
 
     # ###########  Device Methods #############

--- a/body/stretch_body/wacc.py
+++ b/body/stretch_body/wacc.py
@@ -40,12 +40,10 @@ class Wacc(Device):
         self._dirty_config = True #Force push down
         self._dirty_command = False
         self._command = {'d2':0,'d3':0, 'trigger':0}
-        self.name ='hello-wacc'
         self.transport = Transport(usb='/dev/hello-wacc', logger=self.logger)
         self.status = { 'ax':0,'ay':0,'az':0,'a0':0,'d0':0,'d1':0, 'd2':0,'d3':0,'single_tap_count': 0, 'state':0, 'debug':0,
                        'timestamp': 0,
                        'transport': self.transport.status}
-        self.ts_last=None
         self.board_info = {'board_version': None, 'firmware_version': None, 'protocol_version': None}
         self.valid_firmware_protocol = 'p1'
         self.hw_valid = False
@@ -146,7 +144,7 @@ class Wacc(Device):
         print('Single Tap Count', self.status['single_tap_count'])
         print('State ', self.status['state'])
         print('Debug',self.status['debug'])
-        print('Timestamp', self.status['timestamp'])
+        print('Timestamp (s)', self.status['timestamp'])
         print('Board version:', self.board_info['board_version'])
         print('Firmware version:', self.board_info['firmware_version'])
 
@@ -183,7 +181,7 @@ class Wacc(Device):
             self.status['d3'] = unpack_uint8_t(s[sidx:]); sidx += 1
             self.status['single_tap_count'] = unpack_uint32_t(s[sidx:]);sidx += 4
             self.status['state'] = unpack_uint32_t(s[sidx:]); sidx += 4
-            self.status['timestamp'] = self.timestamp.set(unpack_uint32_t(s[sidx:]));sidx += 4
+            self.status['timestamp'] = self.timestamp.set(unpack_uint64_t(s[sidx:]));sidx += 8
             self.status['debug'] = unpack_uint32_t(s[sidx:]);sidx += 4
             return sidx
 
@@ -212,6 +210,9 @@ class Wacc(Device):
             sidx += 1
             pack_float_t(s, sidx, self.config['accel_gravity_scale'])
             sidx += 4
+            self.config['enable_sync_mode'] = 0 # TODO: hardcoded disabled until implemented
+            pack_uint8_t(s, sidx, self.config['enable_sync_mode'])
+            sidx += 1
             return sidx
 
     # ################Transport Callbacks #####################

--- a/body/test/test_hello_utils.py
+++ b/body/test/test_hello_utils.py
@@ -90,3 +90,48 @@ class TestHelloUtils(unittest.TestCase):
             os.environ['HELLO_FLEET_PATH'] = original_fleet_path
         else:
             self.assertEqual(stretch_body.hello_utils.get_stretch_directory(), "/tmp/")
+
+    def test_evaluate_polynomial_at(self):
+        """Verify correctness of the hello_utils evaluate_polynomial_at method
+
+        Spline coefficients calculated in Desmos at:
+        https://www.desmos.com/calculator/atv5ilhodq
+        """
+        # Segment b
+        b_waypoint1 = {'time': 0.0, 'position': 62.425, 'velocity': 0.0, 'acceleration': 0.0}
+        b_waypoint2 = {'time': 3.0, 'position': 52.350, 'velocity': 0.0, 'acceleration': 0.0}
+        b_segment = [62.425, 0, 0, -3.7314815, 1.8657407, -0.2487654]
+
+        pos, vel, accel = stretch_body.hello_utils.evaluate_polynomial_at(b_segment, b_waypoint1['time'] - b_waypoint1['time'])
+        self.assertAlmostEqual(pos, b_waypoint1['position'], places=4)
+        self.assertAlmostEqual(vel, b_waypoint1['velocity'], places=4)
+        self.assertAlmostEqual(accel, b_waypoint1['acceleration'], places=4)
+
+        pos, vel, accel = stretch_body.hello_utils.evaluate_polynomial_at(b_segment, b_waypoint2['time'] - b_waypoint1['time'])
+        self.assertAlmostEqual(pos, b_waypoint2['position'], places=4)
+        self.assertAlmostEqual(vel, b_waypoint2['velocity'], places=4)
+        self.assertAlmostEqual(accel, b_waypoint2['acceleration'], places=4)
+
+        pos, vel, accel = stretch_body.hello_utils.evaluate_polynomial_at(b_segment, 1.3 - b_waypoint1['time'])
+        self.assertAlmostEqual(pos, 58.632, places=3)
+        self.assertNotAlmostEqual(vel, 0.0, places=4)
+        self.assertNotAlmostEqual(accel, 0, places=4)
+
+        # Segment c
+        c_waypoint1 = {'time': 3.0, 'position': 52.350, 'velocity': 0.0, 'acceleration': 0.0}
+        c_waypoint2 = {'time': 6.0, 'position': 62.425, 'velocity': 0.0, 'acceleration': 0.0}
+        c_segment = [52.350, 0, 0, 3.7314815, -1.8657407, 0.2487654]
+        pos, vel, accel = stretch_body.hello_utils.evaluate_polynomial_at(c_segment, c_waypoint1['time'] - c_waypoint1['time'])
+        self.assertAlmostEqual(pos, c_waypoint1['position'], places=4)
+        self.assertAlmostEqual(vel, c_waypoint1['velocity'], places=4)
+        self.assertAlmostEqual(accel, c_waypoint1['acceleration'], places=4)
+
+        pos, vel, accel = stretch_body.hello_utils.evaluate_polynomial_at(c_segment, c_waypoint2['time'] - c_waypoint1['time'])
+        self.assertAlmostEqual(pos, c_waypoint2['position'], places=4)
+        self.assertAlmostEqual(vel, c_waypoint2['velocity'], places=4)
+        self.assertAlmostEqual(accel, c_waypoint2['acceleration'], places=4)
+
+        pos, vel, accel = stretch_body.hello_utils.evaluate_polynomial_at(c_segment, 4.584 - c_waypoint1['time'])
+        self.assertAlmostEqual(pos, 57.915, places=3)
+        self.assertNotAlmostEqual(vel, 0.0, places=4)
+        self.assertNotAlmostEqual(accel, 0, places=4)

--- a/body/test/test_pimu.py
+++ b/body/test/test_pimu.py
@@ -10,6 +10,7 @@ import time
 
 class TestPimu(unittest.TestCase):
 
+    @unittest.skip(reason='Doesnt test anything yet')
     def test_invalid_protocol(self):
         """Simulate an invalid protocol and verify the correct error.
         """
@@ -18,5 +19,37 @@ class TestPimu(unittest.TestCase):
         p.startup()
         # TODO: capture logging with https://testfixtures.readthedocs.io/en/latest/logging.html
         #       verify output is '[WARNING] [pimu]: \n----------------\nFirmware protocol mismatch on hello-pimu. [...]'
+
+        p.stop()
+
+    def test_runstop_status(self):
+        """Verify that runstop status doesn't fluctuate
+        """
+        p = stretch_body.pimu.Pimu()
+        p.startup()
+
+        p.runstop_event_reset()
+        p.push_command()
+        time.sleep(1)
+        for _ in range(50):
+            time.sleep(0.1)
+            p.pull_status()
+            self.assertFalse(p.status['runstop_event'])
+
+        p.runstop_event_trigger()
+        p.push_command()
+        time.sleep(1)
+        for _ in range(50):
+            time.sleep(0.1)
+            p.pull_status()
+            self.assertTrue(p.status['runstop_event'])
+
+        p.runstop_event_reset()
+        p.push_command()
+        time.sleep(1)
+        for _ in range(50):
+            time.sleep(0.1)
+            p.pull_status()
+            self.assertFalse(p.status['runstop_event'])
 
         p.stop()

--- a/body/test/test_steppers.py
+++ b/body/test/test_steppers.py
@@ -115,8 +115,9 @@ class TestSteppers(unittest.TestCase):
         https://www.desmos.com/calculator/atv5ilhodq
         """
         s = stretch_body.stepper.Stepper('/dev/hello-motor-lift')
+        s.disable_sync_mode()
         self.assertTrue(s.startup())
-        limits_rad = (0.0, 115.14478302001953) # lift motor limits
+        limits_rad = (0.0, 115.14478302001953)  # lift motor limits
 
         # bring motor to starting position
         position_rad = 62.425
@@ -152,33 +153,34 @@ class TestSteppers(unittest.TestCase):
         s.push_command()
         time.sleep(0.1)
         start_time = time.time()
-        s.start_waypoint_trajectory(first_segment)
-        print(s.waypoint_traj_id)
+        self.assertTrue(s.start_waypoint_trajectory(first_segment))
 
         # first segment executing
         for _ in range(10):
-            # self.assertEqual(s.waypoint_traj_id, 2) # TODO: uC reports 1 unless next seg loaded
-            print(s.waypoint_traj_id)
+            s.pull_status()
+            self.assertEqual(s.status['waypoint_traj']['segment_id'], 2)
+            print(s.status['waypoint_traj']['segment_id'])
             time.sleep(0.1)
-            s.set_next_trajectory_segment(second_segment)
+            self.assertTrue(s.set_next_trajectory_segment(second_segment))
             s.pull_status()
             self.assertLessEqual(s.status['pos'], 62.425 + 1.0)
             self.assertGreaterEqual(s.status['pos'], 52.35 - 1.0)
             pos, _, _ = evaluate_polynomial_at(first_segment[1:-1], time.time() - start_time)
             self.assertAlmostEqual(s.status['pos'], pos, places=-1)
-        time.sleep(2) # let the remainder of the first segment complete
+        time.sleep(2)  # let the remainder of the first segment complete
 
         # second segment executing
         for _ in range(10):
-            # self.assertEqual(s.waypoint_traj_id, 3) # TODO: uC doesn't report 3
-            print(s.waypoint_traj_id)
+            s.pull_status()
+            self.assertEqual(s.status['waypoint_traj']['segment_id'], 3)
+            print(s.status['waypoint_traj']['segment_id'])
             time.sleep(0.1)
             s.pull_status()
             self.assertLessEqual(s.status['pos'], 62.425 + 1.0)
             self.assertGreaterEqual(s.status['pos'], 52.35 - 1.0)
             pos, _, _ = evaluate_polynomial_at(second_segment[1:-1], (time.time() - start_time) - 3.0)
             self.assertAlmostEqual(s.status['pos'], pos, places=-1)
-        time.sleep(2) # let the remainder of the second segment complete
+        time.sleep(2)  # let the remainder of the second segment complete
 
         s.pull_status()
         self.assertAlmostEqual(s.status['pos'], position_rad, places=1)

--- a/body/test/test_steppers.py
+++ b/body/test/test_steppers.py
@@ -4,6 +4,7 @@ stretch_body.robot_params.RobotParams.set_logging_level("DEBUG")
 
 import unittest
 import stretch_body.stepper
+import stretch_body.pimu
 
 import time
 
@@ -38,3 +39,38 @@ class TestSteppers(unittest.TestCase):
                 self.assertFalse(s.status['is_moving_filtered'])
                 time.sleep(0.1)
             s.stop()
+
+    def test_runstop_status(self):
+        """Verify that runstop status doesn't fluctuate
+        """
+        p = stretch_body.pimu.Pimu()
+        p.startup()
+        s = stretch_body.stepper.Stepper('/dev/hello-motor-arm')
+        s.startup()
+
+        p.runstop_event_reset()
+        p.push_command()
+        time.sleep(1)
+        for _ in range(50):
+            time.sleep(0.1)
+            s.pull_status()
+            self.assertFalse(s.status['runstop_on'])
+
+        p.runstop_event_trigger()
+        p.push_command()
+        time.sleep(1)
+        for _ in range(50):
+            time.sleep(0.1)
+            s.pull_status()
+            self.assertTrue(s.status['runstop_on'])
+
+        p.runstop_event_reset()
+        p.push_command()
+        time.sleep(1)
+        for _ in range(50):
+            time.sleep(0.1)
+            s.pull_status()
+            self.assertFalse(s.status['runstop_on'])
+
+        p.stop()
+        s.stop()

--- a/body/test/test_steppers.py
+++ b/body/test/test_steppers.py
@@ -11,7 +11,6 @@ import time
 
 
 class TestSteppers(unittest.TestCase):
-
     @unittest.skip(reason='Test fails because encoders give noisy reading of is_moving')
     def test_is_moving(self):
         """Test that is_moving is False when no motion
@@ -107,6 +106,172 @@ class TestSteppers(unittest.TestCase):
         self.assertAlmostEqual(s.status['pos'], position_rad, places=2)
 
         s.stop()
+
+    def test_stop_waypoint_trajectory_interface(self):
+        """Verify that waypoint trajectories stop as expected
+        """
+        s = stretch_body.stepper.Stepper('/dev/hello-motor-lift')
+        s.disable_sync_mode()
+        self.assertTrue(s.startup())
+        limits_rad = (0.0, 115.14478302001953)  # lift motor limits
+
+
+        position_rad = 62.425
+        velocity_rad = 9.948
+        acceleration_rad = 15.707
+        stiffness = 1.0
+        i_feedforward = 0.54
+        i_contact_neg = -1.46
+        i_contact_pos = 2.54
+        MODE_POS_TRAJ = 5
+        ################################################################
+        #stop by sending a duration=0 second segment
+        #bring motor to starting position
+        print('Waypoint stop test 1')
+        s.set_command(mode=MODE_POS_TRAJ,
+                      x_des=position_rad,
+                      v_des=velocity_rad,
+                      a_des=acceleration_rad,
+                      stiffness=stiffness,
+                      i_feedforward=i_feedforward,
+                      i_contact_pos=i_contact_pos,
+                      i_contact_neg=i_contact_neg)
+        s.push_command()
+        s.wait_until_at_setpoint()
+        s.pull_status()
+        self.assertAlmostEqual(s.status['pos'], position_rad, places=1)
+
+        # send waypoint trajectory
+        first_segment = [3.0, 62.425, 0, 0, -3.731, 1.866, -0.249, 2]
+        second_segment = [0.0, 52.35, 0, 0, 3.731, -1.866, 0.249, 3] #duration=O marks stop
+        s.enable_pos_traj_waypoint()
+        s.push_command()
+        time.sleep(0.1)
+        start_time = time.time()
+        self.assertTrue(s.start_waypoint_trajectory(first_segment))
+
+        # first segment executing,
+        for _ in range(10):
+            s.pull_status()
+            self.assertEqual(s.status['waypoint_traj']['segment_id'], 2)
+            time.sleep(0.1)
+            self.assertTrue(s.set_next_trajectory_segment(second_segment))
+            s.pull_status()
+            self.assertLessEqual(s.status['pos'], 62.425 + 1.0)
+            self.assertGreaterEqual(s.status['pos'], 52.35 - 1.0)
+            pos, _, _ = evaluate_polynomial_at(first_segment[1:-1], time.time() - start_time)
+            self.assertAlmostEqual(s.status['pos'], pos, places=-1)
+        time.sleep(2)  # let the remainder of the first segment complete
+        s.pull_status()
+        pos, _, _ = evaluate_polynomial_at(first_segment[1:-1], first_segment[0])
+        self.assertAlmostEqual(s.status['pos'], pos, places=1)
+        self.assertEqual(s.status['waypoint_traj']['state'], 'idle')
+
+        # ################################################################
+        # stop by sending only one segment
+        # bring motor to starting position
+        print('Waypoint stop test 2')
+        s.set_command(mode=MODE_POS_TRAJ,
+                      x_des=position_rad,
+                      v_des=velocity_rad,
+                      a_des=acceleration_rad,
+                      stiffness=stiffness,
+                      i_feedforward=i_feedforward,
+                      i_contact_pos=i_contact_pos,
+                      i_contact_neg=i_contact_neg)
+        s.push_command()
+        s.wait_until_at_setpoint()
+        s.pull_status()
+        self.assertAlmostEqual(s.status['pos'], position_rad, places=1)
+
+        # send waypoint trajectory
+        first_segment = [3.0, 62.425, 0, 0, -3.731, 1.866, -0.249, 2]
+        s.enable_pos_traj_waypoint()
+        s.push_command()
+        time.sleep(0.1)
+        start_time = time.time()
+        self.assertTrue(s.start_waypoint_trajectory(first_segment))
+
+        # first segment executing, stop by sending a duration=0 second segment
+        for _ in range(10):
+            s.pull_status()
+            self.assertEqual(s.status['waypoint_traj']['segment_id'], 2)
+            time.sleep(0.1)
+            self.assertLessEqual(s.status['pos'], 62.425 + 1.0)
+            self.assertGreaterEqual(s.status['pos'], 52.35 - 1.0)
+            pos, _, _ = evaluate_polynomial_at(first_segment[1:-1], time.time() - start_time)
+            self.assertAlmostEqual(s.status['pos'], pos, places=-1)
+        time.sleep(2)  # let the remainder of the first segment complete
+        s.pull_status()
+        pos, _, _ = evaluate_polynomial_at(first_segment[1:-1], first_segment[0])
+        self.assertAlmostEqual(s.status['pos'], pos, places=1)
+        self.assertEqual(s.status['waypoint_traj']['state'], 'idle')
+
+        # ################################################################
+        print('Waypoint stop test 3')
+        # stop by terminating directly
+        # bring motor to starting position
+        s.set_command(mode=MODE_POS_TRAJ,
+                      x_des=position_rad,
+                      v_des=velocity_rad,
+                      a_des=acceleration_rad,
+                      stiffness=stiffness,
+                      i_feedforward=i_feedforward,
+                      i_contact_pos=i_contact_pos,
+                      i_contact_neg=i_contact_neg)
+        s.push_command()
+        s.wait_until_at_setpoint()
+        s.pull_status()
+        self.assertAlmostEqual(s.status['pos'], position_rad, places=1)
+        print('Moved to pos')
+        # send waypoint trajectory
+        first_segment = [3.0, 62.425, 0, 0, -3.731, 1.866, -0.249, 2]
+        s.enable_pos_traj_waypoint()
+        s.push_command()
+        time.sleep(0.1)
+        start_time = time.time()
+        self.assertTrue(s.start_waypoint_trajectory(first_segment))
+
+        # first segment executing, stop by sending a duration=0 second segment
+        for _ in range(10):
+            s.pull_status()
+            self.assertEqual(s.status['waypoint_traj']['segment_id'], 2)
+            time.sleep(0.1)
+            self.assertLessEqual(s.status['pos'], 62.425 + 1.0)
+            self.assertGreaterEqual(s.status['pos'], 52.35 - 1.0)
+            pos, _, _ = evaluate_polynomial_at(first_segment[1:-1], time.time() - start_time)
+            self.assertAlmostEqual(s.status['pos'], pos, places=-1)
+        s.stop_waypoint_trajectory() #End prematurely
+        dt=time.time() - start_time
+        s.pull_status()
+        pos, _, _ = evaluate_polynomial_at(first_segment[1:-1], dt)
+        self.assertAlmostEqual(s.status['pos'], pos, delta=1.0)
+        self.assertEqual(s.status['waypoint_traj']['state'], 'idle')
+        s.stop()
+
+
+    def test_malicious_waypoint_trajectory_interface(self):
+        #Send bad values to trajectory interface
+        #Joint should not move
+        s = stretch_body.stepper.Stepper('/dev/hello-motor-lift')
+        s.disable_sync_mode()
+        self.assertTrue(s.startup())
+
+        # send waypoint trajectory
+        first_segment = [3.0, 62.425, 0, 0, -3.731, 1.866, -0.249, 0] #Bad ID
+        second_segment = [3.0, 52.35, 0, 0, 3.731, -1.866, 0.249, 1] #Bad ID
+        s.enable_pos_traj_waypoint()
+        s.push_command()
+        x_start = s.status['pos']
+        self.assertEqual(s.status['waypoint_traj']['state'],'idle')
+        self.assertFalse(s.start_waypoint_trajectory(first_segment))
+        self.assertFalse(s.start_waypoint_trajectory(second_segment))
+        self.assertFalse(s.set_next_trajectory_segment(first_segment))
+        self.assertFalse(s.set_next_trajectory_segment(second_segment))
+        s.pull_status()
+        self.assertAlmostEqual(s.status['pos'], x_start, places=1)
+        self.assertEqual(s.status['waypoint_traj']['state'], 'idle')
+
 
     def test_waypoint_trajectory_interface(self):
         """Verify correct behavior of the waypoint trajectory

--- a/body/test/test_steppers.py
+++ b/body/test/test_steppers.py
@@ -5,6 +5,7 @@ stretch_body.robot_params.RobotParams.set_logging_level("DEBUG")
 import unittest
 import stretch_body.stepper
 import stretch_body.pimu
+from stretch_body.hello_utils import evaluate_polynomial_at
 
 import time
 
@@ -112,8 +113,6 @@ class TestSteppers(unittest.TestCase):
 
         Spline coefficients calculated in Desmos at:
         https://www.desmos.com/calculator/atv5ilhodq
-
-        TODO: Check plotted spline fits ideal spline within certain error
         """
         s = stretch_body.stepper.Stepper('/dev/hello-motor-lift')
         self.assertTrue(s.startup())
@@ -137,11 +136,13 @@ class TestSteppers(unittest.TestCase):
                       i_contact_pos=i_contact_pos,
                       i_contact_neg=i_contact_neg)
         s.push_command()
-        time.sleep(7)
+        s.wait_until_at_setpoint()
         s.pull_status()
-        self.assertAlmostEqual(s.status['pos'], position_rad, places=2)
+        self.assertAlmostEqual(s.status['pos'], position_rad, places=1)
 
         # send waypoint trajectory
+        first_segment = [3.0, 62.425, 0, 0, -3.731, 1.866, -0.249, 2]
+        second_segment = [3.0, 52.35, 0, 0, 3.731, -1.866, 0.249, 3]
         s.enable_pos_traj_waypoint()
         # s.set_command(v_des=velocity_rad,
         #               a_des=acceleration_rad,
@@ -150,26 +151,35 @@ class TestSteppers(unittest.TestCase):
         #               i_contact_neg=i_contact_neg)
         s.push_command()
         time.sleep(0.1)
-        s.start_waypoint_trajectory([3.0, 62.425, 0, 0, -3.731, 1.866, -0.249, 2])
+        start_time = time.time()
+        s.start_waypoint_trajectory(first_segment)
         print(s.waypoint_traj_id)
+
+        # first segment executing
         for _ in range(10):
             # self.assertEqual(s.waypoint_traj_id, 2) # TODO: uC reports 1 unless next seg loaded
             print(s.waypoint_traj_id)
             time.sleep(0.1)
-            s.set_next_trajectory_segment([3.0, 52.35, 0, 0, 3.731, -1.866, 0.249, 3])
+            s.set_next_trajectory_segment(second_segment)
             s.pull_status()
-            self.assertLessEqual(s.status['pos'], 62.425)
-            self.assertGreaterEqual(s.status['pos'], 52.35)
-        time.sleep(2)
+            self.assertLessEqual(s.status['pos'], 62.425 + 1.0)
+            self.assertGreaterEqual(s.status['pos'], 52.35 - 1.0)
+            pos, _, _ = evaluate_polynomial_at(first_segment[1:-1], time.time() - start_time)
+            self.assertAlmostEqual(s.status['pos'], pos, places=-1)
+        time.sleep(2) # let the remainder of the first segment complete
+
+        # second segment executing
         for _ in range(10):
             # self.assertEqual(s.waypoint_traj_id, 3) # TODO: uC doesn't report 3
             print(s.waypoint_traj_id)
             time.sleep(0.1)
             s.pull_status()
-            self.assertLessEqual(s.status['pos'], 62.425)
-            self.assertGreaterEqual(s.status['pos'], 52.35)
-        time.sleep(2)
+            self.assertLessEqual(s.status['pos'], 62.425 + 1.0)
+            self.assertGreaterEqual(s.status['pos'], 52.35 - 1.0)
+            pos, _, _ = evaluate_polynomial_at(second_segment[1:-1], (time.time() - start_time) - 3.0)
+            self.assertAlmostEqual(s.status['pos'], pos, places=-1)
+        time.sleep(2) # let the remainder of the second segment complete
+
         s.pull_status()
         self.assertAlmostEqual(s.status['pos'], position_rad, places=1)
-
         s.stop()


### PR DESCRIPTION
This moves the waypoint trajectory segment ID reporting into the status message. The RPC calls for the waypoint interface report success instead (they may fail if the request is rejected to the current uC state machine).

This also adds a number of unittests to check that the new segment ID and uC state are reported correctly.