### PR TITLE
Support new firmware protocol (P1)

### DIFF
--- a/body/stretch_body/arm.py
+++ b/body/stretch_body/arm.py
@@ -1,7 +1,10 @@
 from __future__ import print_function
-from stretch_body.stepper import *
+from stretch_body.stepper import Stepper
 from stretch_body.device import Device
-from stretch_body.hello_utils import *
+
+import time
+import math
+
 
 class Arm(Device):
     """
@@ -132,7 +135,7 @@ class Arm(Device):
         else:
             i_contact_pos = self.i_contact_pos
 
-        self.motor.set_command(mode=MODE_VEL_TRAJ,
+        self.motor.set_command(mode=Stepper.MODE_VEL_TRAJ,
                                v_des=v_r,
                                a_des=a_r,
                                stiffness=stiffness,
@@ -181,7 +184,7 @@ class Arm(Device):
         else:
             i_contact_pos = self.i_contact_pos
 
-        self.motor.set_command(mode = Stepper.MODE_POS_TRAJ,
+        self.motor.set_command(mode=Stepper.MODE_POS_TRAJ,
                                 x_des=self.translate_to_motor_rad(x_m),
                                 v_des=v_r,
                                 a_des=a_r,

--- a/body/stretch_body/arm.py
+++ b/body/stretch_body/arm.py
@@ -181,7 +181,7 @@ class Arm(Device):
         else:
             i_contact_pos = self.i_contact_pos
 
-        self.motor.set_command(mode = MODE_POS_TRAJ,
+        self.motor.set_command(mode = Stepper.MODE_POS_TRAJ,
                                 x_des=self.translate_to_motor_rad(x_m),
                                 v_des=v_r,
                                 a_des=a_r,
@@ -237,7 +237,7 @@ class Arm(Device):
         else:
             i_contact_pos = self.i_contact_pos
 
-        self.motor.set_command(mode=MODE_POS_TRAJ_INCR,
+        self.motor.set_command(mode=Stepper.MODE_POS_TRAJ_INCR,
                                x_des=self.translate_to_motor_rad(x_m),
                                v_des=v_r,
                                a_des=a_r,

--- a/body/stretch_body/base.py
+++ b/body/stretch_body/base.py
@@ -109,14 +109,14 @@ class Base(Device):
 
 
 
-        self.left_wheel.set_command(mode=MODE_POS_TRAJ_INCR, x_des=x_mr,
+        self.left_wheel.set_command(mode=Stepper.MODE_POS_TRAJ_INCR, x_des=x_mr,
                                     v_des=v_mr,
                                     a_des=a_mr,
                                     stiffness=stiffness,
                                     i_feedforward=0,
                                     i_contact_pos=i_contact_l,
                                     i_contact_neg=-1*i_contact_l)
-        self.right_wheel.set_command(mode=MODE_POS_TRAJ_INCR, x_des=x_mr,
+        self.right_wheel.set_command(mode=Stepper.MODE_POS_TRAJ_INCR, x_des=x_mr,
                                     v_des=v_mr,
                                     a_des=a_mr,
                                     stiffness=stiffness,
@@ -164,14 +164,14 @@ class Base(Device):
 
         if stiffness is None:
             stiffness = self.stiffness
-        self.left_wheel.set_command(mode=MODE_POS_TRAJ_INCR,x_des=-1*x_mr,
+        self.left_wheel.set_command(mode=Stepper.MODE_POS_TRAJ_INCR,x_des=-1*x_mr,
                                     v_des=v_mr,
                                     a_des=a_mr,
                                     stiffness=stiffness,
                                     i_feedforward=0,
                                     i_contact_pos=i_contact_l,
                                     i_contact_neg=-1 * i_contact_l)
-        self.right_wheel.set_command(mode=MODE_POS_TRAJ_INCR,x_des=x_mr,
+        self.right_wheel.set_command(mode=Stepper.MODE_POS_TRAJ_INCR,x_des=x_mr,
                                      v_des=v_mr,
                                      a_des=a_mr,
                                      stiffness=stiffness,
@@ -196,8 +196,8 @@ class Base(Device):
         v_sign = numpy.sign(v_m)
         v_m = v_sign * min(abs(v_m), self.params['motion']['max']['vel_m'])
         v_mr = self.translate_to_motor_rad(v_m)
-        self.left_wheel.set_command(mode=MODE_VEL_TRAJ, v_des=v_mr, a_des=a_mr)
-        self.right_wheel.set_command(mode=MODE_VEL_TRAJ, v_des=v_mr, a_des=a_mr)
+        self.left_wheel.set_command(mode=Stepper.MODE_VEL_TRAJ, v_des=v_mr, a_des=a_mr)
+        self.right_wheel.set_command(mode=Stepper.MODE_VEL_TRAJ, v_des=v_mr, a_des=a_mr)
 
     def set_rotational_velocity(self, v_r, a_r=None):
         """
@@ -217,8 +217,8 @@ class Base(Device):
         v_mr_max = self.translate_to_motor_rad(self.params['motion']['max']['vel_m'])
         v_mr = self.rotate_to_motor_rad(v_r)
         v_mr = w_sign * min(abs(v_mr), v_mr_max)
-        self.left_wheel.set_command(mode=MODE_VEL_TRAJ, v_des=-1*v_mr, a_des=a_mr)
-        self.right_wheel.set_command(mode=MODE_VEL_TRAJ, v_des=v_mr, a_des=a_mr)
+        self.left_wheel.set_command(mode=Stepper.MODE_VEL_TRAJ, v_des=-1*v_mr, a_des=a_mr)
+        self.right_wheel.set_command(mode=Stepper.MODE_VEL_TRAJ, v_des=v_mr, a_des=a_mr)
 
     def set_velocity(self, v_m, w_r, a=None):
         """
@@ -248,8 +248,8 @@ class Base(Device):
         wr_m = wr_sign * min(abs(wr_m), self.params['motion']['max']['vel_m'])
         wr_r = self.translate_to_motor_rad(wr_m)
 
-        self.left_wheel.set_command(mode=MODE_VEL_TRAJ, v_des=wl_r, a_des=a_mr)
-        self.right_wheel.set_command(mode=MODE_VEL_TRAJ, v_des=wr_r, a_des=a_mr)
+        self.left_wheel.set_command(mode=Stepper.MODE_VEL_TRAJ, v_des=wl_r, a_des=a_mr)
+        self.right_wheel.set_command(mode=Stepper.MODE_VEL_TRAJ, v_des=wr_r, a_des=a_mr)
 
     def step_sentry(self,robot):
         """

--- a/body/stretch_body/lift.py
+++ b/body/stretch_body/lift.py
@@ -1,7 +1,10 @@
 from __future__ import print_function
-from stretch_body.stepper import *
+from stretch_body.stepper import Stepper
 from stretch_body.device import Device
+
 import time
+import math
+
 
 class Lift(Device):
     """
@@ -133,7 +136,7 @@ class Lift(Device):
         else:
             i_contact_pos = self.i_contact_pos
 
-        self.motor.set_command(mode=MODE_VEL_TRAJ,
+        self.motor.set_command(mode=Stepper.MODE_VEL_TRAJ,
                                v_des=v_r,
                                a_des=a_r,
                                stiffness=stiffness,
@@ -267,13 +270,13 @@ class Lift(Device):
 
     def motor_rad_to_translate_m(self,ang): #input in rad
         d=self.params['pinion_t']*self.params['belt_pitch_m']/math.pi
-        lift_m = (rad_to_deg(ang)/180.0)*math.pi*(d/2)
+        lift_m = (math.degrees(ang)/180.0)*math.pi*(d/2)
         return lift_m
 
     def translate_to_motor_rad(self, lift_m):
         d = self.params['pinion_t'] * self.params['belt_pitch_m'] / math.pi
         ang = 180*lift_m/((d/2)*math.pi)
-        return deg_to_rad(ang)
+        return math.radians(ang)
 
     def __wait_for_contact(self, timeout=5.0):
         ts=time.time()

--- a/body/stretch_body/lift.py
+++ b/body/stretch_body/lift.py
@@ -183,7 +183,7 @@ class Lift(Device):
         else:
             i_contact_pos = self.i_contact_pos
 
-        self.motor.set_command(mode = MODE_POS_TRAJ,
+        self.motor.set_command(mode = Stepper.MODE_POS_TRAJ,
                                 x_des=self.translate_to_motor_rad(x_m),
                                 v_des=v_r,
                                 a_des=a_r,
@@ -241,7 +241,7 @@ class Lift(Device):
 
         #print('Lift %.2f , %.2f  , %.2f' % (x_m, self.motor_rad_to_translate_m(v_r), self.motor_rad_to_translate_m(a_r)))
 
-        self.motor.set_command(mode = MODE_POS_TRAJ_INCR,
+        self.motor.set_command(mode = Stepper.MODE_POS_TRAJ_INCR,
                                 x_des=self.translate_to_motor_rad(x_m),
                                 v_des=v_r,
                                 a_des=a_r,

--- a/body/stretch_body/pimu.py
+++ b/body/stretch_body/pimu.py
@@ -517,7 +517,7 @@ class Pimu(PimuBase):
     """
     def __init__(self, event_reset=False):
         PimuBase.__init__(self, event_reset)
-        self.protocol_map = {'p0': Pimu_Protocol_P0, 'p1': Pimu_Protocol_P1}
+        self.supported_protocols = {'p0': Pimu_Protocol_P0, 'p1': Pimu_Protocol_P1}
 
     def startup(self):
         """
@@ -526,8 +526,8 @@ class Pimu(PimuBase):
         """
         PimuBase.startup(self)
         if self.hw_valid:
-            if self.board_info['protocol_version'] in self.protocol_map:
-                Pimu.__bases__ = (self.protocol_map[self.board_info['protocol_version']],)
+            if self.board_info['protocol_version'] in self.supported_protocols:
+                Pimu.__bases__ = (self.supported_protocols[self.board_info['protocol_version']],)
             else:
                 protocol_msg = """
                 ----------------
@@ -537,7 +537,7 @@ class Pimu(PimuBase):
                 Disabling device.
                 Please upgrade the firmware and/or version of Stretch Body.
                 ----------------
-                """.format(self.name, self.board_info['protocol_version'], self.protocol_map)
+                """.format(self.name, self.board_info['protocol_version'], self.supported_protocols)
                 self.logger.warning(textwrap.dedent(protocol_msg))
                 self.hw_valid = False
                 self.transport.stop()

--- a/body/stretch_body/pimu.py
+++ b/body/stretch_body/pimu.py
@@ -400,8 +400,8 @@ class PimuBase(Device):
             pack_float_t(s, sidx, self.config['low_voltage_alert']);sidx += 4
             pack_float_t(s, sidx, self.config['high_current_alert']);sidx += 4
             pack_float_t(s, sidx, self.config['over_tilt_alert']); sidx += 4
-            self.config['enable_sync_mode'] = 0 # TODO: hardcoded disabled until implemented
-            pack_uint8_t(s, sidx, self.config['enable_sync_mode']); sidx += 1
+            #self.config['enable_sync_mode'] = 0 # TODO: hardcoded disabled until implemented
+            #pack_uint8_t(s, sidx, self.config['enable_sync_mode']); sidx += 1
             return sidx
 
     def pack_trigger(self,s,sidx):

--- a/body/stretch_body/pimu.py
+++ b/body/stretch_body/pimu.py
@@ -114,7 +114,8 @@ class IMU_Protocol_P1(IMUBase):
 class IMU(IMUBase):
     def __init__(self):
         IMUBase.__init__(self)
-        self.supported_protocols = {'p0': IMU_Protocol_P0, 'p1': IMU_Protocol_P1}
+        # Order in descending order so more recent protocols/methods override less recent
+        self.supported_protocols = {'p0': (IMU_Protocol_P0,), 'p1': (IMU_Protocol_P1,IMU_Protocol_P0,)}
 
 # ##################################################################################
 class PimuBase(Device):
@@ -553,7 +554,8 @@ class Pimu(PimuBase):
     """
     def __init__(self, event_reset=False):
         PimuBase.__init__(self, event_reset)
-        self.supported_protocols = {'p0': Pimu_Protocol_P0, 'p1': Pimu_Protocol_P1}
+        # Order in descending order so more recent protocols/methods override less recent
+        self.supported_protocols = {'p0': (Pimu_Protocol_P0,), 'p1': (Pimu_Protocol_P1,Pimu_Protocol_P0,)}
 
     def startup(self):
         """
@@ -563,8 +565,8 @@ class Pimu(PimuBase):
         PimuBase.startup(self)
         if self.hw_valid:
             if self.board_info['protocol_version'] in self.supported_protocols:
-                Pimu.__bases__ = (self.supported_protocols[self.board_info['protocol_version']],)
-                self.imu.__bases__= (self.imu.supported_protocols[self.board_info['protocol_version']],)
+                Pimu.__bases__ = self.supported_protocols[self.board_info['protocol_version']]
+                IMU.__bases__= self.imu.supported_protocols[self.board_info['protocol_version']]
             else:
                 protocol_msg = """
                 ----------------

--- a/body/stretch_body/pimu.py
+++ b/body/stretch_body/pimu.py
@@ -401,8 +401,6 @@ class PimuBase(Device):
             pack_float_t(s, sidx, self.config['low_voltage_alert']);sidx += 4
             pack_float_t(s, sidx, self.config['high_current_alert']);sidx += 4
             pack_float_t(s, sidx, self.config['over_tilt_alert']); sidx += 4
-            #self.config['enable_sync_mode'] = 0 # TODO: hardcoded disabled until implemented
-            #pack_uint8_t(s, sidx, self.config['enable_sync_mode']); sidx += 1
             return sidx
 
     def pack_trigger(self,s,sidx):

