### PR TITLE
added vel interface and tests for arm and lift

### DIFF
--- a/body/stretch_body/lift.py
+++ b/body/stretch_body/lift.py
@@ -56,6 +56,42 @@ class Lift(Device):
 
         self.soft_motion_limits=[x_min, x_max]
 
+    def set_velocity(self, v_m, a_m=None,stiffness=None, contact_thresh_pos_N=None, contact_thresh_neg_N=None, req_calibration=True):
+        if req_calibration:
+            if not self.motor.status['pos_calibrated']:
+                self.logger.warning('Lift not calibrated')
+                return
+        v_m=min(self.params['motion']['max']['vel_m'],v_m) if v_m>=0 else max(-1*self.params['motion']['max']['vel_m'],v_m)
+        v_r = self.translate_to_motor_rad(v_m)
+
+        if stiffness is not None:
+            stiffness = max(0, min(1.0, stiffness))
+        else:
+            stiffness = self.stiffness
+
+        if a_m is not None:
+            a_r = self.translate_to_motor_rad(min(abs(a_m), self.params['motion']['max']['accel_m']))
+        else:
+            a_r = self.accel_r
+
+        if contact_thresh_neg_N is not None:
+            i_contact_neg = max(self.translate_force_to_motor_current(contact_thresh_neg_N),self.params['contact_thresh_max_N'][0])
+        else:
+            i_contact_neg = self.i_contact_neg
+
+        if contact_thresh_pos_N is not None:
+            i_contact_pos = min(self.translate_force_to_motor_current(contact_thresh_pos_N),self.params['contact_thresh_max_N'][1])
+        else:
+            i_contact_pos = self.i_contact_pos
+
+        self.motor.set_command(mode=MODE_VEL_TRAJ,
+                               v_des=v_r,
+                               a_des=a_r,
+                               stiffness=stiffness,
+                               i_feedforward=self.i_feedforward,
+                               i_contact_pos=i_contact_pos,
+                               i_contact_neg=i_contact_neg)
+
     def move_to(self,x_m,v_m=None, a_m=None, stiffness=None, contact_thresh_pos_N=None, contact_thresh_neg_N=None, req_calibration=True):
         """
         x_m: commanded absolute position (meters). x_m=0 is down. x_m=~1.1 is up

--- a/body/test/test_lift.py
+++ b/body/test/test_lift.py
@@ -10,6 +10,37 @@ import time
 
 class TestLift(unittest.TestCase):
 
+    def test_vel_guarded_contact(self):
+        l = stretch_body.lift.Lift()
+        l.motor.disable_sync_mode()
+        self.assertTrue(l.startup())
+        l.pull_status()
+        if not l.motor.status['pos_calibrated']:
+            self.fail('test requires lift to be homed')
+
+        l.move_to(0.5)
+        l.push_command()
+        l.motor.wait_until_at_setpoint(timeout=8.0)
+        l.pull_status()
+        self.assertAlmostEqual(l.status['pos'], 0.5, places=1)
+
+        g1=l.motor.status['guarded_event']
+        vel_des=.10 #m/s
+        l.set_velocity(v_m=vel_des)
+        l.push_command()
+        time.sleep(10.0) #Move to top hardstop
+        l.pull_status()
+        g2=l.motor.status['guarded_event']
+        self.assertNotEqual(g1,g2)
+
+        l.move_to(0.5)
+        l.push_command()
+        l.motor.wait_until_at_setpoint(timeout=8.0)
+        l.pull_status()
+        self.assertAlmostEqual(l.status['pos'], 0.5, places=1)
+
+        l.stop()
+
     def test_homing(self):
         """Test lift homes correctly.
         """


### PR DESCRIPTION
This adds a velocity interface to the arm and lift classes comparable to the base. It also adds unit tests that use this interface and also verifies that the guarded contact works correctly when a 'runaway' joint in velocity mode hits the end stop.

This resolves issue: https://github.com/hello-robot/stretch_body/issues/73