### PR TITLE
fixes issue where joint holds on exit

### DIFF
--- a/body/stretch_body/pimu.py
+++ b/body/stretch_body/pimu.py
@@ -182,10 +182,10 @@ class Pimu(Device):
         if not self.hw_valid:
             return
         with self.lock:
-            self.hw_valid = False
             self.set_fan_off()
             self.push_command(exiting=True)
             self.transport.stop()
+            self.hw_valid = False
 
     def pull_status(self,exiting=False):
         if not self.hw_valid:

--- a/body/stretch_body/stepper.py
+++ b/body/stretch_body/stepper.py
@@ -136,11 +136,11 @@ class Stepper(Device):
         if not self.hw_valid:
             return
         with self.lock:
-            self.hw_valid = False
             self.logger.debug('Shutting down Stepper on: ' + self.usb)
             self.enable_safety()
             self.push_command(exiting=True)
             self.transport.stop()
+            self.hw_valid = False
 
     def push_command(self,exiting=False):
         if not self.hw_valid:

--- a/body/stretch_body/wacc.py
+++ b/body/stretch_body/wacc.py
@@ -87,9 +87,9 @@ class Wacc(Device):
         if not self.hw_valid:
             return
         with self.lock:
-            self.hw_valid = False
             self.push_command(exiting=True)
             self.transport.stop()
+            self.hw_valid = False
 
     def set_D2(self,on):#0 or 1
         """


### PR DESCRIPTION
By introducing hw_valid to the joints we introduced a bug where calling joint.stop() doesn't place the joint in safety mode. Thus when a user program exited, the joint wouldn't float as expected.

* On stop() the joint sets hw_valid to false
* It then calls enable_safety() then push_command()
* These calls are not honored as hw_valid is false
* Moved hw_valid=false to end of the function, yields the correct behavior.