--- a/body/stretch_body/pimu.py
+++ b/body/stretch_body/pimu.py
@@ -5,42 +5,9 @@ from stretch_body.hello_utils import *
 import textwrap
 import threading
 import psutil
-import logging
 import time
 
-RPC_SET_PIMU_CONFIG = 1
-RPC_REPLY_PIMU_CONFIG = 2
-RPC_GET_PIMU_STATUS = 3
-RPC_REPLY_PIMU_STATUS = 4
-RPC_SET_PIMU_TRIGGER = 5
-RPC_REPLY_PIMU_TRIGGER = 6
-RPC_GET_PIMU_BOARD_INFO =7
-RPC_REPLY_PIMU_BOARD_INFO =8
-RPC_SET_MOTOR_SYNC =9
-RPC_REPLY_MOTOR_SYNC =10
 
-STATE_AT_CLIFF_0= 1
-STATE_AT_CLIFF_1= 2
-STATE_AT_CLIFF_2= 4
-STATE_AT_CLIFF_3= 8
-STATE_RUNSTOP_EVENT= 16
-STATE_CLIFF_EVENT= 32
-STATE_FAN_ON =64
-STATE_BUZZER_ON= 128
-STATE_LOW_VOLTAGE_ALERT=256
-STATE_OVER_TILT_ALERT= 512
-STATE_HIGH_CURRENT_ALERT= 1024
-
-TRIGGER_BOARD_RESET=  1
-TRIGGER_RUNSTOP_RESET=  2
-TRIGGER_CLIFF_EVENT_RESET= 4
-TRIGGER_BUZZER_ON=  8
-TRIGGER_BUZZER_OFF=  16
-TRIGGER_FAN_ON=  32
-TRIGGER_FAN_OFF = 64
-TRIGGER_IMU_RESET =128
-TRIGGER_RUNSTOP_ON= 256
-TRIGGER_BEEP =512
 # ######################## PIMU #################################
 
 """
@@ -114,10 +81,45 @@ class IMU(Device):
         return sidx
 
 
-class Pimu(Device):
+class PimuBase(Device):
     """
     API to the Stretch RE1 Power and IMU board (Pimu)
     """
+    RPC_SET_PIMU_CONFIG = 1
+    RPC_REPLY_PIMU_CONFIG = 2
+    RPC_GET_PIMU_STATUS = 3
+    RPC_REPLY_PIMU_STATUS = 4
+    RPC_SET_PIMU_TRIGGER = 5
+    RPC_REPLY_PIMU_TRIGGER = 6
+    RPC_GET_PIMU_BOARD_INFO = 7
+    RPC_REPLY_PIMU_BOARD_INFO = 8
+    RPC_SET_MOTOR_SYNC = 9
+    RPC_REPLY_MOTOR_SYNC = 10
+
+    STATE_AT_CLIFF_0 = 1
+    STATE_AT_CLIFF_1 = 2
+    STATE_AT_CLIFF_2 = 4
+    STATE_AT_CLIFF_3 = 8
+    STATE_RUNSTOP_EVENT = 16
+    STATE_CLIFF_EVENT = 32
+    STATE_FAN_ON = 64
+    STATE_BUZZER_ON = 128
+    STATE_LOW_VOLTAGE_ALERT = 256
+    STATE_OVER_TILT_ALERT = 512
+    STATE_HIGH_CURRENT_ALERT = 1024
+
+    TRIGGER_BOARD_RESET = 1
+    TRIGGER_RUNSTOP_RESET = 2
+    TRIGGER_CLIFF_EVENT_RESET = 4
+    TRIGGER_BUZZER_ON = 8
+    TRIGGER_BUZZER_OFF = 16
+    TRIGGER_FAN_ON = 32
+    TRIGGER_FAN_OFF = 64
+    TRIGGER_IMU_RESET = 128
+    TRIGGER_RUNSTOP_ON = 256
+    TRIGGER_BEEP = 512
+
+
     def __init__(self, event_reset=False):
         Device.__init__(self, 'pimu')
         self.lock = threading.RLock()
@@ -142,7 +144,6 @@ class Pimu(Device):
             self.cliff_event_reset()
 
         self.board_info = {'board_version': None, 'firmware_version': None, 'protocol_version': None}
-        self.valid_firmware_protocol = 'p1'
         self.hw_valid = False
         self.ts_last_motor_sync=None
         self.ts_last_motor_sync_warn=None
@@ -152,32 +153,14 @@ class Pimu(Device):
 
     def startup(self):
         with self.lock:
-            self.hw_valid=self.transport.startup()
+            self.hw_valid = self.transport.startup()
             if self.hw_valid:
                 # Pull board info
-                self.transport.payload_out[0] = RPC_GET_PIMU_BOARD_INFO
+                self.transport.payload_out[0] = self.RPC_GET_PIMU_BOARD_INFO
                 self.transport.queue_rpc(1, self.rpc_board_info_reply)
                 self.transport.step(exiting=False)
-                # Check that protocol matches
-                if not(self.valid_firmware_protocol == self.board_info['protocol_version']):
-                    protocol_msg = """
-                    ----------------
-                    Firmware protocol mismatch on {0}.
-                    Protocol on board is {1}.
-                    Valid protocol is: {2}.
-                    Disabling device.
-                    Please upgrade the firmware and/or version of Stretch Body.
-                    ----------------
-                    """.format(self.name, self.board_info['protocol_version'], self.valid_firmware_protocol)
-                    self.logger.warning(textwrap.dedent(protocol_msg))
-                    self.hw_valid=False
-                    self.transport.stop()
-
-            if self.hw_valid:
-                self.push_command()
-                self.pull_status()
                 return True
-        return False
+            return False
 
     def stop(self):
         if not self.hw_valid:
@@ -193,7 +176,7 @@ class Pimu(Device):
             return
         with self.lock:
             # Queue Body Status RPC
-            self.transport.payload_out[0] = RPC_GET_PIMU_STATUS
+            self.transport.payload_out[0] = self.RPC_GET_PIMU_STATUS
             self.transport.queue_rpc(1, self.rpc_status_reply)
             self.transport.step(exiting=exiting)
 
@@ -202,13 +185,13 @@ class Pimu(Device):
             return
         with self.lock:
             if self._dirty_config:
-                self.transport.payload_out[0] = RPC_SET_PIMU_CONFIG
+                self.transport.payload_out[0] = self.RPC_SET_PIMU_CONFIG
                 sidx = self.pack_config(self.transport.payload_out, 1)
                 self.transport.queue_rpc2(sidx, self.rpc_config_reply)
                 self._dirty_config=False
 
             if self._dirty_trigger:
-                self.transport.payload_out[0] = RPC_SET_PIMU_TRIGGER
+                self.transport.payload_out[0] = self.RPC_SET_PIMU_TRIGGER
                 sidx = self.pack_trigger(self.transport.payload_out, 1)
                 self.transport.queue_rpc2(sidx, self.rpc_trigger_reply)
                 self._trigger=0
@@ -247,7 +230,7 @@ class Pimu(Device):
         Reset the robot runstop, allowing motion to continue
         """
         with self.lock:
-            self._trigger=self._trigger | TRIGGER_RUNSTOP_RESET
+            self._trigger=self._trigger | self.TRIGGER_RUNSTOP_RESET
             self._dirty_trigger=True
 
     def runstop_event_trigger(self):
@@ -255,7 +238,7 @@ class Pimu(Device):
         Trigger the robot runstop, stopping motion
         """
         with self.lock:
-            self._trigger=self._trigger | TRIGGER_RUNSTOP_ON
+            self._trigger=self._trigger | self.TRIGGER_RUNSTOP_ON
             self._dirty_trigger=True
 
     def trigger_beep(self):
@@ -263,13 +246,13 @@ class Pimu(Device):
         Generate a single short beep
         """
         with self.lock:
-            self._trigger=self._trigger | TRIGGER_BEEP
+            self._trigger=self._trigger | self.TRIGGER_BEEP
             self._dirty_trigger=True
 
     # ####################### Utility functions ####################################################
     def imu_reset(self):
         with self.lock:
-            self._trigger=self._trigger | TRIGGER_IMU_RESET
+            self._trigger=self._trigger | self.TRIGGER_IMU_RESET
             self._dirty_trigger=True
 
     def trigger_motor_sync(self):
@@ -286,39 +269,39 @@ class Pimu(Device):
             return
 
         with self.lock:
-            self.transport.payload_out[0] = RPC_SET_MOTOR_SYNC
+            self.transport.payload_out[0] = self.RPC_SET_MOTOR_SYNC
             self.transport.queue_rpc(1, self.rpc_motor_sync_reply)
             self.transport.step()
             self.ts_last_motor_sync = t
 
     def set_fan_on(self):
         with self.lock:
-            self._trigger=self._trigger | TRIGGER_FAN_ON
+            self._trigger=self._trigger | self.TRIGGER_FAN_ON
             self._dirty_trigger=True
 
     def set_fan_off(self):
         with self.lock:
-            self._trigger=self._trigger | TRIGGER_FAN_OFF
+            self._trigger=self._trigger | self.TRIGGER_FAN_OFF
             self._dirty_trigger=True
 
     def set_buzzer_on(self):
         with self.lock:
-            self._trigger=self._trigger | TRIGGER_BUZZER_ON
+            self._trigger=self._trigger | self.TRIGGER_BUZZER_ON
             self._dirty_trigger=True
 
     def set_buzzer_off(self):
         with self.lock:
-            self._trigger=self._trigger | TRIGGER_BUZZER_OFF
+            self._trigger=self._trigger | self.TRIGGER_BUZZER_OFF
             self._dirty_trigger=True
 
     def board_reset(self):
         with self.lock:
-            self._trigger=self._trigger | TRIGGER_BOARD_RESET
+            self._trigger=self._trigger | self.TRIGGER_BOARD_RESET
             self._dirty_trigger=True
 
     def cliff_event_reset(self):
         with self.lock:
-            self._trigger=self._trigger | TRIGGER_CLIFF_EVENT_RESET
+            self._trigger=self._trigger | self.TRIGGER_CLIFF_EVENT_RESET
             self._dirty_trigger=True
 
     # ########### Sensor Calibration #################
@@ -348,42 +331,6 @@ class Pimu(Device):
             self.board_info['firmware_version'] = unpack_string_t(s[sidx:], 20)
             self.board_info['protocol_version'] = self.board_info['firmware_version'][self.board_info['firmware_version'].rfind('p'):]
             sidx += 20
-            return sidx
-
-
-    def unpack_status(self,s):
-        with self.lock:
-            sidx=0
-            sidx +=self.imu.unpack_status((s[sidx:]))
-            self.status['voltage']=self.get_voltage(unpack_float_t(s[sidx:]));sidx+=4
-            self.status['current'] = self.get_current(unpack_float_t(s[sidx:]));sidx+=4
-            self.status['temp'] = self.get_temp(unpack_float_t(s[sidx:]));sidx+=4
-
-            for i in range(4):
-                self.status['cliff_range'][i]=unpack_float_t(s[sidx:])
-                sidx+=4
-
-            self.status['state'] = unpack_uint32_t(s[sidx:])
-            sidx += 4
-
-            self.status['at_cliff']=[]
-            self.status['at_cliff'].append((self.status['state'] & STATE_AT_CLIFF_0) != 0)
-            self.status['at_cliff'].append((self.status['state'] & STATE_AT_CLIFF_1) != 0)
-            self.status['at_cliff'].append((self.status['state'] & STATE_AT_CLIFF_2) != 0)
-            self.status['at_cliff'].append((self.status['state'] & STATE_AT_CLIFF_3) != 0)
-            self.status['runstop_event'] = (self.status['state'] & STATE_RUNSTOP_EVENT) != 0
-            self.status['cliff_event'] = (self.status['state'] & STATE_CLIFF_EVENT) != 0
-            self.status['fan_on'] = (self.status['state'] & STATE_FAN_ON) != 0
-            self.status['buzzer_on'] = (self.status['state'] & STATE_BUZZER_ON) != 0
-            self.status['low_voltage_alert'] = (self.status['state'] & STATE_LOW_VOLTAGE_ALERT) != 0
-            self.status['high_current_alert'] = (self.status['state'] & STATE_HIGH_CURRENT_ALERT) != 0
-            self.status['over_tilt_alert'] = (self.status['state'] & STATE_OVER_TILT_ALERT) != 0
-            self.status['timestamp'] = self.timestamp.set(unpack_uint64_t(s[sidx:])); sidx += 8
-            self.imu.status['timestamp'] = self.status['timestamp']
-            timestamp_line_sync = unpack_uint64_t(s[sidx:]); sidx += 8
-            self.status['bump_event_cnt'] = unpack_uint16_t(s[sidx:]);sidx += 2
-            self.status['debug'] = unpack_float_t(s[sidx:]); sidx += 4
-            self.status['cpu_temp']=self.get_cpu_temp()
             return sidx
 
     def pack_config(self,s,sidx):
@@ -426,30 +373,32 @@ class Pimu(Device):
             pack_uint32_t(s,sidx,self._trigger); sidx+=4
             return sidx
 
+    def unpack_status(self,s):
+        pass
     # ################Transport Callbacks #####################
 
     def rpc_motor_sync_reply(self,reply):
-        if reply[0] != RPC_REPLY_MOTOR_SYNC:
+        if reply[0] != self.RPC_REPLY_MOTOR_SYNC:
             self.logger.warning('Error RPC_REPLY_MOTOR_SYNC', reply[0])
 
     def rpc_config_reply(self,reply):
