### PR TITLE
Transport Library

### DIFF
--- a/body/stretch_body/transport/__init__.py
+++ b/body/stretch_body/transport/__init__.py
@@ -1,0 +1,1 @@
+import transport.rpc

--- a/body/stretch_body/transport/__init__.py
+++ b/body/stretch_body/transport/__init__.py
@@ -1,1 +1,33 @@
-import transport.rpc
+from __future__ import print_function
+import stretch_body.transport.rpc
+import serial
+import fcntl
+import errno
+import logging
+
+bus = None
+logger = logging.getLogger('transport')
+
+
+def start(usb):
+    global bus, logger
+    logger.debug('Opening transport on: {0}'.format(usb))
+    try:
+        bus = serial.Serial(usb, write_timeout=1.0)
+        fcntl.flock(bus.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except (serial.SerialException, IOError) as e:
+        if e.errno == errno.ENOENT:
+            logger.error('Device {0} does not exist. Check cable connections.'.format(usb))
+        elif e.errno == errno.EAGAIN:
+            logger.error('Device {0} busy. Close other Stretch Body instances.'.format(usb))
+            bus.close()
+        bus = None
+    return bus is not None
+
+
+def stop():
+    global bus, logger
+    if bus is not None:
+        logger.debug('Closing transport on: {0}'.format(bus.port))
+        bus.close()
+        bus = None

--- a/body/stretch_body/transport/cobs_encoder.py
+++ b/body/stretch_body/transport/cobs_encoder.py
@@ -3,22 +3,21 @@ import time
 import array
 import struct
 
-# other
 RPC_BLOCK_SIZE = 32
 
 
-def cobs_frame(data, size):
+def frame(data, size):
     crc = calculate_crc(data, size)
     data[size] = (crc >> 8) & 0xFF
     data[size + 1] = (crc) & 0xFF
     size += 2
-    encoded_data = cobs_encode(data, size)
+    encoded_data = encode(data, size)
     encoded_data.append(0x00)
     return encoded_data
 
 
-def cobs_deframe(encoded_data):
-    crc1, data, size = cobs_decode(encoded_data, len(encoded_data))
+def deframe(encoded_data):
+    crc1, data, size = decode(encoded_data, len(encoded_data))
     crc2 = calculate_crc(data, size)
     if crc1 != crc2:
         print("ERROR!!!!! CRC1 not equal CRC2")
@@ -39,7 +38,7 @@ def calculate_crc(data, size):
     return crc
 
 
-def cobs_encode(data, size):
+def encode(data, size):
     read_index = 0
     write_index = 1
     code_index = 0
@@ -66,7 +65,7 @@ def cobs_encode(data, size):
     return encode_buffer[:write_index]
 
 
-def cobs_decode(encoded_data, size):
+def decode(encoded_data, size):
     buffer = array.array('B', [0] * (RPC_BLOCK_SIZE*2))
     if size == 0:
         return (0, buffer, 0)

--- a/body/stretch_body/transport/cobs_encoder.py
+++ b/body/stretch_body/transport/cobs_encoder.py
@@ -6,12 +6,15 @@ import struct
 RPC_BLOCK_SIZE = 32
 
 
-def frame(data, size):
-    crc = calculate_crc(data, size)
-    data[size] = (crc >> 8) & 0xFF
-    data[size + 1] = (crc) & 0xFF
+def frame(data):
+    size = len(data)
+    buffer = array.array('B', [0] * (RPC_BLOCK_SIZE*2))
+    buffer[:size] = array.array('B', data)
+    crc = calculate_crc(buffer, size)
+    buffer[size] = (crc >> 8) & 0xFF
+    buffer[size + 1] = (crc) & 0xFF
     size += 2
-    encoded_data = encode(data, size)
+    encoded_data = encode(buffer, size)
     encoded_data.append(0x00)
     return encoded_data
 

--- a/body/stretch_body/transport/encoder.py
+++ b/body/stretch_body/transport/encoder.py
@@ -1,0 +1,91 @@
+from __future__ import print_function
+import time
+import array
+import struct
+
+# other
+RPC_BLOCK_SIZE = 32
+
+
+def cobs_frame(data, size):
+    crc = calculate_crc(data, size)
+    data[size] = (crc >> 8) & 0xFF
+    data[size + 1] = (crc) & 0xFF
+    size += 2
+    encoded_data = cobs_encode(data, size)
+    encoded_data.append(0x00)
+    return encoded_data
+
+
+def cobs_deframe(encoded_data):
+    crc1, data, size = cobs_decode(encoded_data, len(encoded_data))
+    crc2 = calculate_crc(data, size)
+    if crc1 != crc2:
+        print("ERROR!!!!! CRC1 not equal CRC2")
+        return False
+    return data, size
+
+
+def calculate_crc(data, size):
+    crc = 0xFFFF
+    for i in range(size):
+        crc ^= data[i]
+        for i in range(8):
+            if ((crc & 1) != 0):
+                crc >>= 1
+                crc ^= 0xA001
+            else:
+                crc >>= 1
+    return crc
+
+
+def cobs_encode(data, size):
+    read_index = 0
+    write_index = 1
+    code_index = 0
+    code = 1
+    encode_buffer = [0] * (2 * size)
+    while (read_index < size):
+        if (data[read_index] == 0):
+            encode_buffer[code_index] = code
+            code = 1
+            code_index = write_index
+            write_index += 1
+            read_index += 1
+        else:
+            encode_buffer[write_index] = data[read_index]
+            read_index += 1
+            write_index += 1
+            code += 1
+            if (code == 0xFF):
+                encode_buffer[code_index] = code
+                code = 1
+                code_index = write_index
+                write_index += 1
+    encode_buffer[code_index] = code
+    return encode_buffer[:write_index]
+
+
+def cobs_decode(encoded_data, size):
+    buffer = array.array('B', [0] * (RPC_BLOCK_SIZE*2))
+    if size == 0:
+        return (0, buffer, 0)
+
+    read_index = 0
+    write_index = 0
+    code = 0
+    while read_index < size:
+        code = encoded_data[read_index]
+        if (read_index + code > size and code != 1):
+            return (0, buffer, 0)
+
+        read_index += 1
+        for i in range(1, code):
+            buffer[write_index] = encoded_data[read_index]
+            read_index += 1
+            write_index += 1
+        if (code != 0xFF and read_index != size):
+            buffer[write_index] = 0
+            write_index += 1
+    crc = (buffer[write_index - 2] << 8) | buffer[write_index - 1]
+    return (crc, buffer, write_index-2)

--- a/body/stretch_body/transport/rpc.py
+++ b/body/stretch_body/transport/rpc.py
@@ -18,29 +18,74 @@ RPC_ACK_GET_BLOCK_LAST = 108
 # other
 RPC_BLOCK_SIZE = 32
 RPC_DATA_SIZE = 1024
+RPC_ACK_ERROR = -1
 READ_TIMEOUT = 0.2 # seconds
 PACKET_MARKER = 0
 
 
-def send(usb, rpc_type, ack_type, rpc_struct, ack_struct, rpc_arguments):
+def send(usb, call_type, reply_type, call_struct, reply_struct, call_dict, clear_buffers=False):
     if usb not in transport.buses:
         transport.logger.debug('Transport not open on: {0}'.format(usb))
         return False
 
-    # initiate a new RPC
-    encoded_buffer = encoder.frame(data=[RPC_START_NEW_RPC])
-    transport.buses[usb].write(encoded_buffer)
-    buffer, _ = _receive(usb)
-    if buffer[0] != RPC_ACK_NEW_RPC:
-        transport.logger.error('Transport receive error on: RPC_ACK_NEW_RPC')
-        return False
+    # discard previous rpcs
+    if clear_buffers:
+        time.sleep(0.1) # wait for old data to arrive
+        transport.buses[usb].reset_output_buffer()
+        transport.buses[usb].reset_input_buffer()
 
-    # # send rpc arguments as data blocks
-    # something = [0] * 32
-    # for i in range(0, len(something), RPC_BLOCK_SIZE):
-    #     pass
+    # initiate a new RPC
+    _transact(usb=usb, data=[RPC_START_NEW_RPC], expected_ack=RPC_ACK_NEW_RPC)
+    # encoded_buffer = encoder.frame(data=[RPC_START_NEW_RPC])
+    # transport.buses[usb].write(encoded_buffer)
+    # buffer = _receive(usb)
+    # if buffer[0] != RPC_ACK_NEW_RPC:
+    #     transport.logger.error('Transport receive error on: RPC_ACK_NEW_RPC')
+    #     return False
+
+    # send call data in batches
+    data = [call_type]
+    for i in range(0, len(data), RPC_BLOCK_SIZE):
+        data_block = data[i:i+RPC_BLOCK_SIZE]
+        last_block = len(data) <= i + RPC_BLOCK_SIZE
+        call_block_type = RPC_SEND_BLOCK_LAST if last_block else RPC_SEND_BLOCK_MORE
+        reply_block_type = RPC_ACK_SEND_BLOCK_LAST if last_block else RPC_ACK_SEND_BLOCK_MORE
+
+        encoded_buffer = encoder.frame(data=[call_block_type] + data_block)
+        transport.buses[usb].write(encoded_buffer)
+        buffer = _receive(usb)
+        if buffer[0] != reply_block_type:
+            transport.logger.error('Transport receive error on: RPC_ACK_SEND_BLOCK_MORE/LAST')
+            return False
+
+    # receive reply data in batches
+    encoded_buffer = encoder.frame(data=[RPC_GET_BLOCK])
+    transport.buses[usb].write(encoded_buffer)
+    buffer = _receive(usb)
+    if buffer[0] != RPC_ACK_GET_BLOCK_MORE and buffer[0] != RPC_ACK_GET_BLOCK_LAST:
+        transport.logger.error('Transport receive error on: RPC_ACK_GET_BLOCK_MORE/LAST')
+        return False
+    received_data = buffer
+    while buffer[0] == RPC_ACK_GET_BLOCK_MORE:
+        encoded_buffer = encoder.frame(data=[RPC_GET_BLOCK])
+        transport.buses[usb].write(encoded_buffer)
+        buffer = _receive(usb)
+        if buffer[0] != RPC_ACK_GET_BLOCK_MORE and buffer[0] != RPC_ACK_GET_BLOCK_LAST:
+            transport.logger.error('Transport receive error on: RPC_ACK_GET_BLOCK_MORE/LAST')
+            return False
+        received_data += buffer
 
     return True
+
+
+def _transact(usb, data, expected_ack):
+    encoded_buffer = encoder.frame(data=data)
+    transport.buses[usb].write(encoded_buffer)
+    received_buffer = _receive(usb)
+    if received_buffer[0] != expected_ack:
+        transport.logger.error('Transport receive error on: {0}'.format(expected_ack))
+        raise TransportError
+    return received_buffer
 
 
 def _receive(usb):
@@ -54,6 +99,7 @@ def _receive(usb):
                 byte = struct.unpack('B', byte)[0]
             if byte == PACKET_MARKER:
                 buffer, size = encoder.deframe(encoded_data=rx_buffer)
-                return buffer, size
+                return buffer
             else:
                 rx_buffer.append(byte)
+    return [RPC_ACK_ERROR]

--- a/body/stretch_body/transport/rpc.py
+++ b/body/stretch_body/transport/rpc.py
@@ -1,10 +1,8 @@
 from __future__ import print_function
-from transport import encoder
+import stretch_body.transport as transport
+from stretch_body.transport import encoder
 import time
 import array
-import fcntl
-import serial
-import logging
 
 # methods
 RPC_START_NEW_RPC =100
@@ -23,56 +21,27 @@ RPC_DATA_SIZE = 1024
 READ_TIMEOUT = 0.2 # seconds
 PACKET_MARKER = 0
 
-bus = None
-logger = logging.getLogger()
-
-
-def start(usb):
-    global bus, logger
-    logger.warn('Starting transport on: ' + usb)
-    try:
-        bus = serial.Serial(usb, write_timeout=1.0)
-        if bus.isOpen():
-            try:
-                fcntl.flock(bus.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
-            except IOError:
-                logger.error('Port %s is busy. Check if another Stretch Body process is already running' % usb)
-                bus.close()
-                bus = None
-    except serial.SerialException as e:
-        logger.error("SerialException({0}): {1}".format(e.errno, e.strerror))
-        bus = None
-
-
-def stop():
-    global bus, logger
-    if bus is not None:
-        logger.warn('Shutting down transport')
-        bus.close()
-        bus = None
-
 
 def send(method, arguments_format, returns_format, arguments):
-    global bus, logger
-    if bus is None:
-        return
+    if transport.bus is None:
+        return False
     buffer = array.array('B', [0] * (RPC_BLOCK_SIZE*2))
     buffer[0] = RPC_START_NEW_RPC
     encoded_buffer = encoder.cobs_frame(data=buffer, size=1)
-    bus.write(encoded_buffer)
+    transport.bus.write(encoded_buffer)
     buffer, size = _receive_data()
     if buffer[0] != RPC_ACK_NEW_RPC:
-        logger.error('Transport RX Error on RPC_ACK_NEW_RPC')
-        return
+        transport.logger.error('Transport RX Error on RPC_ACK_NEW_RPC')
+        return False
+    return True
 
 
 def _receive_data():
-    global bus, logger
     start = time.time()
     rx_buffer = []
     while (time.time() - start) < READ_TIMEOUT:
-        nn = bus.inWaiting()
-        waiting_bytes = bus.read(nn) if nn > 0 else []
+        nn = transport.bus.inWaiting()
+        waiting_bytes = transport.bus.read(nn) if nn > 0 else []
         for byte in waiting_bytes:
             if type(byte) == str: # Py2 needs this, Py3 not
                 byte = struct.unpack('B', byte)[0]

--- a/body/stretch_body/transport/rpc.py
+++ b/body/stretch_body/transport/rpc.py
@@ -1,0 +1,83 @@
+from __future__ import print_function
+from transport import encoder
+import time
+import array
+import fcntl
+import serial
+import logging
+
+# methods
+RPC_START_NEW_RPC =100
+RPC_ACK_NEW_RPC= 101
+RPC_SEND_BLOCK_MORE = 102
+RPC_ACK_SEND_BLOCK_MORE = 103
+RPC_SEND_BLOCK_LAST = 104
+RPC_ACK_SEND_BLOCK_LAST = 105
+RPC_GET_BLOCK = 106
+RPC_ACK_GET_BLOCK_MORE = 107
+RPC_ACK_GET_BLOCK_LAST = 108
+
+# other
+RPC_BLOCK_SIZE = 32
+RPC_DATA_SIZE = 1024
+READ_TIMEOUT = 0.2 # seconds
+PACKET_MARKER = 0
+
+bus = None
+logger = logging.getLogger()
+
+
+def start(usb):
+    global bus, logger
+    logger.warn('Starting transport on: ' + usb)
+    try:
+        bus = serial.Serial(usb, write_timeout=1.0)
+        if bus.isOpen():
+            try:
+                fcntl.flock(bus.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except IOError:
+                logger.error('Port %s is busy. Check if another Stretch Body process is already running' % usb)
+                bus.close()
+                bus = None
+    except serial.SerialException as e:
+        logger.error("SerialException({0}): {1}".format(e.errno, e.strerror))
+        bus = None
+
+
+def stop():
+    global bus, logger
+    if bus is not None:
+        logger.warn('Shutting down transport')
+        bus.close()
+        bus = None
+
+
+def send(method, arguments_format, returns_format, arguments):
+    global bus, logger
+    if bus is None:
+        return
+    buffer = array.array('B', [0] * (RPC_BLOCK_SIZE*2))
+    buffer[0] = RPC_START_NEW_RPC
+    encoded_buffer = encoder.cobs_frame(data=buffer, size=1)
+    bus.write(encoded_buffer)
+    buffer, size = _receive_data()
+    if buffer[0] != RPC_ACK_NEW_RPC:
+        logger.error('Transport RX Error on RPC_ACK_NEW_RPC')
+        return
+
+
+def _receive_data():
+    global bus, logger
+    start = time.time()
+    rx_buffer = []
+    while (time.time() - start) < READ_TIMEOUT:
+        nn = bus.inWaiting()
+        waiting_bytes = bus.read(nn) if nn > 0 else []
+        for byte in waiting_bytes:
+            if type(byte) == str: # Py2 needs this, Py3 not
+                byte = struct.unpack('B', byte)[0]
+            if byte == PACKET_MARKER:
+                buffer, size = encoder.cobs_deframe(encoded_data=rx_buffer)
+                return buffer, size
+            else:
+                rx_buffer.append(byte)

--- a/body/stretch_body/transport/rpc.py
+++ b/body/stretch_body/transport/rpc.py
@@ -22,26 +22,33 @@ READ_TIMEOUT = 0.2 # seconds
 PACKET_MARKER = 0
 
 
-def send(method, arguments_format, returns_format, arguments):
-    if transport.bus is None:
+def send(usb, rpc_type, ack_type, rpc_struct, ack_struct, rpc_arguments):
+    if usb not in transport.buses:
+        transport.logger.debug('Transport not open on: {0}'.format(usb))
         return False
-    buffer = array.array('B', [0] * (RPC_BLOCK_SIZE*2))
-    buffer[0] = RPC_START_NEW_RPC
-    encoded_buffer = encoder.frame(data=buffer, size=1)
-    transport.bus.write(encoded_buffer)
-    buffer, size = _receive()
+
+    # initiate a new RPC
+    encoded_buffer = encoder.frame(data=[RPC_START_NEW_RPC])
+    transport.buses[usb].write(encoded_buffer)
+    buffer, _ = _receive(usb)
     if buffer[0] != RPC_ACK_NEW_RPC:
-        transport.logger.error('Transport RX Error on RPC_ACK_NEW_RPC')
+        transport.logger.error('Transport receive error on: RPC_ACK_NEW_RPC')
         return False
+
+    # # send rpc arguments as data blocks
+    # something = [0] * 32
+    # for i in range(0, len(something), RPC_BLOCK_SIZE):
+    #     pass
+
     return True
 
 
-def _receive():
+def _receive(usb):
     start = time.time()
     rx_buffer = []
     while (time.time() - start) < READ_TIMEOUT:
-        nn = transport.bus.inWaiting()
-        waiting_bytes = transport.bus.read(nn) if nn > 0 else []
+        nn = transport.buses[usb].in_waiting
+        waiting_bytes = transport.buses[usb].read(nn) if nn > 0 else []
         for byte in waiting_bytes:
             if type(byte) == str: # Py2 needs this, Py3 not
                 byte = struct.unpack('B', byte)[0]

--- a/body/test/test_transport.py
+++ b/body/test/test_transport.py
@@ -1,0 +1,59 @@
+# Logging level must be set before importing any stretch_body class
+import stretch_body.robot_params
+stretch_body.robot_params.RobotParams.set_logging_level("DEBUG")
+
+import unittest
+import stretch_body.transport
+import stretch_body.transport.cobs_encoder
+
+import time
+
+
+class TestTransport(unittest.TestCase):
+
+    # def test_generate_rpc_data(self):
+    #     """Test that is_moving_filtered is False when no motion
+    #     """
+    #     pass
+    #     rpc_struct = """
+    #     struct __attribute__ ((packed)) Status{
+    #       uint8_t mode;                 //current control mode
+    #       float effort;                 //ticks, 1 tick = 12.95mA
+    #       double pos;                   //rad, wrapped
+    #       float vel;                    //rad/sec
+    #       float err;                    //controller error (inner loop)
+    #       uint32_t diag;                //diagnostic codes     
+    #       uint64_t timestamp;           //us of time of when encoder was read (since power-on)
+    #       uint64_t timestamp_line_sync; //us of time of when status sync was triggered (since power-on)
+    #       float debug; 
+    #       uint32_t guarded_event;       //counter of guarded events since power-up
+    #       float pos_traj;                 //Target of waypoint trajectory
+    #     };
+    #     """
+
+    def test_get_status(self):
+        RPC_GET_STATUS = 3
+        RPC_REPLY_STATUS = 4
+        reply_struct = """
+        struct __attribute__ ((packed)) Status{
+            uint8_t mode;   //current control mode
+            float effort;   //ticks, 1 tick = 12.95mA
+            double pos;      //rad, wrapped
+            float vel;      //rad/sec
+            float err;       //controller error (inner loop)
+            uint32_t diag;       //diagnostic codes
+            uint32_t timestamp; //us
+            float debug;
+            uint32_t guarded_event;
+        };
+        """
+        usb = '/dev/hello-motor-lift'
+        stretch_body.transport.startup(usb)
+        reply_dict = stretch_body.transport.rpc.send(
+            usb=usb,
+            call_type=RPC_GET_STATUS,
+            reply_type=RPC_REPLY_STATUS,
+            call_struct=None,
+            reply_struct=reply_struct,
+            call_dict=None
+        )


### PR DESCRIPTION
This PR tracks the on-going work of refactoring the serial communication capabilities of Stretch Body into a "transport" library. The idea is to collect the packing/unpacking, encoding, RPC, and serial related logic (spread out among classes like `stepper.py`, `cobs_encoding.py`, and `transport.py`) into a single python module that presents a simpler interface. This interface operates on RPC contracts, where the firmware and client libraries have agreed upon structs for the calling and returned arguments. This library will also be a natural point to tackle the thread starvation issues inherent to the Python multithreading library.

TODO:
 - Complete the RPC_START_NEW_RPC test