### PR TITLE
implemented warning on high motor_sync rates

### DIFF
--- a/body/stretch_body/pimu.py
+++ b/body/stretch_body/pimu.py
@@ -133,7 +133,7 @@ class Pimu(Device):
         self.status = {'voltage': 0, 'current': 0, 'temp': 0,'cpu_temp': 0, 'cliff_range':[0,0,0,0], 'frame_id': 0,
                        'timestamp': 0,'at_cliff':[False,False,False,False], 'runstop_event': False, 'bump_event_cnt': 0,
                        'cliff_event': False, 'fan_on': False, 'buzzer_on': False, 'low_voltage_alert':False,'high_current_alert':False,'over_tilt_alert':False,
-                       'imu': self.imu.status,'debug':0,'state':0,
+                       'imu': self.imu.status,'debug':0,'state':0,'motor_sync_drop':0,
                        'transport': self.transport.status}
         self._trigger=0
         self.ts_last_fan_on=None
@@ -146,6 +146,9 @@ class Pimu(Device):
         self.board_info = {'board_version': None, 'firmware_version': None, 'protocol_version': None}
         self.valid_firmware_protocol = 'p0'
         self.hw_valid = False
+        self.ts_last_motor_sync=None
+        self.ts_last_motor_sync_warn=None
+
 
     # ###########  Device Methods #############
 
@@ -234,6 +237,7 @@ class Pimu(Device):
         print('Debug', self.status['debug'])
         print('Timestamp', self.status['timestamp'])
         print('Read error', self.transport.status['read_error'])
+        print('Dropped motor sync',self.status['motor_sync_drop'])
         print('Board version:',self.board_info['board_version'])
         print('Firmware version:', self.board_info['firmware_version'])
         self.imu.pretty_print()
@@ -274,10 +278,20 @@ class Pimu(Device):
         #Push out immediately
         if not self.hw_valid:
             return
+
+        t = time.time()
+        if self.ts_last_motor_sync is not None and t-self.ts_last_motor_sync<1.0/self.params['max_sync_rate_hz']:
+            self.status['motor_sync_drop'] += 1
+            if self.ts_last_motor_sync_warn is None or t-self.ts_last_motor_sync_warn>5.0:
+                print('Warning: Rate of calls to Pimu:trigger_motor_sync above maximum frequency of %.2f Hz. Motor commands dropped: %d'%(self.params['max_sync_rate_hz'],self.status['motor_sync_drop']))
+                self.ts_last_motor_sync_warn=t
+            return
+
         with self.lock:
             self.transport.payload_out[0] = RPC_SET_MOTOR_SYNC
             self.transport.queue_rpc(1, self.rpc_motor_sync_reply)
             self.transport.step()
+            self.ts_last_motor_sync = t
 
     def set_fan_on(self):
         with self.lock:

--- a/body/stretch_body/robot_params.py
+++ b/body/stretch_body/robot_params.py
@@ -24,6 +24,7 @@ factory_params = {
     "robot_collision": {
         'models': ['collision_arm_camera']
     },
+    'pimu':{'max_sync_rate_hz':20.0},
     'hello-motor-arm':{
         'gains': {'vel_near_setpoint_d': 3.5}
     },

--- a/body/test/test_pimu.py
+++ b/body/test/test_pimu.py
@@ -10,6 +10,19 @@ import time
 
 class TestPimu(unittest.TestCase):
 
+    def test_motor_sync_rate(self):
+        print('test_motor_sync_rate')
+        p = stretch_body.pimu.Pimu()
+        p.startup()
+        for i in range(100):
+            p.trigger_motor_sync()
+            time.sleep(1/p.params['max_sync_rate_hz'])
+        self.assertTrue(p.status['motor_sync_drop']==0)
+        for i in range(100):
+            p.trigger_motor_sync()
+            time.sleep(0.01)
+        self.assertTrue(p.status['motor_sync_drop']>75)
+
     def test_invalid_protocol(self):
         """Simulate an invalid protocol and verify the correct error.
         """


### PR DESCRIPTION
This adds a warning to Pimu:trigger_motor_sync if it is called by the user above the specified rate (20hz). This is necessary as the runstop line is muxed with the motor_sync function. It can have a false positive when trigger_motor_sync is call at rates above ~28hz (P0 firmware).

 If the Pimu detects that trigger_motor_sync is call too soon it will drop the push_command request.