-        if reply[0] != RPC_REPLY_PIMU_CONFIG:
+        if reply[0] != self.RPC_REPLY_PIMU_CONFIG:
             self.logger.warning('Error RPC_REPLY_PIMU_CONFIG', reply[0])
 
     def rpc_board_info_reply(self,reply):
-        if reply[0] == RPC_REPLY_PIMU_BOARD_INFO:
+        if reply[0] == self.RPC_REPLY_PIMU_BOARD_INFO:
             self.unpack_board_info(reply[1:])
         else:
             self.logger.warning('Error RPC_REPLY_PIMU_BOARD_INFO', reply[0])
 
     def rpc_trigger_reply(self,reply):
-        if reply[0] != RPC_REPLY_PIMU_TRIGGER:
+        if reply[0] != self.RPC_REPLY_PIMU_TRIGGER:
             self.logger.warning('Error RPC_REPLY_PIMU_TRIGGER', reply[0])
         else:
             tt=unpack_uint32_t(reply[1:])
 
     def rpc_status_reply(self,reply):
-        if reply[0] == RPC_REPLY_PIMU_STATUS:
+        if reply[0] == self.RPC_REPLY_PIMU_STATUS:
             self.unpack_status(reply[1:])
         else:
             self.logger.warning('Error RPC_REPLY_PIMU_STATUS', reply[0])
@@ -466,9 +415,7 @@ class Pimu(Device):
             cpu_temp=25.0
         return cpu_temp
 
-
-
-    def step_sentry(self):
+    def step_sentry(self,robot=None):
         if self.hw_valid and self.robot_params['robot_sentry']['base_fan_control']:
             #Manage CPU temp using the mobile base fan
             #See https://www.intel.com/content/www/us/en/support/articles/000005946/intel-nuc.html
@@ -488,3 +435,113 @@ class Pimu(Device):
                 self.set_fan_off()
                 self.push_command()
             self.fan_on_last = self.status['fan_on']
+
+
+# ######################## PIMU PROTOCOL PO #################################
+
+class Pimu_Protocol_P0(PimuBase):
+    def unpack_status(self,s):
+        with self.lock:
+            sidx=0
+            sidx +=self.imu.unpack_status((s[sidx:]))
+            self.status['voltage']=self.get_voltage(unpack_float_t(s[sidx:]));sidx+=4
+            self.status['current'] = self.get_current(unpack_float_t(s[sidx:]));sidx+=4
+            self.status['temp'] = self.get_temp(unpack_float_t(s[sidx:]));sidx+=4
+
+            for i in range(4):
+                self.status['cliff_range'][i]=unpack_float_t(s[sidx:])
+                sidx+=4
+
+            self.status['state'] = unpack_uint32_t(s[sidx:])
+            sidx += 4
+
+            self.status['at_cliff']=[]
+            self.status['at_cliff'].append((self.status['state'] & self.STATE_AT_CLIFF_0) != 0)
+            self.status['at_cliff'].append((self.status['state'] & self.STATE_AT_CLIFF_1) != 0)
+            self.status['at_cliff'].append((self.status['state'] & self.STATE_AT_CLIFF_2) != 0)
+            self.status['at_cliff'].append((self.status['state'] & self.STATE_AT_CLIFF_3) != 0)
+            self.status['runstop_event'] = (self.status['state'] & self.STATE_RUNSTOP_EVENT) != 0
+            self.status['cliff_event'] = (self.status['state'] & self.STATE_CLIFF_EVENT) != 0
+            self.status['fan_on'] = (self.status['state'] & self.STATE_FAN_ON) != 0
+            self.status['buzzer_on'] = (self.status['state'] & self.STATE_BUZZER_ON) != 0
+            self.status['low_voltage_alert'] = (self.status['state'] & self.STATE_LOW_VOLTAGE_ALERT) != 0
+            self.status['high_current_alert'] = (self.status['state'] & self.STATE_HIGH_CURRENT_ALERT) != 0
+            self.status['over_tilt_alert'] = (self.status['state'] & self.STATE_OVER_TILT_ALERT) != 0
+            self.status['timestamp'] = self.timestamp.set(unpack_uint32_t(s[sidx:])); sidx += 4
+            self.status['bump_event_cnt'] = unpack_uint16_t(s[sidx:]);sidx += 2
+            self.status['debug'] = unpack_float_t(s[sidx:]); sidx += 4
+            self.status['cpu_temp']=self.get_cpu_temp()
+            return sidx
+
+# ######################## PIMU PROTOCOL P1 #################################
+class Pimu_Protocol_P1(PimuBase):
+    def unpack_status(self,s):
+        with self.lock:
+            sidx=0
+            sidx +=self.imu.unpack_status((s[sidx:]))
+            self.status['voltage']=self.get_voltage(unpack_float_t(s[sidx:]));sidx+=4
+            self.status['current'] = self.get_current(unpack_float_t(s[sidx:]));sidx+=4
+            self.status['temp'] = self.get_temp(unpack_float_t(s[sidx:]));sidx+=4
+
+            for i in range(4):
+                self.status['cliff_range'][i]=unpack_float_t(s[sidx:])
+                sidx+=4
+
+            self.status['state'] = unpack_uint32_t(s[sidx:])
+            sidx += 4
+
+            self.status['at_cliff']=[]
+            self.status['at_cliff'].append((self.status['state'] & PimuBase.STATE_AT_CLIFF_0) != 0)
+            self.status['at_cliff'].append((self.status['state'] & self.STATE_AT_CLIFF_1) != 0)
+            self.status['at_cliff'].append((self.status['state'] & self.STATE_AT_CLIFF_2) != 0)
+            self.status['at_cliff'].append((self.status['state'] & self.STATE_AT_CLIFF_3) != 0)
+            self.status['runstop_event'] = (self.status['state'] & self.STATE_RUNSTOP_EVENT) != 0
+            self.status['cliff_event'] = (self.status['state'] & self.STATE_CLIFF_EVENT) != 0
+            self.status['fan_on'] = (self.status['state'] & self.STATE_FAN_ON) != 0
+            self.status['buzzer_on'] = (self.status['state'] & self.STATE_BUZZER_ON) != 0
+            self.status['low_voltage_alert'] = (self.status['state'] & self.STATE_LOW_VOLTAGE_ALERT) != 0
+            self.status['high_current_alert'] = (self.status['state'] & self.STATE_HIGH_CURRENT_ALERT) != 0
+            self.status['over_tilt_alert'] = (self.status['state'] & self.STATE_OVER_TILT_ALERT) != 0
+
+            self.status['timestamp'] = self.timestamp.set(unpack_uint64_t(s[sidx:])); sidx += 8
+            self.imu.status['timestamp'] = self.status['timestamp']
+            self.status['bump_event_cnt'] = unpack_uint16_t(s[sidx:]);sidx += 2
+            self.status['debug'] = unpack_float_t(s[sidx:]); sidx += 4
+            self.status['cpu_temp']=self.get_cpu_temp()
+            return sidx
+
+# ######################## PIMU #################################
+class Pimu(PimuBase):
+    """
+    API to the Stretch RE1 Power and IMU board (Pimu)
+    """
+    def __init__(self, event_reset=False):
+        PimuBase.__init__(self, event_reset)
+        self.protocol_map = {'p0': Pimu_Protocol_P0, 'p1': Pimu_Protocol_P1}
+
+    def startup(self):
+        """
+        First determine which protocol version the uC firmware is running.
+        Based on that version, replaces PimuBase class inheritance with a inheritance to a child class of PimuBase that supports that protocol
+        """
+        PimuBase.startup(self)
+        if self.hw_valid:
+            if self.board_info['protocol_version'] in self.protocol_map:
+                Pimu.__bases__ = (self.protocol_map[self.board_info['protocol_version']],)
+            else:
+                protocol_msg = """
+                ----------------
+                Firmware protocol mismatch on {0}.
+                Protocol on board is {1}.
+                Valid protocols are: {2}.
+                Disabling device.
+                Please upgrade the firmware and/or version of Stretch Body.
+                ----------------
+                """.format(self.name, self.board_info['protocol_version'], self.protocol_map)
+                self.logger.warning(textwrap.dedent(protocol_msg))
+                self.hw_valid = False
+                self.transport.stop()
+        if self.hw_valid:
+            self.push_command()
+            self.pull_status()
+        return self.hw_valid

--- a/body/stretch_body/pimu.py
+++ b/body/stretch_body/pimu.py
@@ -86,7 +86,7 @@ class IMU(Device):
         print('Pitch (deg)', rad_to_deg(self.status['pitch']))
         print('Heading (deg)', rad_to_deg(self.status['heading']))
         print('Bump', self.status['bump'])
-        print('Timestamp', self.status['timestamp'])
+        print('Timestamp (s)', self.status['timestamp'])
         print('-----------------------')
 
     #Called by transport thread
@@ -111,7 +111,6 @@ class IMU(Device):
         self.status['qy'] = unpack_float_t(s[sidx:]);sidx += 4
         self.status['qz'] = unpack_float_t(s[sidx:]);sidx += 4
         self.status['bump'] = unpack_float_t(s[sidx:]);sidx += 4
-        self.status['timestamp'] = self.timestamp.set(unpack_uint32_t(s[sidx:]));sidx += 4
         return sidx
 
 
@@ -128,7 +127,6 @@ class Pimu(Device):
         self._dirty_trigger = False
         self.frame_id_last = None
         self.frame_id_base = 0
-        self.name = 'hello-pimu'
         self.transport = Transport(usb='/dev/hello-pimu', logger=self.logger)
         self.status = {'voltage': 0, 'current': 0, 'temp': 0,'cpu_temp': 0, 'cliff_range':[0,0,0,0], 'frame_id': 0,
                        'timestamp': 0,'at_cliff':[False,False,False,False], 'runstop_event': False, 'bump_event_cnt': 0,
@@ -235,7 +233,7 @@ class Pimu(Device):
         print('High Current Alert', self.status['high_current_alert'])
         print('Over Tilt Alert',self.status['over_tilt_alert'])
         print('Debug', self.status['debug'])
-        print('Timestamp', self.status['timestamp'])
+        print('Timestamp (s)', self.status['timestamp'])
         print('Read error', self.transport.status['read_error'])
         print('Dropped motor sync',self.status['motor_sync_drop'])
         print('Board version:',self.board_info['board_version'])
@@ -380,7 +378,9 @@ class Pimu(Device):
             self.status['low_voltage_alert'] = (self.status['state'] & STATE_LOW_VOLTAGE_ALERT) != 0
             self.status['high_current_alert'] = (self.status['state'] & STATE_HIGH_CURRENT_ALERT) != 0
             self.status['over_tilt_alert'] = (self.status['state'] & STATE_OVER_TILT_ALERT) != 0
-            self.status['timestamp'] = self.timestamp.set(unpack_uint32_t(s[sidx:])); sidx += 4
+            self.status['timestamp'] = self.timestamp.set(unpack_uint64_t(s[sidx:])); sidx += 8
+            self.imu.status['timestamp'] = self.status['timestamp']
+            timestamp_line_sync = unpack_uint64_t(s[sidx:]); sidx += 8
             self.status['bump_event_cnt'] = unpack_uint16_t(s[sidx:]);sidx += 2
             self.status['debug'] = unpack_float_t(s[sidx:]); sidx += 4
             self.status['cpu_temp']=self.get_cpu_temp()
@@ -417,6 +417,8 @@ class Pimu(Device):
             pack_float_t(s, sidx, self.config['low_voltage_alert']);sidx += 4
             pack_float_t(s, sidx, self.config['high_current_alert']);sidx += 4
             pack_float_t(s, sidx, self.config['over_tilt_alert']); sidx += 4
+            self.config['enable_sync_mode'] = 0 # TODO: hardcoded disabled until implemented
+            pack_uint8_t(s, sidx, self.config['enable_sync_mode']); sidx += 1
             return sidx
 
     def pack_trigger(self,s,sidx):

--- a/body/stretch_body/pimu.py
+++ b/body/stretch_body/pimu.py
@@ -15,7 +15,7 @@ The PIMU is the power and IMU Arduino board in the base
 """
 
 
-class IMU(Device):
+class IMUBase(Device):
     """
     API to the Stretch RE1 IMU found in the base
     """
@@ -56,7 +56,37 @@ class IMU(Device):
         print('Timestamp (s)', self.status['timestamp'])
         print('-----------------------')
 
-    #Called by transport thread
+    def unpack_status(self, s):
+        raise NotImplementedError()
+
+# ######################## IMU PROTOCOL P0 #################################
+class IMU_Protocol_P0(IMUBase):
+    def unpack_status(self, s):
+        # take in an array of bytes
+        # this needs to exactly match the C struct format
+        sidx=0
+        self.status['ax']=  unpack_float_t(s[sidx:]);sidx += 4
+        self.status['ay'] = unpack_float_t(s[sidx:]);sidx += 4
+        self.status['az'] = unpack_float_t(s[sidx:]);sidx += 4
+        self.status['gx'] = unpack_float_t(s[sidx:]);sidx += 4
+        self.status['gy'] = unpack_float_t(s[sidx:]);sidx += 4
+        self.status['gz'] = unpack_float_t(s[sidx:]);sidx += 4
+        self.status['mx'] = unpack_float_t(s[sidx:]);sidx += 4
+        self.status['my'] = unpack_float_t(s[sidx:]);sidx += 4
+        self.status['mz'] = unpack_float_t(s[sidx:]);sidx += 4
+        self.status['roll'] = deg_to_rad(unpack_float_t(s[sidx:]));sidx += 4
+        self.status['pitch'] = deg_to_rad(unpack_float_t(s[sidx:]));sidx += 4
+        self.status['heading'] = deg_to_rad(unpack_float_t(s[sidx:]));sidx += 4
+        self.status['qw'] = unpack_float_t(s[sidx:]);sidx += 4
+        self.status['qx'] = unpack_float_t(s[sidx:]);sidx += 4
+        self.status['qy'] = unpack_float_t(s[sidx:]);sidx += 4
+        self.status['qz'] = unpack_float_t(s[sidx:]);sidx += 4
+        self.status['bump'] = unpack_float_t(s[sidx:]);sidx += 4
+        self.status['timestamp'] = self.timestamp.set(unpack_uint32_t(s[sidx:]));sidx += 4
+        return sidx
+
+# ######################## IMU PROTOCOL P1 #################################
+class IMU_Protocol_P1(IMUBase):
     def unpack_status(self, s):
         # take in an array of bytes
         # this needs to exactly match the C struct format
@@ -80,7 +110,13 @@ class IMU(Device):
         self.status['bump'] = unpack_float_t(s[sidx:]);sidx += 4
         return sidx
 
+# ######################## IMU #################################
+class IMU(IMUBase):
+    def __init__(self):
+        IMUBase.__init__(self)
+        self.supported_protocols = {'p0': IMU_Protocol_P0, 'p1': IMU_Protocol_P1}
 
+# ##################################################################################
 class PimuBase(Device):
     """
     API to the Stretch RE1 Power and IMU board (Pimu)
@@ -374,7 +410,7 @@ class PimuBase(Device):
             return sidx
 
     def unpack_status(self,s):
-        pass
+        raise NotImplementedError()
     # ################Transport Callbacks #####################
 
     def rpc_motor_sync_reply(self,reply):
@@ -528,6 +564,7 @@ class Pimu(PimuBase):
         if self.hw_valid:
             if self.board_info['protocol_version'] in self.supported_protocols:
                 Pimu.__bases__ = (self.supported_protocols[self.board_info['protocol_version']],)
+                self.imu.__bases__= (self.imu.supported_protocols[self.board_info['protocol_version']],)
             else:
                 protocol_msg = """
                 ----------------
@@ -537,7 +574,7 @@ class Pimu(PimuBase):
                 Disabling device.
                 Please upgrade the firmware and/or version of Stretch Body.
                 ----------------
-                """.format(self.name, self.board_info['protocol_version'], self.supported_protocols)
+                """.format(self.name, self.board_info['protocol_version'], self.supported_protocols.keys())
                 self.logger.warning(textwrap.dedent(protocol_msg))
                 self.hw_valid = False
                 self.transport.stop()

--- a/body/stretch_body/pimu.py
+++ b/body/stretch_body/pimu.py
@@ -144,7 +144,7 @@ class Pimu(Device):
             self.cliff_event_reset()
 
         self.board_info = {'board_version': None, 'firmware_version': None, 'protocol_version': None}
-        self.valid_firmware_protocol = 'p0'
+        self.valid_firmware_protocol = 'p1'
         self.hw_valid = False
         self.ts_last_motor_sync=None
         self.ts_last_motor_sync_warn=None

--- a/body/stretch_body/stepper.py
+++ b/body/stretch_body/stepper.py
@@ -753,7 +753,8 @@ class Stepper(StepperBase):
     """
     def __init__(self,usb):
         StepperBase.__init__(self,usb)
-        self.supported_protocols = {'p0': Stepper_Protocol_P0, 'p1': Stepper_Protocol_P1}
+        # Order in descending order so more recent protocols/methods override less recent
+        self.supported_protocols = {'p0': (Stepper_Protocol_P0,), 'p1': (Stepper_Protocol_P1,Stepper_Protocol_P0,)}
 
     def startup(self):
         """
@@ -763,7 +764,7 @@ class Stepper(StepperBase):
         StepperBase.startup(self)
         if self.hw_valid:
             if self.board_info['protocol_version'] in self.supported_protocols:
-                Stepper.__bases__ = (self.supported_protocols[self.board_info['protocol_version']],)
+                Stepper.__bases__ = self.supported_protocols[self.board_info['protocol_version']]
             else:
                 protocol_msg = """
                 ----------------

--- a/body/stretch_body/stepper.py
+++ b/body/stretch_body/stepper.py
@@ -473,7 +473,7 @@ class Stepper(Device):
             return
         #This will take a few seconds. Blocks until complete.
         if len(data)!=16384:
-            self.logger.debug('Bad encoder data')
+            self.logger.warning('Bad encoder data')
         else:
             self.logger.debug('Writing encoder calibration...')
             for p in range(256):
@@ -489,7 +489,7 @@ class Stepper(Device):
                 # self.logger.debug('Sending encoder calibration rpc of size',sidx)
                 self.transport.queue_rpc(sidx, self.rpc_enc_calib_reply)
                 self.transport.step()
-            self.logger.debug('')
+
     def rpc_enc_calib_reply(self,reply):
         if reply[0] != RPC_REPLY_ENC_CALIB:
             self.logger.debug('Error RPC_REPLY_ENC_CALIB', reply[0])

--- a/body/stretch_body/stepper.py
+++ b/body/stretch_body/stepper.py
@@ -216,7 +216,7 @@ class StepperBase(Device):
             if limit_neg!=self.motion_limits[0] or limit_pos!=self.motion_limits[1]:
                 #Push out immediately
                 self.motion_limits=[limit_neg, limit_pos]
-                self.transport.payload_out[0] = RPC_SET_MOTION_LIMITS
+                self.transport.payload_out[0] = self.RPC_SET_MOTION_LIMITS
                 sidx = self.pack_motion_limits(self.transport.payload_out, 1)
                 self.transport.queue_rpc2(sidx, self.rpc_motion_limits_reply)
                 self.transport.step2()

--- a/body/stretch_body/stepper.py
+++ b/body/stretch_body/stepper.py
@@ -94,7 +94,7 @@ class Stepper(Device):
         self._trigger=0
         self._trigger_data=0
         self.load_test_payload = arr.array('B', range(256)) * 4
-        self.valid_firmware_protocol='p0'
+        self.valid_firmware_protocol='p1'
         self.hw_valid=False
         self.gains = self.params['gains'].copy()
 

--- a/body/stretch_body/stepper.py
+++ b/body/stretch_body/stepper.py
@@ -753,7 +753,7 @@ class Stepper(StepperBase):
     """
     def __init__(self,usb):
         StepperBase.__init__(self,usb)
-        self.protocol_map = {'p0': Stepper_Protocol_P0, 'p1': Stepper_Protocol_P1}
+        self.supported_protocols = {'p0': Stepper_Protocol_P0, 'p1': Stepper_Protocol_P1}
 
     def startup(self):
         """
@@ -762,8 +762,8 @@ class Stepper(StepperBase):
         """
         StepperBase.startup(self)
         if self.hw_valid:
-            if self.board_info['protocol_version'] in self.protocol_map:
-                Stepper.__bases__ = (self.protocol_map[self.board_info['protocol_version']],)
+            if self.board_info['protocol_version'] in self.supported_protocols:
+                Stepper.__bases__ = (self.supported_protocols[self.board_info['protocol_version']],)
             else:
                 protocol_msg = """
                 ----------------
@@ -773,7 +773,7 @@ class Stepper(StepperBase):
                 Disabling device.
                 Please upgrade the firmware and/or version of Stretch Body.
                 ----------------
-                """.format(self.name, self.board_info['protocol_version'], self.protocol_map)
+                """.format(self.name, self.board_info['protocol_version'], self.supported_protocols)
                 self.logger.warning(textwrap.dedent(protocol_msg))
                 self.hw_valid = False
                 self.transport.stop()

--- a/body/stretch_body/stepper.py
+++ b/body/stretch_body/stepper.py
@@ -6,69 +6,70 @@ import textwrap
 import threading
 import sys
 
-RPC_SET_COMMAND = 1
-RPC_REPLY_COMMAND = 2
-RPC_GET_STATUS = 3
-RPC_REPLY_STATUS = 4
-RPC_SET_GAINS = 5
-RPC_REPLY_GAINS = 6
-RPC_LOAD_TEST =7
-RPC_REPLY_LOAD_TEST =8
-RPC_SET_TRIGGER = 9
-RPC_REPLY_SET_TRIGGER =10
-RPC_SET_ENC_CALIB =11
-RPC_REPLY_ENC_CALIB =12
-RPC_READ_GAINS_FROM_FLASH =13
-RPC_REPLY_READ_GAINS_FROM_FLASH =14
-RPC_SET_MENU_ON =15
-RPC_REPLY_MENU_ON=16
-RPC_GET_STEPPER_BOARD_INFO =17
-RPC_REPLY_STEPPER_BOARD_INFO =18
-RPC_SET_MOTION_LIMITS=19
-RPC_REPLY_MOTION_LIMITS =20
+# ######################## WACC #################################
 
-MODE_SAFETY=0
-MODE_FREEWHEEL=1
-MODE_HOLD=2
-MODE_POS_PID=3
-MODE_VEL_PID=4
-MODE_POS_TRAJ=5
-MODE_VEL_TRAJ=6
-MODE_CURRENT=7
-MODE_POS_TRAJ_INCR=8
-
-DIAG_POS_CALIBRATED =1         #Has a pos zero RPC been recieved since powerup
-DIAG_RUNSTOP_ON =2             #Is controller in runstop mode
-DIAG_NEAR_POS_SETPOINT =4      #Is pos controller within gains.pAs_d of setpoint
-DIAG_NEAR_VEL_SETPOINT =8     #Is vel controller within gains.vAs_d of setpoint
-DIAG_IS_MOVING =16             #Is measured velocity greater than gains.vAs_d
-DIAG_AT_CURRENT_LIMIT =32      #Is controller current saturated
-DIAG_IS_MG_ACCELERATING =64   #Is controler motion generator acceleration non-zero
-DIAG_IS_MG_MOVING =128         #Is controller motion generator velocity non-zero
-DIAG_CALIBRATION_RCVD = 256     #Is calibration table in flash
-DIAG_IN_GUARDED_EVENT = 512     # Guarded event occured during motion
-DIAG_IN_SAFETY_EVENT = 1024      #Is it forced into safety mode
-DIAG_WAITING_ON_SYNC = 2048     #Command received but no sync yet
-
-CONFIG_SAFETY_HOLD =1           #Hold position in safety mode? Otherwise freewheel
-CONFIG_ENABLE_RUNSTOP =2        #Recognize runstop signal?
-CONFIG_ENABLE_SYNC_MODE =4      #Commands are synchronized from digital trigger
-CONFIG_ENABLE_GUARDED_MODE=8    #Stops on current threshold
-CONFIG_FLIP_ENCODER_POLARITY=16
-CONFIG_FLIP_EFFORT_POLARITY=32
-
-TRIGGER_MARK_POS = 1
-TRIGGER_RESET_MOTION_GEN = 2
-TRIGGER_BOARD_RESET = 4
-TRIGGER_WRITE_GAINS_TO_FLASH = 8
-TRIGGER_RESET_POS_CALIBRATED = 16
-TRIGGER_POS_CALIBRATED = 32
-
-
-class Stepper(Device):
+class StepperBase(Device):
     """
     API to the Stretch RE1 stepper board
     """
+    RPC_SET_COMMAND = 1
+    RPC_REPLY_COMMAND = 2
+    RPC_GET_STATUS = 3
+    RPC_REPLY_STATUS = 4
+    RPC_SET_GAINS = 5
+    RPC_REPLY_GAINS = 6
+    RPC_LOAD_TEST = 7
+    RPC_REPLY_LOAD_TEST = 8
+    RPC_SET_TRIGGER = 9
+    RPC_REPLY_SET_TRIGGER = 10
+    RPC_SET_ENC_CALIB = 11
+    RPC_REPLY_ENC_CALIB = 12
+    RPC_READ_GAINS_FROM_FLASH = 13
+    RPC_REPLY_READ_GAINS_FROM_FLASH = 14
+    RPC_SET_MENU_ON = 15
+    RPC_REPLY_MENU_ON = 16
+    RPC_GET_STEPPER_BOARD_INFO = 17
+    RPC_REPLY_STEPPER_BOARD_INFO = 18
+    RPC_SET_MOTION_LIMITS = 19
+    RPC_REPLY_MOTION_LIMITS = 20
+
+    MODE_SAFETY = 0
+    MODE_FREEWHEEL = 1
+    MODE_HOLD = 2
+    MODE_POS_PID = 3
+    MODE_VEL_PID = 4
+    MODE_POS_TRAJ = 5
+    MODE_VEL_TRAJ = 6
+    MODE_CURRENT = 7
+    MODE_POS_TRAJ_INCR = 8
+
+    DIAG_POS_CALIBRATED = 1  # Has a pos zero RPC been recieved since powerup
+    DIAG_RUNSTOP_ON = 2  # Is controller in runstop mode
+    DIAG_NEAR_POS_SETPOINT = 4  # Is pos controller within gains.pAs_d of setpoint
+    DIAG_NEAR_VEL_SETPOINT = 8  # Is vel controller within gains.vAs_d of setpoint
+    DIAG_IS_MOVING = 16  # Is measured velocity greater than gains.vAs_d
+    DIAG_AT_CURRENT_LIMIT = 32  # Is controller current saturated
+    DIAG_IS_MG_ACCELERATING = 64  # Is controler motion generator acceleration non-zero
+    DIAG_IS_MG_MOVING = 128  # Is controller motion generator velocity non-zero
+    DIAG_CALIBRATION_RCVD = 256  # Is calibration table in flash
+    DIAG_IN_GUARDED_EVENT = 512  # Guarded event occured during motion
+    DIAG_IN_SAFETY_EVENT = 1024  # Is it forced into safety mode
+    DIAG_WAITING_ON_SYNC = 2048  # Command received but no sync yet
+
+    CONFIG_SAFETY_HOLD = 1  # Hold position in safety mode? Otherwise freewheel
+    CONFIG_ENABLE_RUNSTOP = 2  # Recognize runstop signal?
+    CONFIG_ENABLE_SYNC_MODE = 4  # Commands are synchronized from digital trigger
+    CONFIG_ENABLE_GUARDED_MODE = 8  # Stops on current threshold
+    CONFIG_FLIP_ENCODER_POLARITY = 16
+    CONFIG_FLIP_EFFORT_POLARITY = 32
+
+    TRIGGER_MARK_POS = 1
+    TRIGGER_RESET_MOTION_GEN = 2
+    TRIGGER_BOARD_RESET = 4
+    TRIGGER_WRITE_GAINS_TO_FLASH = 8
+    TRIGGER_RESET_POS_CALIBRATED = 16
+    TRIGGER_POS_CALIBRATED = 32
+
     def __init__(self, usb):
         Device.__init__(self, name=usb[5:])
         self.usb=usb
@@ -80,8 +81,8 @@ class Stepper(Device):
                        'is_moving':0,'is_moving_filtered':0,'at_current_limit':0,'is_mg_accelerating':0,'is_mg_moving':0,'calibration_rcvd': 0,'in_guarded_event':0,
                        'in_safety_event':0,'waiting_on_sync':0}
         self.board_info={'board_version':None, 'firmware_version':None,'protocol_version':None}
-        self.mode_names={MODE_SAFETY:'MODE_SAFETY', MODE_FREEWHEEL:'MODE_FREEWHEEL',MODE_HOLD:'MODE_HOLD',MODE_POS_PID:'MODE_POS_PID',
-                         MODE_VEL_PID:'MODE_VEL_PID',MODE_POS_TRAJ:'MODE_POS_TRAJ',MODE_VEL_TRAJ:'MODE_VEL_TRAJ',MODE_CURRENT:'MODE_CURRENT', MODE_POS_TRAJ_INCR:'MODE_POS_TRAJ_INCR'}
+        self.mode_names={self.MODE_SAFETY:'MODE_SAFETY', self.MODE_FREEWHEEL:'MODE_FREEWHEEL',self.MODE_HOLD:'MODE_HOLD',self.MODE_POS_PID:'MODE_POS_PID',
+                         self.MODE_VEL_PID:'MODE_VEL_PID',self.MODE_POS_TRAJ:'MODE_POS_TRAJ',self.MODE_VEL_TRAJ:'MODE_VEL_TRAJ',self.MODE_CURRENT:'MODE_CURRENT', self.MODE_POS_TRAJ_INCR:'MODE_POS_TRAJ_INCR'}
         self.motion_limits=[0,0]
         self.is_moving_history = [False] * 10
 
@@ -93,41 +94,20 @@ class Stepper(Device):
         self._trigger=0
         self._trigger_data=0
         self.load_test_payload = arr.array('B', range(256)) * 4
-        self.valid_firmware_protocol='p1'
         self.hw_valid=False
         self.gains = self.params['gains'].copy()
 
     # ###########  Device Methods #############
     def startup(self):
         with self.lock:
-            self.hw_valid=self.transport.startup()
+            self.hw_valid = self.transport.startup()
             if self.hw_valid:
-                #Pull board info
-                self.transport.payload_out[0] = RPC_GET_STEPPER_BOARD_INFO
+                # Pull board info
+                self.transport.payload_out[0] = self.RPC_GET_STEPPER_BOARD_INFO
                 self.transport.queue_rpc(1, self.rpc_board_info_reply)
                 self.transport.step(exiting=False)
-                #Check that protocol matches
-                if not(self.valid_firmware_protocol == self.board_info['protocol_version']):
-                    protocol_msg = """
-                    ----------------
-                    Firmware protocol mismatch on {0}.
-                    Protocol on board is {1}.
-                    Valid protocol is: {2}.
-                    Disabling device.
-                    Please upgrade the firmware and/or version of Stretch Body.
-                    ----------------
-                    """.format(self.name, self.board_info['protocol_version'], self.valid_firmware_protocol)
-                    self.logger.warning(textwrap.dedent(protocol_msg))
-                    self.hw_valid=False
-                    self.transport.stop()
-            if self.hw_valid:
-                self.enable_safety()
-                self._dirty_gains = True
-                self.pull_status()
-                self.push_command()
                 return True
             return False
-
 
     #Configure control mode prior to calling this on process shutdown (or default to freewheel)
     def stop(self):
@@ -145,26 +125,26 @@ class Stepper(Device):
             return
         with self.lock:
             if self._dirty_load_test:
-                self.transport.payload_out[0] = RPC_LOAD_TEST
+                self.transport.payload_out[0] = self.RPC_LOAD_TEST
                 self.transport.payload_out[1:] = self.load_test_payload
                 self.transport.queue_rpc2(1024 + 1, self.rpc_load_test_reply)
                 self._dirty_load_test=False
 
             if self._dirty_trigger:
-                self.transport.payload_out[0] = RPC_SET_TRIGGER
+                self.transport.payload_out[0] = self.RPC_SET_TRIGGER
                 sidx = self.pack_trigger(self.transport.payload_out, 1)
                 self.transport.queue_rpc2(sidx, self.rpc_trigger_reply)
                 self._trigger=0
                 self._dirty_trigger = False
 
             if self._dirty_gains:
-                self.transport.payload_out[0] = RPC_SET_GAINS
+                self.transport.payload_out[0] = self.RPC_SET_GAINS
                 sidx = self.pack_gains(self.transport.payload_out, 1)
                 self.transport.queue_rpc2(sidx, self.rpc_gains_reply)
                 self._dirty_gains=False
 
             if self._dirty_command:
-                self.transport.payload_out[0] = RPC_SET_COMMAND
+                self.transport.payload_out[0] = self.RPC_SET_COMMAND
                 sidx = self.pack_command(self.transport.payload_out, 1)
                 self.transport.queue_rpc2(sidx, self.rpc_command_reply)
                 self._dirty_command=False
@@ -176,12 +156,12 @@ class Stepper(Device):
             return
         with self.lock:
             if self._dirty_read_gains_from_flash:
-                self.transport.payload_out[0] = RPC_READ_GAINS_FROM_FLASH
+                self.transport.payload_out[0] = self.RPC_READ_GAINS_FROM_FLASH
                 self.transport.queue_rpc(1, self.rpc_read_gains_from_flash_reply)
                 self._dirty_read_gains_from_flash = False
 
             # Queue Status RPC
-            self.transport.payload_out[0] = RPC_GET_STATUS
+            self.transport.payload_out[0] = self.RPC_GET_STATUS
             sidx = 1
             self.transport.queue_rpc(sidx, self.rpc_status_reply)
             self.transport.step(exiting=exiting)
@@ -252,7 +232,7 @@ class Stepper(Device):
 
     def write_gains_to_flash(self):
         with self.lock:
-            self._trigger = self._trigger | TRIGGER_WRITE_GAINS_TO_FLASH
+            self._trigger = self._trigger | self.TRIGGER_WRITE_GAINS_TO_FLASH
             self._dirty_trigger = True
 
     def read_gains_from_flash(self):
@@ -260,61 +240,61 @@ class Stepper(Device):
 
     def board_reset(self):
         with self.lock:
-            self._trigger = self._trigger | TRIGGER_BOARD_RESET
+            self._trigger = self._trigger | self.TRIGGER_BOARD_RESET
             self._dirty_trigger=True
 
     def mark_position(self,x):
-        if self.status['mode']!=MODE_SAFETY:
+        if self.status['mode']!=self.MODE_SAFETY:
             self.logger.warning('Can not mark position. Must be in MODE_SAFETY for',self.usb)
             return
 
         with self.lock:
             self._trigger_data=x
-            self._trigger = self._trigger | TRIGGER_MARK_POS
+            self._trigger = self._trigger | self.TRIGGER_MARK_POS
             self._dirty_trigger=True
 
     def reset_motion_gen(self):
         with self.lock:
-            self._trigger = self._trigger | TRIGGER_RESET_MOTION_GEN
+            self._trigger = self._trigger | self.TRIGGER_RESET_MOTION_GEN
             self._dirty_trigger = True
 
     def reset_pos_calibrated(self):
         with self.lock:
-            self._trigger = self._trigger | TRIGGER_RESET_POS_CALIBRATED
+            self._trigger = self._trigger | self.TRIGGER_RESET_POS_CALIBRATED
             self._dirty_trigger = True
 
     def set_pos_calibrated(self):
         with self.lock:
-            self._trigger = self._trigger | TRIGGER_POS_CALIBRATED
+            self._trigger = self._trigger | self.TRIGGER_POS_CALIBRATED
             self._dirty_trigger = True
 
     # ###########################################################################
     def enable_safety(self):
-            self.set_command(mode=MODE_SAFETY)
+            self.set_command(mode=self.MODE_SAFETY)
 
     def enable_freewheel(self):
-            self.set_command(mode=MODE_FREEWHEEL)
+            self.set_command(mode=self.MODE_FREEWHEEL)
 
     def enable_hold(self):
-        self.set_command(mode=MODE_HOLD)
+        self.set_command(mode=self.MODE_HOLD)
 
     def enable_vel_pid(self):
-        self.set_command(mode=MODE_VEL_PID, v_des=0)
+        self.set_command(mode=self.MODE_VEL_PID, v_des=0)
 
     def enable_pos_pid(self):
-        self.set_command(mode=MODE_POS_PID, x_des=self.status['pos'])
+        self.set_command(mode=self.MODE_POS_PID, x_des=self.status['pos'])
 
     def enable_vel_traj(self):
-        self.set_command(mode=MODE_VEL_TRAJ, v_des=0)
+        self.set_command(mode=self.MODE_VEL_TRAJ, v_des=0)
 
     def enable_pos_traj(self):
-        self.set_command(mode=MODE_POS_TRAJ, x_des=self.status['pos'])
+        self.set_command(mode=self.MODE_POS_TRAJ, x_des=self.status['pos'])
 
     def enable_pos_traj_incr(self):
-        self.set_command(mode=MODE_POS_TRAJ_INCR, x_des=0)
+        self.set_command(mode=self.MODE_POS_TRAJ_INCR, x_des=0)
 
     def enable_current(self):
-        self.set_command(mode=MODE_CURRENT, i_des=0)
+        self.set_command(mode=self.MODE_CURRENT, i_des=0)
 
     def enable_sync_mode(self):
         self.gains['enable_sync_mode'] = 1
@@ -350,13 +330,13 @@ class Stepper(Device):
 
             if x_des is not None:
                 self._command['x_des'] = x_des
-                if self._command['mode'] == MODE_POS_TRAJ_INCR:
+                if self._command['mode'] == self.MODE_POS_TRAJ_INCR:
                     self._command['incr_trigger'] = (self._command['incr_trigger']+1)%255
 
             if v_des is not None:
                 self._command['v_des'] = v_des
             else:
-                if mode == MODE_VEL_PID or mode == MODE_VEL_TRAJ:
+                if mode == self.MODE_VEL_PID or mode == self.MODE_VEL_TRAJ:
                     self._command['v_des'] = 0
                 else:
                     self._command['v_des'] = self.params['motion']['vel']
@@ -376,7 +356,7 @@ class Stepper(Device):
             else:
                 self._command['i_feedforward'] = 0
 
-            if i_des is not None and mode == MODE_CURRENT:
+            if i_des is not None and mode == self.MODE_CURRENT:
                 self._command['i_feedforward'] =i_des
 
 
@@ -479,7 +459,7 @@ class Stepper(Device):
                 if p%10==0:
                     sys.stdout.write('.')
                     sys.stdout.flush()
-                self.transport.payload_out[0] = RPC_SET_ENC_CALIB
+                self.transport.payload_out[0] = self.RPC_SET_ENC_CALIB
                 self.transport.payload_out[1] = p
                 sidx=2
                 for i in range(64):
@@ -490,7 +470,7 @@ class Stepper(Device):
                 self.transport.step()
 
     def rpc_enc_calib_reply(self,reply):
-        if reply[0] != RPC_REPLY_ENC_CALIB:
+        if reply[0] != self.RPC_REPLY_ENC_CALIB:
             self.logger.debug('Error RPC_REPLY_ENC_CALIB', reply[0])
 
     # ######################Menu Inteface ################################3
@@ -506,7 +486,7 @@ class Stepper(Device):
             return
         with self.lock:
             # Run immediately rather than queue
-            self.transport.payload_out[0] = RPC_SET_MENU_ON
+            self.transport.payload_out[0] = self.RPC_SET_MENU_ON
             self.transport.queue_rpc(1, self.rpc_menu_on_reply)
             self.transport.step()
 
@@ -540,36 +520,6 @@ class Stepper(Device):
             sidx += 20
             return sidx
 
-    def unpack_status(self,s):
-        with self.lock:
-            sidx=0
-            self.status['mode']=unpack_uint8_t(s[sidx:]);sidx+=1
-            self.status['effort'] = unpack_float_t(s[sidx:]);sidx+=4
-            self.status['current']=self.effort_to_current(self.status['effort'])
-            self.status['pos'] = unpack_double_t(s[sidx:]);sidx+=8
-            self.status['vel'] = unpack_float_t(s[sidx:]);sidx+=4
-            self.status['err'] = unpack_float_t(s[sidx:]);sidx += 4
-            self.status['diag'] = unpack_uint32_t(s[sidx:]);sidx += 4
-            self.status['timestamp'] = self.timestamp.set(unpack_uint64_t(s[sidx:]));sidx += 8
-            timestamp_line_sync = unpack_uint64_t(s[sidx:]);sidx += 8
-            self.status['debug'] = unpack_float_t(s[sidx:]);sidx += 4
-            self.status['guarded_event'] = unpack_uint32_t(s[sidx:]);sidx += 4
-            waypoint_setpoint = unpack_float_t(s[sidx:]);sidx += 4
-            self.status['pos_calibrated'] =self.status['diag'] & DIAG_POS_CALIBRATED > 0
-            self.status['runstop_on'] =self.status['diag'] & DIAG_RUNSTOP_ON > 0
-            self.status['near_pos_setpoint'] =self.status['diag'] & DIAG_NEAR_POS_SETPOINT > 0
-            self.status['near_vel_setpoint'] = self.status['diag'] & DIAG_NEAR_VEL_SETPOINT > 0
-            self.status['is_moving'] =self.status['diag'] & DIAG_IS_MOVING > 0
-            self.status['at_current_limit'] =self.status['diag'] & DIAG_AT_CURRENT_LIMIT > 0
-            self.status['is_mg_accelerating'] = self.status['diag'] & DIAG_IS_MG_ACCELERATING > 0
-            self.status['is_mg_moving'] =self.status['diag'] & DIAG_IS_MG_MOVING > 0
-            self.status['calibration_rcvd'] = self.status['diag'] & DIAG_CALIBRATION_RCVD > 0
-            self.status['in_guarded_event'] = self.status['diag'] & DIAG_IN_GUARDED_EVENT > 0
-            self.status['in_safety_event'] = self.status['diag'] & DIAG_IN_SAFETY_EVENT > 0
-            self.status['waiting_on_sync'] = self.status['diag'] & DIAG_WAITING_ON_SYNC > 0
-            return sidx
-
-
     def unpack_gains(self,s):
         with self.lock:
             sidx=0
@@ -594,12 +544,12 @@ class Stepper(Device):
             self.gains['safety_stiffness'] = unpack_float_t(s[sidx:]);sidx += 4
             self.gains['i_safety_feedforward'] = unpack_float_t(s[sidx:]);sidx += 4
             config = unpack_uint8_t(s[sidx:]);sidx += 1
-            self.gains['safety_hold']= int(config & CONFIG_SAFETY_HOLD>0)
-            self.gains['enable_runstop'] = int(config & CONFIG_ENABLE_RUNSTOP>0)
-            self.gains['enable_sync_mode'] = int(config & CONFIG_ENABLE_SYNC_MODE>0)
-            self.gains['enable_guarded_mode'] = int(config & CONFIG_ENABLE_GUARDED_MODE > 0)
-            self.gains['flip_encoder_polarity'] = int(config & CONFIG_FLIP_ENCODER_POLARITY > 0)
-            self.gains['flip_effort_polarity'] = int(config & CONFIG_FLIP_EFFORT_POLARITY > 0)
+            self.gains['safety_hold']= int(config & self.CONFIG_SAFETY_HOLD>0)
+            self.gains['enable_runstop'] = int(config & self.CONFIG_ENABLE_RUNSTOP>0)
+            self.gains['enable_sync_mode'] = int(config & self.CONFIG_ENABLE_SYNC_MODE>0)
+            self.gains['enable_guarded_mode'] = int(config & self.CONFIG_ENABLE_GUARDED_MODE > 0)
+            self.gains['flip_encoder_polarity'] = int(config & self.CONFIG_FLIP_ENCODER_POLARITY > 0)
+            self.gains['flip_effort_polarity'] = int(config & self.CONFIG_FLIP_EFFORT_POLARITY > 0)
             return sidx
 
     def pack_motion_limits(self,s,sidx):
@@ -656,18 +606,18 @@ class Stepper(Device):
             pack_float_t(s, sidx, self.gains['i_safety_feedforward']);sidx += 4
             config=0
             if self.gains['safety_hold']:
-                config=config | CONFIG_SAFETY_HOLD
+                config=config | self.CONFIG_SAFETY_HOLD
             if self.gains['enable_runstop']:
-                config=config | CONFIG_ENABLE_RUNSTOP
+                config=config | self.CONFIG_ENABLE_RUNSTOP
             self.gains['enable_sync_mode'] = 0 # TODO: hardcoded disabled until fixed
             if self.gains['enable_sync_mode']:
-                config=config | CONFIG_ENABLE_SYNC_MODE
+                config=config | self.CONFIG_ENABLE_SYNC_MODE
             if self.gains['enable_guarded_mode']:
-                config=config | CONFIG_ENABLE_GUARDED_MODE
+                config=config | self.CONFIG_ENABLE_GUARDED_MODE
             if self.gains['flip_encoder_polarity']:
-                config = config | CONFIG_FLIP_ENCODER_POLARITY
+                config = config | self.CONFIG_FLIP_ENCODER_POLARITY
             if self.gains['flip_effort_polarity']:
-                config = config | CONFIG_FLIP_EFFORT_POLARITY
+                config = config | self.CONFIG_FLIP_EFFORT_POLARITY
 
             pack_uint8_t(s, sidx, config); sidx += 1
             return sidx
@@ -680,8 +630,11 @@ class Stepper(Device):
             sidx += 4
             return sidx
 
+    def unpack_status(self,s):
+        pass
+
     def rpc_load_test_reply(self, reply):
-        if reply[0] == RPC_REPLY_LOAD_TEST:
+        if reply[0] == self.RPC_REPLY_LOAD_TEST:
             d = reply[1:]
             for i in range(1024):
                 if d[i] != self.load_test_payload[(i + 1) % 1024]:
@@ -691,39 +644,144 @@ class Stepper(Device):
             print('Error RPC_REPLY_LOAD_TEST', reply[0])
 
     def rpc_board_info_reply(self, reply):
-        if reply[0] == RPC_REPLY_STEPPER_BOARD_INFO:
+        if reply[0] == self.RPC_REPLY_STEPPER_BOARD_INFO:
             self.unpack_board_info(reply[1:])
         else:
             print('Error RPC_REPLY_STEPPER_BOARD_INFO', reply[0])
 
     def rpc_gains_reply(self, reply):
-        if reply[0] != RPC_REPLY_GAINS:
+        if reply[0] != self.RPC_REPLY_GAINS:
             print('Error RPC_REPLY_GAINS', reply[0])
 
     def rpc_trigger_reply(self, reply):
-        if reply[0] != RPC_REPLY_SET_TRIGGER:
+        if reply[0] != self.RPC_REPLY_SET_TRIGGER:
             print('Error RPC_REPLY_SET_TRIGGER', reply[0])
 
     def rpc_command_reply(self, reply):
-        if reply[0] != RPC_REPLY_COMMAND:
+        if reply[0] != self.RPC_REPLY_COMMAND:
             print('Error RPC_REPLY_COMMAND', reply[0])
 
     def rpc_motion_limits_reply(self, reply):
-        if reply[0] != RPC_REPLY_MOTION_LIMITS:
+        if reply[0] != self.RPC_REPLY_MOTION_LIMITS:
             print('Error RPC_REPLY_MOTION_LIMITS', reply[0])
 
     def rpc_menu_on_reply(self, reply):
-        if reply[0] != RPC_REPLY_MENU_ON:
+        if reply[0] != self.RPC_REPLY_MENU_ON:
             print('Error RPC_REPLY_MENU_ON', reply[0])
 
     def rpc_status_reply(self, reply):
-        if reply[0] == RPC_REPLY_STATUS:
+        if reply[0] == self.RPC_REPLY_STATUS:
             nr = self.unpack_status(reply[1:])
         else:
             print('Error RPC_REPLY_STATUS', reply[0])
 
     def rpc_read_gains_from_flash_reply(self, reply):
-        if reply[0] == RPC_REPLY_READ_GAINS_FROM_FLASH:
+        if reply[0] == self.RPC_REPLY_READ_GAINS_FROM_FLASH:
             nr = self.unpack_gains(reply[1:])
         else:
             print('Error RPC_REPLY_READ_GAINS_FROM_FLASH', reply[0])
+
+# ######################## STEPPER PROTOCOL PO #################################
+
+class Stepper_Protocol_P0(StepperBase):
+    def unpack_status(self,s):
+        with self.lock:
+            sidx=0
+            self.status['mode']=unpack_uint8_t(s[sidx:]);sidx+=1
+            self.status['effort'] = unpack_float_t(s[sidx:]);sidx+=4
+            self.status['current']=self.effort_to_current(self.status['effort'])
+            self.status['pos'] = unpack_double_t(s[sidx:]);sidx+=8
+            self.status['vel'] = unpack_float_t(s[sidx:]);sidx+=4
+            self.status['err'] = unpack_float_t(s[sidx:]);sidx += 4
+            self.status['diag'] = unpack_uint32_t(s[sidx:]);sidx += 4
+            self.status['timestamp'] = self.timestamp.set(unpack_uint32_t(s[sidx:]));sidx += 4
+            self.status['debug'] = unpack_float_t(s[sidx:]);sidx += 4
+            self.status['guarded_event'] = unpack_uint32_t(s[sidx:]);sidx += 4
+
+            self.status['pos_calibrated'] =self.status['diag'] & self.DIAG_POS_CALIBRATED > 0
+            self.status['runstop_on'] =self.status['diag'] & self.DIAG_RUNSTOP_ON > 0
+            self.status['near_pos_setpoint'] =self.status['diag'] & self.DIAG_NEAR_POS_SETPOINT > 0
+            self.status['near_vel_setpoint'] = self.status['diag'] & self.DIAG_NEAR_VEL_SETPOINT > 0
+            self.status['is_moving'] =self.status['diag'] & self.DIAG_IS_MOVING > 0
+            self.status['at_current_limit'] =self.status['diag'] & self.DIAG_AT_CURRENT_LIMIT > 0
+            self.status['is_mg_accelerating'] = self.status['diag'] & self.DIAG_IS_MG_ACCELERATING > 0
+            self.status['is_mg_moving'] =self.status['diag'] & self.DIAG_IS_MG_MOVING > 0
+            self.status['calibration_rcvd'] = self.status['diag'] & self.DIAG_CALIBRATION_RCVD > 0
+            self.status['in_guarded_event'] = self.status['diag'] & self.DIAG_IN_GUARDED_EVENT > 0
+            self.status['in_safety_event'] = self.status['diag'] & self.DIAG_IN_SAFETY_EVENT > 0
+            self.status['waiting_on_sync'] = self.status['diag'] & self.DIAG_WAITING_ON_SYNC > 0
+            return sidx
+
+# ######################## STEPPER PROTOCOL P1 #################################
+class Stepper_Protocol_P1(StepperBase):
+    def unpack_status(self,s):
+        with self.lock:
+            sidx=0
+            self.status['mode']=unpack_uint8_t(s[sidx:]);sidx+=1
+            self.status['effort'] = unpack_float_t(s[sidx:]);sidx+=4
+            self.status['current']=self.effort_to_current(self.status['effort'])
+            self.status['pos'] = unpack_double_t(s[sidx:]);sidx+=8
+            self.status['vel'] = unpack_float_t(s[sidx:]);sidx+=4
+            self.status['err'] = unpack_float_t(s[sidx:]);sidx += 4
+            self.status['diag'] = unpack_uint32_t(s[sidx:]);sidx += 4
+            self.status['timestamp'] = self.timestamp.set(unpack_uint64_t(s[sidx:]));sidx += 8
+            self.status['debug'] = unpack_float_t(s[sidx:]);sidx += 4
+            self.status['guarded_event'] = unpack_uint32_t(s[sidx:]);sidx += 4
+            traj_setpoint = unpack_float_t(s[sidx:]);sidx += 4
+            traj_id = unpack_uint16_t(s[sidx:]);sidx += 2
+
+            self.status['pos_calibrated'] =self.status['diag'] & self.DIAG_POS_CALIBRATED > 0
+            self.status['runstop_on'] =self.status['diag'] & self.DIAG_RUNSTOP_ON > 0
+            self.status['near_pos_setpoint'] =self.status['diag'] & self.DIAG_NEAR_POS_SETPOINT > 0
+            self.status['near_vel_setpoint'] = self.status['diag'] & self.DIAG_NEAR_VEL_SETPOINT > 0
+            self.status['is_moving'] =self.status['diag'] & self.DIAG_IS_MOVING > 0
+            self.status['at_current_limit'] =self.status['diag'] & self.DIAG_AT_CURRENT_LIMIT > 0
+            self.status['is_mg_accelerating'] = self.status['diag'] & self.DIAG_IS_MG_ACCELERATING > 0
+            self.status['is_mg_moving'] =self.status['diag'] & self.DIAG_IS_MG_MOVING > 0
+            self.status['calibration_rcvd'] = self.status['diag'] & self.DIAG_CALIBRATION_RCVD > 0
+            self.status['in_guarded_event'] = self.status['diag'] & self.DIAG_IN_GUARDED_EVENT > 0
+            self.status['in_safety_event'] = self.status['diag'] & self.DIAG_IN_SAFETY_EVENT > 0
+            self.status['waiting_on_sync'] = self.status['diag'] & self.DIAG_WAITING_ON_SYNC > 0
+            return sidx
+
+
+
+# ######################## PIMU #################################
+class Stepper(StepperBase):
+    """
+    API to the Stretch RE1 Power and IMU board (Pimu)
+    """
+    def __init__(self,usb):
+        StepperBase.__init__(self,usb)
+        self.protocol_map = {'p0': Stepper_Protocol_P0, 'p1': Stepper_Protocol_P1}
+
+    def startup(self):
+        """
+        First determine which protocol version the uC firmware is running.
+        Based on that version, replaces PimuBase class inheritance with a inheritance to a child class of PimuBase that supports that protocol
+        """
+        StepperBase.startup(self)
+        if self.hw_valid:
+            if self.board_info['protocol_version'] in self.protocol_map:
+                Stepper.__bases__ = (self.protocol_map[self.board_info['protocol_version']],)
+            else:
+                protocol_msg = """
+                ----------------
+                Firmware protocol mismatch on {0}.
+                Protocol on board is {1}.
+                Valid protocols are: {2}.
+                Disabling device.
+                Please upgrade the firmware and/or version of Stretch Body.
+                ----------------
+                """.format(self.name, self.board_info['protocol_version'], self.protocol_map)
+                self.logger.warning(textwrap.dedent(protocol_msg))
+                self.hw_valid = False
+                self.transport.stop()
+
+        if self.hw_valid:
+            self.enable_safety()
+            self._dirty_gains = True
+            self.pull_status()
+            self.push_command()
+        return self.hw_valid
+

--- a/body/stretch_body/stepper.py
+++ b/body/stretch_body/stepper.py
@@ -631,7 +631,7 @@ class StepperBase(Device):
             return sidx
 
     def unpack_status(self,s):
-        pass
+        raise NotImplementedError()
 
     def rpc_load_test_reply(self, reply):
         if reply[0] == self.RPC_REPLY_LOAD_TEST:
@@ -773,7 +773,7 @@ class Stepper(StepperBase):
                 Disabling device.
                 Please upgrade the firmware and/or version of Stretch Body.
                 ----------------
-                """.format(self.name, self.board_info['protocol_version'], self.supported_protocols)
+                """.format(self.name, self.board_info['protocol_version'], self.supported_protocols.keys())
                 self.logger.warning(textwrap.dedent(protocol_msg))
                 self.hw_valid = False
                 self.transport.stop()

--- a/body/stretch_body/stepper.py
+++ b/body/stretch_body/stepper.py
@@ -609,7 +609,6 @@ class StepperBase(Device):
                 config=config | self.CONFIG_SAFETY_HOLD
             if self.gains['enable_runstop']:
                 config=config | self.CONFIG_ENABLE_RUNSTOP
-            self.gains['enable_sync_mode'] = 0 # TODO: hardcoded disabled until fixed
             if self.gains['enable_sync_mode']:
                 config=config | self.CONFIG_ENABLE_SYNC_MODE
             if self.gains['enable_guarded_mode']:

--- a/body/stretch_body/wacc.py
+++ b/body/stretch_body/wacc.py
@@ -47,7 +47,7 @@ class Wacc(Device):
                        'transport': self.transport.status}
         self.ts_last=None
         self.board_info = {'board_version': None, 'firmware_version': None, 'protocol_version': None}
-        self.valid_firmware_protocol = 'p0'
+        self.valid_firmware_protocol = 'p1'
         self.hw_valid = False
 
     # ###########  Device Methods #############

--- a/body/stretch_body/wacc.py
+++ b/body/stretch_body/wacc.py
@@ -42,7 +42,9 @@ class WaccBase(Device):
         self._dirty_command = False
         self._command = {'d2':0,'d3':0, 'trigger':0}
         self.transport = Transport(usb='/dev/hello-wacc', logger=self.logger)
-        self.status = { 'ax':0,'ay':0,'az':0,'a0':0,'d0':0,'d1':0, 'd2':0,'d3':0,'single_tap_count': 0, 'state':0, 'debug':0,'timestamp': 0,'transport': self.transport.status}
+        self.status = { 'ax':0,'ay':0,'az':0,'a0':0,'d0':0,'d1':0, 'd2':0,'d3':0,'single_tap_count': 0, 'state':0, 'debug':0,
+                       'timestamp': 0,
+                       'transport': self.transport.status}
         self.board_info = {'board_version': None, 'firmware_version': None, 'protocol_version': None}
         self.hw_valid = False
 
@@ -176,7 +178,7 @@ class WaccBase(Device):
             return sidx
 
     def unpack_status(self,s):
-        pass
+        raise NotImplementedError()
     # ################Transport Callbacks #####################
     def rpc_board_info_reply(self,reply):
         if reply[0] == self.RPC_REPLY_WACC_BOARD_INFO:
@@ -273,7 +275,7 @@ class Wacc(WaccBase):
                 Disabling device.
                 Please upgrade the firmware and/or version of Stretch Body.
                 ----------------
-                """.format(self.name, self.board_info['protocol_version'], self.supported_protocols)
+                """.format(self.name, self.board_info['protocol_version'], self.supported_protocols.keys())
                 self.logger.warning(textwrap.dedent(protocol_msg))
                 self.hw_valid = False
                 self.transport.stop()

--- a/body/stretch_body/wacc.py
+++ b/body/stretch_body/wacc.py
@@ -172,9 +172,6 @@ class WaccBase(Device):
             sidx += 1
             pack_float_t(s, sidx, self.config['accel_gravity_scale'])
             sidx += 4
-            self.config['enable_sync_mode'] = 0 # TODO: hardcoded disabled until implemented
-            pack_uint8_t(s, sidx, self.config['enable_sync_mode'])
-            sidx += 1
             return sidx
 
     def unpack_status(self,s):

--- a/body/stretch_body/wacc.py
+++ b/body/stretch_body/wacc.py
@@ -40,12 +40,10 @@ class Wacc(Device):
         self._dirty_config = True #Force push down
         self._dirty_command = False
         self._command = {'d2':0,'d3':0, 'trigger':0}
-        self.name ='hello-wacc'
         self.transport = Transport(usb='/dev/hello-wacc', logger=self.logger)
         self.status = { 'ax':0,'ay':0,'az':0,'a0':0,'d0':0,'d1':0, 'd2':0,'d3':0,'single_tap_count': 0, 'state':0, 'debug':0,
                        'timestamp': 0,
                        'transport': self.transport.status}
-        self.ts_last=None
         self.board_info = {'board_version': None, 'firmware_version': None, 'protocol_version': None}
         self.valid_firmware_protocol = 'p1'
         self.hw_valid = False
@@ -146,7 +144,7 @@ class Wacc(Device):
         print('Single Tap Count', self.status['single_tap_count'])
         print('State ', self.status['state'])
         print('Debug',self.status['debug'])
-        print('Timestamp', self.status['timestamp'])
+        print('Timestamp (s)', self.status['timestamp'])
         print('Board version:', self.board_info['board_version'])
         print('Firmware version:', self.board_info['firmware_version'])
 
@@ -183,7 +181,7 @@ class Wacc(Device):
             self.status['d3'] = unpack_uint8_t(s[sidx:]); sidx += 1
             self.status['single_tap_count'] = unpack_uint32_t(s[sidx:]);sidx += 4
             self.status['state'] = unpack_uint32_t(s[sidx:]); sidx += 4
-            self.status['timestamp'] = self.timestamp.set(unpack_uint32_t(s[sidx:]));sidx += 4
+            self.status['timestamp'] = self.timestamp.set(unpack_uint64_t(s[sidx:]));sidx += 8
             self.status['debug'] = unpack_uint32_t(s[sidx:]);sidx += 4
             return sidx
 
@@ -212,6 +210,9 @@ class Wacc(Device):
             sidx += 1
             pack_float_t(s, sidx, self.config['accel_gravity_scale'])
             sidx += 4
+            self.config['enable_sync_mode'] = 0 # TODO: hardcoded disabled until implemented
+            pack_uint8_t(s, sidx, self.config['enable_sync_mode'])
+            sidx += 1
             return sidx
 
     # ################Transport Callbacks #####################

--- a/body/stretch_body/wacc.py
+++ b/body/stretch_body/wacc.py
@@ -4,20 +4,11 @@ from stretch_body.device import Device
 import threading
 import textwrap
 
-RPC_SET_WACC_CONFIG = 1
-RPC_REPLY_WACC_CONFIG = 2
-RPC_GET_WACC_STATUS = 3
-RPC_REPLY_WACC_STATUS = 4
-RPC_SET_WACC_COMMAND = 5
-RPC_REPLY_WACC_COMMAND = 6
-RPC_GET_WACC_BOARD_INFO =7
-RPC_REPLY_WACC_BOARD_INFO =8
 
-TRIGGER_BOARD_RESET = 1
 
 # ######################## WACC #################################
 
-class Wacc(Device):
+class WaccBase(Device):
     """
     API to the Stretch RE1 wrist+accelerometer (Wacc) board
     The Wacc has:
@@ -30,6 +21,16 @@ class Wacc(Device):
     ext_status_cb: Callback to handle custom status data
     ext_command_cb: Callback to handle custom command data
     """
+    RPC_SET_WACC_CONFIG = 1
+    RPC_REPLY_WACC_CONFIG = 2
+    RPC_GET_WACC_STATUS = 3
+    RPC_REPLY_WACC_STATUS = 4
+    RPC_SET_WACC_COMMAND = 5
+    RPC_REPLY_WACC_COMMAND = 6
+    RPC_GET_WACC_BOARD_INFO = 7
+    RPC_REPLY_WACC_BOARD_INFO = 8
+
+    TRIGGER_BOARD_RESET = 1
 
     def __init__(self, ext_status_cb=None, ext_command_cb=None):
         Device.__init__(self, 'wacc')
@@ -41,45 +42,21 @@ class Wacc(Device):
         self._dirty_command = False
         self._command = {'d2':0,'d3':0, 'trigger':0}
         self.transport = Transport(usb='/dev/hello-wacc', logger=self.logger)
-        self.status = { 'ax':0,'ay':0,'az':0,'a0':0,'d0':0,'d1':0, 'd2':0,'d3':0,'single_tap_count': 0, 'state':0, 'debug':0,
-                       'timestamp': 0,
-                       'transport': self.transport.status}
+        self.status = { 'ax':0,'ay':0,'az':0,'a0':0,'d0':0,'d1':0, 'd2':0,'d3':0,'single_tap_count': 0, 'state':0, 'debug':0,'timestamp': 0,'transport': self.transport.status}
         self.board_info = {'board_version': None, 'firmware_version': None, 'protocol_version': None}
-        self.valid_firmware_protocol = 'p1'
         self.hw_valid = False
 
     # ###########  Device Methods #############
-
     def startup(self):
         with self.lock:
-            self.hw_valid=self.transport.startup()
+            self.hw_valid = self.transport.startup()
             if self.hw_valid:
                 # Pull board info
-                self.transport.payload_out[0] = RPC_GET_WACC_BOARD_INFO
+                self.transport.payload_out[0] = self.RPC_GET_WACC_BOARD_INFO
                 self.transport.queue_rpc(1, self.rpc_board_info_reply)
                 self.transport.step(exiting=False)
-                # Check that protocol matches
-                if not(self.valid_firmware_protocol == self.board_info['protocol_version']):
-                    protocol_msg = """
-                    ----------------
-                    Firmware protocol mismatch on {0}.
-                    Protocol on board is {1}.
-                    Valid protocol is: {2}.
-                    Disabling device.
-                    Please upgrade the firmware and/or version of Stretch Body.
-                    ----------------
-                    """.format(self.name, self.board_info['protocol_version'], self.valid_firmware_protocol)
-                    self.logger.warning(textwrap.dedent(protocol_msg))
-                    self.hw_valid=False
-                    self.transport.stop()
-
-            if self.hw_valid:
-                self.push_command()
-                self.pull_status()
                 return True
             return False
-
-
 
     def stop(self):
         if not self.hw_valid:
@@ -104,12 +81,14 @@ class Wacc(Device):
         self._dirty_command = True
 
     def pull_status(self,exiting=False):
+
         if not self.hw_valid:
             return
         with self.lock:
             # Queue Status RPC
-            self.transport.payload_out[0] = RPC_GET_WACC_STATUS
+            self.transport.payload_out[0] = self.RPC_GET_WACC_STATUS
             sidx = 1
+
             self.transport.queue_rpc(sidx, self.rpc_status_reply)
             self.transport.step(exiting=exiting)
 
@@ -118,13 +97,13 @@ class Wacc(Device):
             return
         with self.lock:
             if self._dirty_config:
-                self.transport.payload_out[0] = RPC_SET_WACC_CONFIG
+                self.transport.payload_out[0] = self.RPC_SET_WACC_CONFIG
                 sidx = self.pack_config(self.transport.payload_out, 1)
                 self.transport.queue_rpc2(sidx, self.rpc_config_reply)
                 self._dirty_config=False
 
             if self._dirty_command:
-                self.transport.payload_out[0] = RPC_SET_WACC_COMMAND
+                self.transport.payload_out[0] = self.RPC_SET_WACC_COMMAND
                 sidx = self.pack_command(self.transport.payload_out, 1)
                 self.transport.queue_rpc2(sidx, self.rpc_command_reply)
                 self._command['trigger'] =0
@@ -151,7 +130,7 @@ class Wacc(Device):
     # ####################### Utility functions ####################################################
     def board_reset(self):
         with self.lock:
-            self._command['trigger']=self._command['trigger']| TRIGGER_BOARD_RESET
+            self._command['trigger']=self._command['trigger']| self.TRIGGER_BOARD_RESET
             self._dirty_command=True
 
     # ################Data Packing #####################
@@ -164,25 +143,6 @@ class Wacc(Device):
             self.board_info['firmware_version'] = unpack_string_t(s[sidx:], 20)
             self.board_info['protocol_version'] = self.board_info['firmware_version'][self.board_info['firmware_version'].rfind('p'):]
             sidx += 20
-            return sidx
-
-    def unpack_status(self,s):
-        with self.lock:
-            sidx=0
-            if self.ext_status_cb is not None:
-                sidx+=self.ext_status_cb(s[sidx:])
-            self.status['ax'] = unpack_float_t(s[sidx:]);sidx+=4
-            self.status['ay'] = unpack_float_t(s[sidx:]);sidx+=4
-            self.status['az'] = unpack_float_t(s[sidx:]);sidx+=4
-            self.status['a0'] = unpack_int16_t(s[sidx:]);sidx+=2
-            self.status['d0'] = unpack_uint8_t(s[sidx:]); sidx += 1
-            self.status['d1'] = unpack_uint8_t(s[sidx:]); sidx += 1
-            self.status['d2'] = unpack_uint8_t(s[sidx:]); sidx += 1
-            self.status['d3'] = unpack_uint8_t(s[sidx:]); sidx += 1
-            self.status['single_tap_count'] = unpack_uint32_t(s[sidx:]);sidx += 4
-            self.status['state'] = unpack_uint32_t(s[sidx:]); sidx += 4
-            self.status['timestamp'] = self.timestamp.set(unpack_uint64_t(s[sidx:]));sidx += 8
-            self.status['debug'] = unpack_uint32_t(s[sidx:]);sidx += 4
             return sidx
 
     def pack_command(self,s,sidx):
@@ -215,30 +175,110 @@ class Wacc(Device):
             sidx += 1
             return sidx
 
+    def unpack_status(self,s):
+        pass
     # ################Transport Callbacks #####################
     def rpc_board_info_reply(self,reply):
-        if reply[0] == RPC_REPLY_WACC_BOARD_INFO:
+        if reply[0] == self.RPC_REPLY_WACC_BOARD_INFO:
             self.unpack_board_info(reply[1:])
         else:
             self.logger.warning('Error RPC_REPLY_WACC_BOARD_INFO', reply[0])
 
     def rpc_command_reply(self,reply):
-        if reply[0] != RPC_REPLY_WACC_COMMAND:
+        if reply[0] != self.RPC_REPLY_WACC_COMMAND:
             self.logger.warning('Error RPC_REPLY_WACC_COMMAND', reply[0])
 
     def rpc_config_reply(self,reply):
-        if reply[0] != RPC_REPLY_WACC_CONFIG:
+        if reply[0] != self.RPC_REPLY_WACC_CONFIG:
             self.logger.warning('Error RPC_REPLY_WACC_CONFIG', reply[0])
 
     def rpc_status_reply(self,reply):
-        if reply[0] == RPC_REPLY_WACC_STATUS:
+        if reply[0] == self.RPC_REPLY_WACC_STATUS:
             self.unpack_status(reply[1:])
         else:
             self.logger.warning('Error RPC_REPLY_WACC_STATUS', reply[0])
 
 
 
+# ######################## Wacc PROTOCOL PO #################################
+
+class Wacc_Protocol_P0(WaccBase):
+    def unpack_status(self,s):
+        with self.lock:
+            sidx=0
+            if self.ext_status_cb is not None:
+                sidx+=self.ext_status_cb(s[sidx:])
+            self.status['ax'] = unpack_float_t(s[sidx:]);sidx+=4
+            self.status['ay'] = unpack_float_t(s[sidx:]);sidx+=4
+            self.status['az'] = unpack_float_t(s[sidx:]);sidx+=4
+
+            self.status['a0'] = unpack_int16_t(s[sidx:]);sidx+=2
+            self.status['d0'] = unpack_uint8_t(s[sidx:]); sidx += 1
+            self.status['d1'] = unpack_uint8_t(s[sidx:]); sidx += 1
+            self.status['d2'] = unpack_uint8_t(s[sidx:]); sidx += 1
+            self.status['d3'] = unpack_uint8_t(s[sidx:]); sidx += 1
+            self.status['single_tap_count'] = unpack_uint32_t(s[sidx:]);sidx += 4
+            self.status['state'] = unpack_uint32_t(s[sidx:]); sidx += 4
+            self.status['timestamp'] = self.timestamp.set(unpack_uint32_t(s[sidx:]));sidx += 4
+            self.status['debug'] = unpack_uint32_t(s[sidx:]);sidx += 4
+            return sidx
+
+# ######################## Wacc PROTOCOL P1 #################################
+class Wacc_Protocol_P1(WaccBase):
+    def unpack_status(self,s):
+        with self.lock:
+            sidx=0
+            if self.ext_status_cb is not None:
+                sidx+=self.ext_status_cb(s[sidx:])
+            self.status['ax'] = unpack_float_t(s[sidx:]);sidx+=4
+            self.status['ay'] = unpack_float_t(s[sidx:]);sidx+=4
+            self.status['az'] = unpack_float_t(s[sidx:]);sidx+=4
+            self.status['a0'] = unpack_int16_t(s[sidx:]);sidx+=2
+            self.status['d0'] = unpack_uint8_t(s[sidx:]); sidx += 1
+            self.status['d1'] = unpack_uint8_t(s[sidx:]); sidx += 1
+            self.status['d2'] = unpack_uint8_t(s[sidx:]); sidx += 1
+            self.status['d3'] = unpack_uint8_t(s[sidx:]); sidx += 1
+            self.status['single_tap_count'] = unpack_uint32_t(s[sidx:]);sidx += 4
+            self.status['state'] = unpack_uint32_t(s[sidx:]); sidx += 4
+            self.status['timestamp'] = self.timestamp.set(unpack_uint64_t(s[sidx:]));sidx += 8
+            self.status['debug'] = unpack_uint32_t(s[sidx:]);sidx += 4
+            return sidx
 
 
 
+# ######################## PIMU #################################
+class Wacc(WaccBase):
+    """
+    API to the Stretch RE1 Power and IMU board (Pimu)
+    """
+    def __init__(self):
+        WaccBase.__init__(self)
+        self.protocol_map = {'p0': Wacc_Protocol_P0, 'p1': Wacc_Protocol_P1}
 
+    def startup(self):
+        """
+        First determine which protocol version the uC firmware is running.
+        Based on that version, replaces PimuBase class inheritance with a inheritance to a child class of PimuBase that supports that protocol
+        """
+        WaccBase.startup(self)
+        if self.hw_valid:
+            if self.board_info['protocol_version'] in self.protocol_map:
+                Wacc.__bases__ = (self.protocol_map[self.board_info['protocol_version']],)
+            else:
+                protocol_msg = """
+                ----------------
+                Firmware protocol mismatch on {0}.
+                Protocol on board is {1}.
+                Valid protocols are: {2}.
+                Disabling device.
+                Please upgrade the firmware and/or version of Stretch Body.
+                ----------------
+                """.format(self.name, self.board_info['protocol_version'], self.protocol_map)
+                self.logger.warning(textwrap.dedent(protocol_msg))
+                self.hw_valid = False
+                self.transport.stop()
+
+        if self.hw_valid:
+            self.push_command()
+            self.pull_status()
+        return self.hw_valid

--- a/body/stretch_body/wacc.py
+++ b/body/stretch_body/wacc.py
@@ -255,7 +255,8 @@ class Wacc(WaccBase):
     """
     def __init__(self):
         WaccBase.__init__(self)
-        self.supported_protocols = {'p0': Wacc_Protocol_P0, 'p1': Wacc_Protocol_P1}
+        #Order in descending order so more recent protocols/methods override less recent
+        self.supported_protocols = {'p0': (Wacc_Protocol_P0,), 'p1': (Wacc_Protocol_P1,Wacc_Protocol_P0,)}
 
     def startup(self):
         """

--- a/body/stretch_body/wacc.py
+++ b/body/stretch_body/wacc.py
@@ -253,7 +253,7 @@ class Wacc(WaccBase):
     """
     def __init__(self):
         WaccBase.__init__(self)
-        self.protocol_map = {'p0': Wacc_Protocol_P0, 'p1': Wacc_Protocol_P1}
+        self.supported_protocols = {'p0': Wacc_Protocol_P0, 'p1': Wacc_Protocol_P1}
 
     def startup(self):
         """
@@ -262,8 +262,8 @@ class Wacc(WaccBase):
         """
         WaccBase.startup(self)
         if self.hw_valid:
-            if self.board_info['protocol_version'] in self.protocol_map:
-                Wacc.__bases__ = (self.protocol_map[self.board_info['protocol_version']],)
+            if self.board_info['protocol_version'] in self.supported_protocols:
+                Wacc.__bases__ = (self.supported_protocols[self.board_info['protocol_version']],)
             else:
                 protocol_msg = """
                 ----------------
@@ -273,7 +273,7 @@ class Wacc(WaccBase):
                 Disabling device.
                 Please upgrade the firmware and/or version of Stretch Body.
                 ----------------
-                """.format(self.name, self.board_info['protocol_version'], self.protocol_map)
+                """.format(self.name, self.board_info['protocol_version'], self.supported_protocols)
                 self.logger.warning(textwrap.dedent(protocol_msg))
                 self.hw_valid = False
                 self.transport.stop()

--- a/body/stretch_body/wacc.py
+++ b/body/stretch_body/wacc.py
@@ -263,7 +263,7 @@ class Wacc(WaccBase):
         WaccBase.startup(self)
         if self.hw_valid:
             if self.board_info['protocol_version'] in self.supported_protocols:
-                Wacc.__bases__ = (self.supported_protocols[self.board_info['protocol_version']],)
+                Wacc.__bases__ = self.supported_protocols[self.board_info['protocol_version']]
             else:
                 protocol_msg = """
                 ----------------

--- a/body/test/test_pimu.py
+++ b/body/test/test_pimu.py
@@ -23,11 +23,44 @@ class TestPimu(unittest.TestCase):
             time.sleep(0.01)
         self.assertTrue(p.status['motor_sync_drop']>75)
 
+    @unittest.skip(reason='Doesnt test anything yet')
     def test_invalid_protocol(self):
         """Simulate an invalid protocol and verify the correct error.
         """
         p = stretch_body.pimu.Pimu()
         p.valid_firmware_protocol = 'p-1' # valid protocols are p0 and up
         self.assertFalse(p.startup())
+
+        p.stop()
+
+    def test_runstop_status(self):
+        """Verify that runstop status doesn't fluctuate
+        """
+        p = stretch_body.pimu.Pimu()
+        p.startup()
+
+        p.runstop_event_reset()
+        p.push_command()
+        time.sleep(1)
+        for _ in range(50):
+            time.sleep(0.1)
+            p.pull_status()
+            self.assertFalse(p.status['runstop_event'])
+
+        p.runstop_event_trigger()
+        p.push_command()
+        time.sleep(1)
+        for _ in range(50):
+            time.sleep(0.1)
+            p.pull_status()
+            self.assertTrue(p.status['runstop_event'])
+
+        p.runstop_event_reset()
+        p.push_command()
+        time.sleep(1)
+        for _ in range(50):
+            time.sleep(0.1)
+            p.pull_status()
+            self.assertFalse(p.status['runstop_event'])
 
         p.stop()

--- a/body/test/test_pimu.py
+++ b/body/test/test_pimu.py
@@ -23,12 +23,11 @@ class TestPimu(unittest.TestCase):
             time.sleep(0.01)
         self.assertTrue(p.status['motor_sync_drop']>75)
 
-    @unittest.skip(reason='Doesnt test anything yet')
     def test_invalid_protocol(self):
-        """Simulate an invalid protocol and verify the correct error.
+        """Simulate an invalid protocol and verify startup fails.
         """
         p = stretch_body.pimu.Pimu()
-        p.valid_firmware_protocol = 'p-1' # valid protocols are p0 and up
+        p.supported_protocols = {'p-1': None} # valid protocols are p0 and up
         self.assertFalse(p.startup())
 
         p.stop()

--- a/body/test/test_steppers.py
+++ b/body/test/test_steppers.py
@@ -4,6 +4,7 @@ stretch_body.robot_params.RobotParams.set_logging_level("DEBUG")
 
 import unittest
 import stretch_body.stepper
+import stretch_body.pimu
 
 import time
 
@@ -25,3 +26,38 @@ class TestSteppers(unittest.TestCase):
                 self.assertFalse(s.status['is_moving_filtered'])
                 time.sleep(0.1)
             s.stop()
+
+    def test_runstop_status(self):
+        """Verify that runstop status doesn't fluctuate
+        """
+        p = stretch_body.pimu.Pimu()
+        p.startup()
+        s = stretch_body.stepper.Stepper('/dev/hello-motor-arm')
+        s.startup()
+
+        p.runstop_event_reset()
+        p.push_command()
+        time.sleep(1)
+        for _ in range(50):
+            time.sleep(0.1)
+            s.pull_status()
+            self.assertFalse(s.status['runstop_on'])
+
+        p.runstop_event_trigger()
+        p.push_command()
+        time.sleep(1)
+        for _ in range(50):
+            time.sleep(0.1)
+            s.pull_status()
+            self.assertTrue(s.status['runstop_on'])
+
+        p.runstop_event_reset()
+        p.push_command()
+        time.sleep(1)
+        for _ in range(50):
+            time.sleep(0.1)
+            s.pull_status()
+            self.assertFalse(s.status['runstop_on'])
+
+        p.stop()
+        s.stop()


### PR DESCRIPTION
This PR enables Stretch Body to communicate with new firmware that includes new functionality (e.g. waypoint trajectories, timestamping). This new firmware changes caller/return structs for some existing RPCs and adds some new RPCs. These new RPC contracts are named P1, whereas the old firmware communicated with protocol 0 (P0).

This PR pulls the pack/unpack methods that differ between P0 and P1 into separate classes. In `stepper.py`, `wacc.py`, and `pimu.py`, there are now `<device>_Protocol_P1` classes that override the differing methods to allow that device to support P0 or P1 (depending on the underlying firmware). This introduces the framework for supporting changes to the firmware via new protocol classes in the future. Finally, this PR adds better error handling to `transport.py`, and unit tests to verify functionality of runstopping.

TODO:
 - ~~Support both P0/P1, depending on what the firmware is using.~~