### PR TITLE
Introduce waypoint trajectory RPCs

### DIFF
--- a/body/stretch_body/arm.py
+++ b/body/stretch_body/arm.py
@@ -282,6 +282,8 @@ class Arm(Device):
             self.logger.warning('Not able to home arm. Hardware not present')
             return
         print('Homing Arm...')
+        prev_guarded_mode = self.motor.gains['enable_guarded_mode']
+        prev_sync_mode = self.motor.gains['enable_sync_mode']
         self.motor.enable_guarded_mode()
         self.motor.disable_sync_mode()
         self.motor.reset_pos_calibrated()
@@ -343,15 +345,16 @@ class Arm(Device):
             time.sleep(2.0)
             print('Arm homing successful')
 
-        #Restore default
-        if not self.motor.gains['enable_guarded_mode']:
+        # Restore previous modes
+        if not prev_guarded_mode:
             self.motor.disable_guarded_mode()
-        if self.motor.gains['enable_sync_mode']:
+        if prev_sync_mode:
             self.motor.enable_sync_mode()
         self.push_command()
 
         if measuring:
             return extension_m
+        return 0.0
 
 
     def step_sentry(self,robot):

--- a/body/stretch_body/hello_utils.py
+++ b/body/stretch_body/hello_utils.py
@@ -242,3 +242,24 @@ def thread_service_shutdown(signum, frame):
     print('Caught signal %d' % signum)
     raise ThreadServiceExit
 
+def evaluate_polynomial_at(poly, t):
+    """Evaluate a quintic polynomial at a given time.
+
+    Parameters
+    ----------
+    poly : List(float)
+        Represents a quintic polynomial as a coefficients array [a0, a1, a2, a3, a4, a5].
+        The polynomial is f(t) = a0 + a1*t + a2*t^2 + a3*t^3 + a4*t^4 + a5*t^5
+    t : float
+        the time in seconds at which to evaluate the polynomial
+
+    Returns
+    -------
+    Tuple(float)
+        array with three elements: evaluated position, velocity, and acceleration.
+    """
+    a = poly
+    pos = a[0] + (a[1]*t) + (a[2]*t**2) + (a[3]*t**3) + (a[4]*t**4) + (a[5]*t**5)
+    vel = a[1] + (2*a[2]*t) + (3*a[3]*t**2) + (4*a[4]*t**3) + (5*a[5]*t**4)
+    accel = (2*a[2]) + (6*a[3]*t) + (12*a[4]*t**2) + (20*a[5]*t**3)
+    return (pos, vel, accel)

--- a/body/stretch_body/lift.py
+++ b/body/stretch_body/lift.py
@@ -293,6 +293,8 @@ class Lift(Device):
             self.logger.warning('Not able to home lift. Hardware not present')
             return
         print('Homing lift...')
+        prev_guarded_mode = self.motor.gains['enable_guarded_mode']
+        prev_sync_mode = self.motor.gains['enable_sync_mode']
         self.motor.enable_guarded_mode()
         self.motor.disable_sync_mode()
         self.motor.reset_pos_calibrated()
@@ -326,10 +328,10 @@ class Lift(Device):
         self.push_command()
         time.sleep(6.0)
 
-        #Restore default
-        if not self.motor.gains['enable_guarded_mode']:
+        # Restore previous modes
+        if not prev_guarded_mode:
             self.motor.disable_guarded_mode()
-        if self.motor.gains['enable_sync_mode']:
+        if prev_sync_mode:
             self.motor.enable_sync_mode()
         self.push_command()
 

--- a/body/stretch_body/stepper.py
+++ b/body/stretch_body/stepper.py
@@ -870,6 +870,9 @@ class Stepper_Protocol_P1(StepperBase):
             six coefficients (a0-a5) fill the first seven elements of the list. A segment ID, always
             2 for the first segment, fills the last element of the list.
         """
+        if first_segment[7]!=2:
+            self.logger.warning('Invalid waypoint segment ID for %s'%self.name)
+            return False
         self.waypoint_traj_segment = first_segment
         with self.lock:
             if self.waypoint_traj_segment is not None:
@@ -897,6 +900,9 @@ class Stepper_Protocol_P1(StepperBase):
             coefficients are calculated to smoothly transition across a spline. The segment ID, always
             1 higher than the prior segment's ID, fills the last element of the list.
         """
+        if next_segment[7]<3:
+            self.logger.warning('Invalid waypoint segment ID for %s' % self.name)
+            return False
         self.waypoint_traj_segment = next_segment
         with self.lock:
             if self.waypoint_traj_segment is not None:

--- a/body/stretch_body/stepper.py
+++ b/body/stretch_body/stepper.py
@@ -375,11 +375,17 @@ class StepperBase(Device):
 
 
     def wait_until_at_setpoint(self,timeout=15.0):
+        """
+        Poll until near setpoint
+        Return True if success
+        Return False if timeout
+        """
         ts = time.time()
         self.pull_status()
         while not self.status['near_pos_setpoint'] and time.time() - ts < timeout:
             time.sleep(0.1)
             self.pull_status()
+        return self.status['near_pos_setpoint']
 
     def current_to_effort(self,i_A):
         mA_per_tick = (3300 / 255) / (10 * 0.1)

--- a/body/stretch_body/stepper.py
+++ b/body/stretch_body/stepper.py
@@ -77,8 +77,8 @@ class StepperBase(Device):
     DIAG_IN_SAFETY_EVENT = 1024  # Is it forced into safety mode
     DIAG_WAITING_ON_SYNC = 2048  # Command received but no sync yet
     DIAG_TRAJ_ACTIVE     = 4096     # Whether a waypoint trajectory is actively executing
-    DIAG_TRAJ_WAITING_ON_SYNC = 8192
-    DIAG_IN_SYNC_MODE=16384
+    DIAG_TRAJ_WAITING_ON_SYNC = 8192 # Currently waiting on a sync signal before starting trajectory
+    DIAG_IN_SYNC_MODE = 16384        # Currently running in sync mode
 
     CONFIG_SAFETY_HOLD = 1  # Hold position in safety mode? Otherwise freewheel
     CONFIG_ENABLE_RUNSTOP = 2  # Recognize runstop signal?
@@ -103,13 +103,13 @@ class StepperBase(Device):
         self.status = {'mode': 0, 'effort': 0, 'current':0,'pos': 0, 'vel': 0, 'err':0,'diag': 0,'timestamp': 0, 'debug':0,'guarded_event':0,
                        'transport': self.transport.status,'pos_calibrated':0,'runstop_on':0,'near_pos_setpoint':0,'near_vel_setpoint':0,
                        'is_moving':0,'is_moving_filtered':0,'at_current_limit':0,'is_mg_accelerating':0,'is_mg_moving':0,'calibration_rcvd': 0,'in_guarded_event':0,
-                       'in_safety_event':0,
+                       'in_safety_event':0,'waiting_on_sync':0,
                        'waypoint_traj':{'state':'idle','setpoint':None, 'segment_id':0,}}
         self.board_info={'board_version':None, 'firmware_version':None,'protocol_version':None}
         self.motion_limits=[0,0]
         self.is_moving_history = [False] * 10
 
-        self.waypoint_traj_segment = [0] * 8
+        self._waypoint_traj_segment = [0] * 8
         self._waypoint_traj_start_success = False
         self._waypoint_traj_set_next_traj_success = False
 
@@ -647,11 +647,8 @@ class StepperBase(Device):
             return sidx
 
     def pack_trajectory_segment(self, s, sidx):
-        with self.lock:
-            for i in range(7):
-                pack_float_t(s, sidx, self.waypoint_traj_segment[i]); sidx += 4
-            pack_uint8_t(s, sidx, self.waypoint_traj_segment[7]); sidx += 1
-            return sidx
+        raise NotImplementedError('This method not supported for firmware on protocol {0}.'
+            .format(self.board_info['protocol_version']))
 
     def rpc_load_test_reply(self, reply):
         if reply[0] == self.RPC_REPLY_LOAD_TEST:
@@ -759,7 +756,7 @@ class Stepper_Protocol_P0(StepperBase):
         print('Error (deg)', rad_to_deg(self.status['err']))
         print('Debug', self.status['debug'])
         print('Guarded Events:', self.status['guarded_event'])
-        print('Diag', self.status['diag'])
+        print('Diag', format(self.status['diag'], '032b'))
         print('       Position Calibrated:', self.status['pos_calibrated'])
         print('       Runstop on:', self.status['runstop_on'])
         print('       Near Pos Setpoint:', self.status['near_pos_setpoint'])
@@ -833,7 +830,7 @@ class Stepper_Protocol_P1(StepperBase):
         print('Error (deg)', rad_to_deg(self.status['err']))
         print('Debug', self.status['debug'])
         print('Guarded Events:', self.status['guarded_event'])
-        print('Diag', self.status['diag'])
+        print('Diag', format(self.status['diag'], '032b'))
         print('       Position Calibrated:', self.status['pos_calibrated'])
         print('       Runstop on:', self.status['runstop_on'])
         print('       Near Pos Setpoint:', self.status['near_pos_setpoint'])
@@ -861,7 +858,7 @@ class Stepper_Protocol_P1(StepperBase):
 
     def start_waypoint_trajectory(self, first_segment):
         """Starts execution of a waypoint trajectory on hardware
-        Return True if uC successfully initiated a new trajectory
+
         Parameters
         ----------
         first_segment : list
@@ -869,13 +866,21 @@ class Stepper_Protocol_P1(StepperBase):
             The hardware begins executing this first segment of a spline. The segment's duration and
             six coefficients (a0-a5) fill the first seven elements of the list. A segment ID, always
             2 for the first segment, fills the last element of the list.
+
+        Returns
+        -------
+        bool
+            True if uC successfully initiated a new trajectory
         """
-        if first_segment[7]!=2:
-            self.logger.warning('Invalid waypoint segment ID for %s'%self.name)
+        if len(first_segment) != 8:
+            self.logger.warning('Invalid waypoint segment arr length (must be 8) for %s' % self.name)
             return False
-        self.waypoint_traj_segment = first_segment
+        if first_segment[7] != 2:
+            self.logger.warning('Invalid waypoint segment ID for first segment for %s' % self.name)
+            return False
+        self._waypoint_traj_segment = first_segment
         with self.lock:
-            if self.waypoint_traj_segment is not None:
+            if self._waypoint_traj_segment is not None:
                 self.transport.payload_out[0] = self.RPC_START_NEW_TRAJECTORY
                 sidx = self.pack_trajectory_segment(self.transport.payload_out, 1)
                 self.transport.queue_rpc2(sidx, self.rpc_start_new_traj_reply)
@@ -884,13 +889,12 @@ class Stepper_Protocol_P1(StepperBase):
 
     def set_next_trajectory_segment(self, next_segment):
         """Sets the next segment for the hardware to execute
-        Return True if uC successfully queued next trajectory
 
         This method is generally called multiple times while the prior segment is executing. This
         provides the hardware with the next segment to gracefully transition across the entire spline,
         while allowing users to preempt or modify the future trajectory in real time.
 
-        This will return False if there is not already an segment executing on the uC
+        This method will return False if there is not already an segment executing on the uC
 
         Parameters
         ----------
@@ -899,13 +903,21 @@ class Stepper_Protocol_P1(StepperBase):
             Duration and six coefficients fill the first seven elements of the list. Generally, the
             coefficients are calculated to smoothly transition across a spline. The segment ID, always
             1 higher than the prior segment's ID, fills the last element of the list.
+
+        Returns
+        -------
+        bool
+            True if uC successfully queued next trajectory
         """
-        if next_segment[7]<3:
-            self.logger.warning('Invalid waypoint segment ID for %s' % self.name)
+        if len(next_segment) != 8:
+            self.logger.warning('Invalid waypoint segment arr length (must be 8) for %s' % self.name)
             return False
-        self.waypoint_traj_segment = next_segment
+        if next_segment[7] < 3:
+            self.logger.warning('Invalid waypoint segment ID for next segment for %s' % self.name)
+            return False
+        self._waypoint_traj_segment = next_segment
         with self.lock:
-            if self.waypoint_traj_segment is not None:
+            if self._waypoint_traj_segment is not None:
                 self.transport.payload_out[0] = self.RPC_SET_NEXT_TRAJECTORY_SEG
                 sidx = self.pack_trajectory_segment(self.transport.payload_out, 1)
                 self.transport.queue_rpc2(sidx, self.rpc_set_next_traj_seg_reply)
@@ -919,6 +931,13 @@ class Stepper_Protocol_P1(StepperBase):
             self.transport.payload_out[0] = self.RPC_RESET_TRAJECTORY
             self.transport.queue_rpc2(1, self.rpc_reset_traj_reply)
             self.transport.step2()
+
+    def pack_trajectory_segment(self, s, sidx):
+        with self.lock:
+            for i in range(7):
+                pack_float_t(s, sidx, self._waypoint_traj_segment[i]); sidx += 4
+            pack_uint8_t(s, sidx, self._waypoint_traj_segment[7]); sidx += 1
+            return sidx
 
     def rpc_start_new_traj_reply(self, reply):
         if reply[0] == self.RPC_REPLY_START_NEW_TRAJECTORY:

--- a/body/test/test_collisions.py
+++ b/body/test/test_collisions.py
@@ -1,6 +1,7 @@
 # Logging level must be set before importing any stretch_body class
 import stretch_body.robot_params
 stretch_body.robot_params.RobotParams.set_logging_level("DEBUG")
+
 import stretch_body.hello_utils as hu
 import unittest
 import stretch_body.robot

--- a/body/test/test_dynamixel_hello_XL430.py
+++ b/body/test/test_dynamixel_hello_XL430.py
@@ -292,7 +292,7 @@ class TestDynamixelHelloXL430(unittest.TestCase):
         servo.move_to(0.0)
         time.sleep(5)
 
-        servo.move_to(1.0, v_des=0.0, a_des=0.0)
+        servo.move_to(1.0, v_des=2.0, a_des=2.0)
         move1_vel_ticks = servo.motor.get_profile_velocity()
         move1_accel_ticks = servo.motor.get_profile_acceleration()
         time.sleep(5)

--- a/body/test/test_hello_utils.py
+++ b/body/test/test_hello_utils.py
@@ -175,6 +175,7 @@ class TestHelloUtils(unittest.TestCase):
 
         test_stats.generate_rate_histogram()
 
+    #TODO: Std deviation - use array of values 
     def test_loop_rate_avg(self):
         """Verify that loop rate averages out correctly after few iterations
         """
@@ -296,4 +297,47 @@ class TestHelloUtils(unittest.TestCase):
         # s.generate_rate_histogram()
         self.assertTrue(s.status['missed_loops'] == 0)
 
-    #TODO: Std deviation - use array of values 
+    def test_evaluate_polynomial_at(self):
+        """Verify correctness of the hello_utils evaluate_polynomial_at method
+
+        Spline coefficients calculated in Desmos at:
+        https://www.desmos.com/calculator/atv5ilhodq
+        """
+        # Segment b
+        b_waypoint1 = {'time': 0.0, 'position': 62.425, 'velocity': 0.0, 'acceleration': 0.0}
+        b_waypoint2 = {'time': 3.0, 'position': 52.350, 'velocity': 0.0, 'acceleration': 0.0}
+        b_segment = [62.425, 0, 0, -3.7314815, 1.8657407, -0.2487654]
+
+        pos, vel, accel = stretch_body.hello_utils.evaluate_polynomial_at(b_segment, b_waypoint1['time'] - b_waypoint1['time'])
+        self.assertAlmostEqual(pos, b_waypoint1['position'], places=4)
+        self.assertAlmostEqual(vel, b_waypoint1['velocity'], places=4)
+        self.assertAlmostEqual(accel, b_waypoint1['acceleration'], places=4)
+
+        pos, vel, accel = stretch_body.hello_utils.evaluate_polynomial_at(b_segment, b_waypoint2['time'] - b_waypoint1['time'])
+        self.assertAlmostEqual(pos, b_waypoint2['position'], places=4)
+        self.assertAlmostEqual(vel, b_waypoint2['velocity'], places=4)
+        self.assertAlmostEqual(accel, b_waypoint2['acceleration'], places=4)
+
+        pos, vel, accel = stretch_body.hello_utils.evaluate_polynomial_at(b_segment, 1.3 - b_waypoint1['time'])
+        self.assertAlmostEqual(pos, 58.632, places=3)
+        self.assertNotAlmostEqual(vel, 0.0, places=4)
+        self.assertNotAlmostEqual(accel, 0, places=4)
+
+        # Segment c
+        c_waypoint1 = {'time': 3.0, 'position': 52.350, 'velocity': 0.0, 'acceleration': 0.0}
+        c_waypoint2 = {'time': 6.0, 'position': 62.425, 'velocity': 0.0, 'acceleration': 0.0}
+        c_segment = [52.350, 0, 0, 3.7314815, -1.8657407, 0.2487654]
+        pos, vel, accel = stretch_body.hello_utils.evaluate_polynomial_at(c_segment, c_waypoint1['time'] - c_waypoint1['time'])
+        self.assertAlmostEqual(pos, c_waypoint1['position'], places=4)
+        self.assertAlmostEqual(vel, c_waypoint1['velocity'], places=4)
+        self.assertAlmostEqual(accel, c_waypoint1['acceleration'], places=4)
+
+        pos, vel, accel = stretch_body.hello_utils.evaluate_polynomial_at(c_segment, c_waypoint2['time'] - c_waypoint1['time'])
+        self.assertAlmostEqual(pos, c_waypoint2['position'], places=4)
+        self.assertAlmostEqual(vel, c_waypoint2['velocity'], places=4)
+        self.assertAlmostEqual(accel, c_waypoint2['acceleration'], places=4)
+
+        pos, vel, accel = stretch_body.hello_utils.evaluate_polynomial_at(c_segment, 4.584 - c_waypoint1['time'])
+        self.assertAlmostEqual(pos, 57.915, places=3)
+        self.assertNotAlmostEqual(vel, 0.0, places=4)
+        self.assertNotAlmostEqual(accel, 0, places=4)

--- a/body/test/test_hello_utils.py
+++ b/body/test/test_hello_utils.py
@@ -92,6 +92,7 @@ class TestHelloUtils(unittest.TestCase):
         else:
             self.assertEqual(stretch_body.hello_utils.get_stretch_directory(), "/tmp/")
 
+    @unittest.skip(reason='TODO: cleanup')
     def test_mark_loop_start(self):
         """Verify that loop start time works properly
         """ 
@@ -105,6 +106,7 @@ class TestHelloUtils(unittest.TestCase):
         print("loop start ", test_stats.ts_loop_start, " time ", time_)
         self.assertAlmostEqual(time_, test_stats.ts_loop_start, places = 1)
 
+    @unittest.skip(reason='TODO: cleanup')
     def test_mark_loop_end(self):
         """Verify that mark loop end updates LoopStats correctly
         """
@@ -175,7 +177,8 @@ class TestHelloUtils(unittest.TestCase):
 
         test_stats.generate_rate_histogram()
 
-    #TODO: Std deviation - use array of values 
+    #TODO: Std deviation - use array of values
+    @unittest.skip(reason='TODO: cleanup')
     def test_loop_rate_avg(self):
         """Verify that loop rate averages out correctly after few iterations
         """
@@ -200,7 +203,8 @@ class TestHelloUtils(unittest.TestCase):
 
         #TODO: Add places according to actual numbers generated
         print(" Loop rate average: ", test_stats.status['avg_rate_hz'], " target frequency: ", target_freq)
-        
+
+    @unittest.skip(reason='TODO: cleanup')
     def test_loop_rate_min(self):
         print("Starting test for min loop rate ")
 
@@ -217,6 +221,7 @@ class TestHelloUtils(unittest.TestCase):
         
         self.assertAlmostEqual(test_stats.status['min_rate_hz'], min(loop_rate_target), places = 0)
 
+    @unittest.skip(reason='TODO: cleanup')
     def test_loop_rate_max(self):
         print("Starting test for max loop rate ")
 
@@ -233,6 +238,7 @@ class TestHelloUtils(unittest.TestCase):
 
         self.assertAlmostEqual(test_stats.status['max_rate_hz'], max(loop_rate_target), places=-1)
 
+    @unittest.skip(reason='TODO: cleanup')
     def test_execution_time_ms(self):
         print("Starting test for execution time ms")
 
@@ -283,6 +289,7 @@ class TestHelloUtils(unittest.TestCase):
         #No new warnings
         self.assertEqual(test_stats.status['missed_loops'], len(loop_rate_target_warning))
 
+    @unittest.skip(reason='TODO: cleanup')
     def test_faux_loop(self):
         print('Starting test_faux_loop ')
         target_loop_rate = 25.0

--- a/body/test/test_robot.py
+++ b/body/test/test_robot.py
@@ -97,6 +97,7 @@ class TestRobot(unittest.TestCase):
         r.pull_status()
         time.sleep(1.0)
         self.assertNotAlmostEqual(r.status['arm']['pos'], bad_goal, places=3)
+        r.stop()
 
     def test_dynamixel_runstop(self):
         """Test end_of_arm respects runstop from pimu

--- a/body/test/test_steppers.py
+++ b/body/test/test_steppers.py
@@ -67,6 +67,7 @@ class TestSteppers(unittest.TestCase):
         """
         s = stretch_body.stepper.Stepper('/dev/hello-motor-lift')
         self.assertTrue(s.startup())
+        s.disable_sync_mode()
         limits_rad = (0.0, 115.14478302001953) # lift motor limits
         position_rad = 62.425
         velocity_rad = 9.948
@@ -89,7 +90,7 @@ class TestSteppers(unittest.TestCase):
         time.sleep(7)
 
         s.pull_status()
-        self.assertAlmostEqual(s.status['pos'], position_rad, places=2)
+        self.assertAlmostEqual(s.status['pos'], position_rad, places=1)
 
         s.stop()
 
@@ -218,7 +219,7 @@ class TestSteppers(unittest.TestCase):
         start_time = time.time()
         self.assertTrue(s.start_waypoint_trajectory(first_segment))
 
-        # first segment executing, stop by sending a duration=0 second segment
+        # first segment executing, stop by sending a stop_waypoint_trajectory
         for _ in range(10):
             s.pull_status()
             self.assertEqual(s.status['waypoint_traj']['segment_id'], 2)
@@ -310,7 +311,6 @@ class TestSteppers(unittest.TestCase):
         for _ in range(10):
             s.pull_status()
             self.assertEqual(s.status['waypoint_traj']['segment_id'], 2)
-            print(s.status['waypoint_traj']['segment_id'])
             time.sleep(0.1)
             self.assertTrue(s.set_next_trajectory_segment(second_segment))
             s.pull_status()
@@ -324,7 +324,6 @@ class TestSteppers(unittest.TestCase):
         for _ in range(10):
             s.pull_status()
             self.assertEqual(s.status['waypoint_traj']['segment_id'], 3)
-            print(s.status['waypoint_traj']['segment_id'])
             time.sleep(0.1)
             s.pull_status()
             self.assertLessEqual(s.status['pos'], 62.425 + 1.0)

--- a/body/test/test_steppers.py
+++ b/body/test/test_steppers.py
@@ -12,7 +12,6 @@ import time
 
 class TestSteppers(unittest.TestCase):
 
-
     def test_is_moving_filtered(self):
         """Test that is_moving_filtered is False when no motion
         """
@@ -93,6 +92,172 @@ class TestSteppers(unittest.TestCase):
         self.assertAlmostEqual(s.status['pos'], position_rad, places=2)
 
         s.stop()
+
+    def test_stop_waypoint_trajectory_interface(self):
+        """Verify that waypoint trajectories stop as expected
+        """
+        s = stretch_body.stepper.Stepper('/dev/hello-motor-lift')
+        s.disable_sync_mode()
+        self.assertTrue(s.startup())
+        limits_rad = (0.0, 115.14478302001953)  # lift motor limits
+
+
+        position_rad = 62.425
+        velocity_rad = 9.948
+        acceleration_rad = 15.707
+        stiffness = 1.0
+        i_feedforward = 0.54
+        i_contact_neg = -1.46
+        i_contact_pos = 2.54
+        MODE_POS_TRAJ = 5
+        ################################################################
+        #stop by sending a duration=0 second segment
+        #bring motor to starting position
+        print('Waypoint stop test 1')
+        s.set_command(mode=MODE_POS_TRAJ,
+                      x_des=position_rad,
+                      v_des=velocity_rad,
+                      a_des=acceleration_rad,
+                      stiffness=stiffness,
+                      i_feedforward=i_feedforward,
+                      i_contact_pos=i_contact_pos,
+                      i_contact_neg=i_contact_neg)
+        s.push_command()
+        s.wait_until_at_setpoint()
+        s.pull_status()
+        self.assertAlmostEqual(s.status['pos'], position_rad, places=1)
+
+        # send waypoint trajectory
+        first_segment = [3.0, 62.425, 0, 0, -3.731, 1.866, -0.249, 2]
+        second_segment = [0.0, 52.35, 0, 0, 3.731, -1.866, 0.249, 3] #duration=O marks stop
+        s.enable_pos_traj_waypoint()
+        s.push_command()
+        time.sleep(0.1)
+        start_time = time.time()
+        self.assertTrue(s.start_waypoint_trajectory(first_segment))
+
+        # first segment executing,
+        for _ in range(10):
+            s.pull_status()
+            self.assertEqual(s.status['waypoint_traj']['segment_id'], 2)
+            time.sleep(0.1)
+            self.assertTrue(s.set_next_trajectory_segment(second_segment))
+            s.pull_status()
+            self.assertLessEqual(s.status['pos'], 62.425 + 1.0)
+            self.assertGreaterEqual(s.status['pos'], 52.35 - 1.0)
+            pos, _, _ = evaluate_polynomial_at(first_segment[1:-1], time.time() - start_time)
+            self.assertAlmostEqual(s.status['pos'], pos, places=-1)
+        time.sleep(2)  # let the remainder of the first segment complete
+        s.pull_status()
+        pos, _, _ = evaluate_polynomial_at(first_segment[1:-1], first_segment[0])
+        self.assertAlmostEqual(s.status['pos'], pos, places=1)
+        self.assertEqual(s.status['waypoint_traj']['state'], 'idle')
+
+        # ################################################################
+        # stop by sending only one segment
+        # bring motor to starting position
+        print('Waypoint stop test 2')
+        s.set_command(mode=MODE_POS_TRAJ,
+                      x_des=position_rad,
+                      v_des=velocity_rad,
+                      a_des=acceleration_rad,
+                      stiffness=stiffness,
+                      i_feedforward=i_feedforward,
+                      i_contact_pos=i_contact_pos,
+                      i_contact_neg=i_contact_neg)
+        s.push_command()
+        s.wait_until_at_setpoint()
+        s.pull_status()
+        self.assertAlmostEqual(s.status['pos'], position_rad, places=1)
+
+        # send waypoint trajectory
+        first_segment = [3.0, 62.425, 0, 0, -3.731, 1.866, -0.249, 2]
+        s.enable_pos_traj_waypoint()
+        s.push_command()
+        time.sleep(0.1)
+        start_time = time.time()
+        self.assertTrue(s.start_waypoint_trajectory(first_segment))
+
+        # first segment executing, stop by sending a duration=0 second segment
+        for _ in range(10):
+            s.pull_status()
+            self.assertEqual(s.status['waypoint_traj']['segment_id'], 2)
+            time.sleep(0.1)
+            self.assertLessEqual(s.status['pos'], 62.425 + 1.0)
+            self.assertGreaterEqual(s.status['pos'], 52.35 - 1.0)
+            pos, _, _ = evaluate_polynomial_at(first_segment[1:-1], time.time() - start_time)
+            self.assertAlmostEqual(s.status['pos'], pos, places=-1)
+        time.sleep(2)  # let the remainder of the first segment complete
+        s.pull_status()
+        pos, _, _ = evaluate_polynomial_at(first_segment[1:-1], first_segment[0])
+        self.assertAlmostEqual(s.status['pos'], pos, places=1)
+        self.assertEqual(s.status['waypoint_traj']['state'], 'idle')
+
+        # ################################################################
+        print('Waypoint stop test 3')
+        # stop by terminating directly
+        # bring motor to starting position
+        s.set_command(mode=MODE_POS_TRAJ,
+                      x_des=position_rad,
+                      v_des=velocity_rad,
+                      a_des=acceleration_rad,
+                      stiffness=stiffness,
+                      i_feedforward=i_feedforward,
+                      i_contact_pos=i_contact_pos,
+                      i_contact_neg=i_contact_neg)
+        s.push_command()
+        s.wait_until_at_setpoint()
+        s.pull_status()
+        self.assertAlmostEqual(s.status['pos'], position_rad, places=1)
+        print('Moved to pos')
+        # send waypoint trajectory
+        first_segment = [3.0, 62.425, 0, 0, -3.731, 1.866, -0.249, 2]
+        s.enable_pos_traj_waypoint()
+        s.push_command()
+        time.sleep(0.1)
+        start_time = time.time()
+        self.assertTrue(s.start_waypoint_trajectory(first_segment))
+
+        # first segment executing, stop by sending a duration=0 second segment
+        for _ in range(10):
+            s.pull_status()
+            self.assertEqual(s.status['waypoint_traj']['segment_id'], 2)
+            time.sleep(0.1)
+            self.assertLessEqual(s.status['pos'], 62.425 + 1.0)
+            self.assertGreaterEqual(s.status['pos'], 52.35 - 1.0)
+            pos, _, _ = evaluate_polynomial_at(first_segment[1:-1], time.time() - start_time)
+            self.assertAlmostEqual(s.status['pos'], pos, places=-1)
+        s.stop_waypoint_trajectory() #End prematurely
+        dt=time.time() - start_time
+        s.pull_status()
+        pos, _, _ = evaluate_polynomial_at(first_segment[1:-1], dt)
+        self.assertAlmostEqual(s.status['pos'], pos, delta=1.0)
+        self.assertEqual(s.status['waypoint_traj']['state'], 'idle')
+        s.stop()
+
+
+    def test_malicious_waypoint_trajectory_interface(self):
+        #Send bad values to trajectory interface
+        #Joint should not move
+        s = stretch_body.stepper.Stepper('/dev/hello-motor-lift')
+        s.disable_sync_mode()
+        self.assertTrue(s.startup())
+
+        # send waypoint trajectory
+        first_segment = [3.0, 62.425, 0, 0, -3.731, 1.866, -0.249, 0] #Bad ID
+        second_segment = [3.0, 52.35, 0, 0, 3.731, -1.866, 0.249, 1] #Bad ID
+        s.enable_pos_traj_waypoint()
+        s.push_command()
+        x_start = s.status['pos']
+        self.assertEqual(s.status['waypoint_traj']['state'],'idle')
+        self.assertFalse(s.start_waypoint_trajectory(first_segment))
+        self.assertFalse(s.start_waypoint_trajectory(second_segment))
+        self.assertFalse(s.set_next_trajectory_segment(first_segment))
+        self.assertFalse(s.set_next_trajectory_segment(second_segment))
+        s.pull_status()
+        self.assertAlmostEqual(s.status['pos'], x_start, places=1)
+        self.assertEqual(s.status['waypoint_traj']['state'], 'idle')
+
 
     def test_waypoint_trajectory_interface(self):
         """Verify correct behavior of the waypoint trajectory

--- a/body/test/test_steppers.py
+++ b/body/test/test_steppers.py
@@ -5,6 +5,7 @@ stretch_body.robot_params.RobotParams.set_logging_level("DEBUG")
 import unittest
 import stretch_body.stepper
 import stretch_body.pimu
+from stretch_body.hello_utils import evaluate_polynomial_at
 
 import time
 
@@ -98,8 +99,6 @@ class TestSteppers(unittest.TestCase):
 
         Spline coefficients calculated in Desmos at:
         https://www.desmos.com/calculator/atv5ilhodq
-
-        TODO: Check plotted spline fits ideal spline within certain error
         """
         s = stretch_body.stepper.Stepper('/dev/hello-motor-lift')
         self.assertTrue(s.startup())
@@ -123,11 +122,13 @@ class TestSteppers(unittest.TestCase):
                       i_contact_pos=i_contact_pos,
                       i_contact_neg=i_contact_neg)
         s.push_command()
-        time.sleep(7)
+        s.wait_until_at_setpoint()
         s.pull_status()
-        self.assertAlmostEqual(s.status['pos'], position_rad, places=2)
+        self.assertAlmostEqual(s.status['pos'], position_rad, places=1)
 
         # send waypoint trajectory
+        first_segment = [3.0, 62.425, 0, 0, -3.731, 1.866, -0.249, 2]
+        second_segment = [3.0, 52.35, 0, 0, 3.731, -1.866, 0.249, 3]
         s.enable_pos_traj_waypoint()
         # s.set_command(v_des=velocity_rad,
         #               a_des=acceleration_rad,
@@ -136,26 +137,35 @@ class TestSteppers(unittest.TestCase):
         #               i_contact_neg=i_contact_neg)
         s.push_command()
         time.sleep(0.1)
-        s.start_waypoint_trajectory([3.0, 62.425, 0, 0, -3.731, 1.866, -0.249, 2])
+        start_time = time.time()
+        s.start_waypoint_trajectory(first_segment)
         print(s.waypoint_traj_id)
+
+        # first segment executing
         for _ in range(10):
             # self.assertEqual(s.waypoint_traj_id, 2) # TODO: uC reports 1 unless next seg loaded
             print(s.waypoint_traj_id)
             time.sleep(0.1)
-            s.set_next_trajectory_segment([3.0, 52.35, 0, 0, 3.731, -1.866, 0.249, 3])
+            s.set_next_trajectory_segment(second_segment)
             s.pull_status()
-            self.assertLessEqual(s.status['pos'], 62.425)
-            self.assertGreaterEqual(s.status['pos'], 52.35)
-        time.sleep(2)
+            self.assertLessEqual(s.status['pos'], 62.425 + 1.0)
+            self.assertGreaterEqual(s.status['pos'], 52.35 - 1.0)
+            pos, _, _ = evaluate_polynomial_at(first_segment[1:-1], time.time() - start_time)
+            self.assertAlmostEqual(s.status['pos'], pos, places=-1)
+        time.sleep(2) # let the remainder of the first segment complete
+
+        # second segment executing
         for _ in range(10):
             # self.assertEqual(s.waypoint_traj_id, 3) # TODO: uC doesn't report 3
             print(s.waypoint_traj_id)
             time.sleep(0.1)
             s.pull_status()
-            self.assertLessEqual(s.status['pos'], 62.425)
-            self.assertGreaterEqual(s.status['pos'], 52.35)
-        time.sleep(2)
+            self.assertLessEqual(s.status['pos'], 62.425 + 1.0)
+            self.assertGreaterEqual(s.status['pos'], 52.35 - 1.0)
+            pos, _, _ = evaluate_polynomial_at(second_segment[1:-1], (time.time() - start_time) - 3.0)
+            self.assertAlmostEqual(s.status['pos'], pos, places=-1)
+        time.sleep(2) # let the remainder of the second segment complete
+
         s.pull_status()
         self.assertAlmostEqual(s.status['pos'], position_rad, places=1)
-
         s.stop()

--- a/body/test/test_steppers.py
+++ b/body/test/test_steppers.py
@@ -61,3 +61,101 @@ class TestSteppers(unittest.TestCase):
 
         p.stop()
         s.stop()
+
+    def test_position_trajectory_interface(self):
+        """Verify correct behavior of the position waypoint interface
+        """
+        s = stretch_body.stepper.Stepper('/dev/hello-motor-lift')
+        self.assertTrue(s.startup())
+        limits_rad = (0.0, 115.14478302001953) # lift motor limits
+        position_rad = 62.425
+        velocity_rad = 9.948
+        acceleration_rad = 15.707
+        stiffness = 1.0
+        i_feedforward = 0.54
+        i_contact_neg = -1.46
+        i_contact_pos = 2.54
+        MODE_POS_TRAJ = 5
+
+        s.set_command(mode=MODE_POS_TRAJ,
+                      x_des=position_rad,
+                      v_des=velocity_rad,
+                      a_des=acceleration_rad,
+                      stiffness=stiffness,
+                      i_feedforward=i_feedforward,
+                      i_contact_pos=i_contact_pos,
+                      i_contact_neg=i_contact_neg)
+        s.push_command()
+        time.sleep(7)
+
+        s.pull_status()
+        self.assertAlmostEqual(s.status['pos'], position_rad, places=2)
+
+        s.stop()
+
+    def test_waypoint_trajectory_interface(self):
+        """Verify correct behavior of the waypoint trajectory
+
+        Spline coefficients calculated in Desmos at:
+        https://www.desmos.com/calculator/atv5ilhodq
+
+        TODO: Check plotted spline fits ideal spline within certain error
+        """
+        s = stretch_body.stepper.Stepper('/dev/hello-motor-lift')
+        self.assertTrue(s.startup())
+        limits_rad = (0.0, 115.14478302001953) # lift motor limits
+
+        # bring motor to starting position
+        position_rad = 62.425
+        velocity_rad = 9.948
+        acceleration_rad = 15.707
+        stiffness = 1.0
+        i_feedforward = 0.54
+        i_contact_neg = -1.46
+        i_contact_pos = 2.54
+        MODE_POS_TRAJ = 5
+        s.set_command(mode=MODE_POS_TRAJ,
+                      x_des=position_rad,
+                      v_des=velocity_rad,
+                      a_des=acceleration_rad,
+                      stiffness=stiffness,
+                      i_feedforward=i_feedforward,
+                      i_contact_pos=i_contact_pos,
+                      i_contact_neg=i_contact_neg)
+        s.push_command()
+        time.sleep(7)
+        s.pull_status()
+        self.assertAlmostEqual(s.status['pos'], position_rad, places=2)
+
+        # send waypoint trajectory
+        s.enable_pos_traj_waypoint()
+        # s.set_command(v_des=velocity_rad,
+        #               a_des=acceleration_rad,
+        #               i_feedforward=i_feedforward,
+        #               i_contact_pos=i_contact_pos,
+        #               i_contact_neg=i_contact_neg)
+        s.push_command()
+        time.sleep(0.1)
+        s.start_waypoint_trajectory([3.0, 62.425, 0, 0, -3.731, 1.866, -0.249, 2])
+        print(s.waypoint_traj_id)
+        for _ in range(10):
+            # self.assertEqual(s.waypoint_traj_id, 2) # TODO: uC reports 1 unless next seg loaded
+            print(s.waypoint_traj_id)
+            time.sleep(0.1)
+            s.set_next_trajectory_segment([3.0, 52.35, 0, 0, 3.731, -1.866, 0.249, 3])
+            s.pull_status()
+            self.assertLessEqual(s.status['pos'], 62.425)
+            self.assertGreaterEqual(s.status['pos'], 52.35)
+        time.sleep(2)
+        for _ in range(10):
+            # self.assertEqual(s.waypoint_traj_id, 3) # TODO: uC doesn't report 3
+            print(s.waypoint_traj_id)
+            time.sleep(0.1)
+            s.pull_status()
+            self.assertLessEqual(s.status['pos'], 62.425)
+            self.assertGreaterEqual(s.status['pos'], 52.35)
+        time.sleep(2)
+        s.pull_status()
+        self.assertAlmostEqual(s.status['pos'], position_rad, places=1)
+
+        s.stop()

--- a/body/test/test_sync.py
+++ b/body/test/test_sync.py
@@ -11,47 +11,151 @@ import time
 
 class TestSync(unittest.TestCase):
 
-    def test_motor_sync(self):
-        """Verify that the motor sync enable/disable works as expected
-        """
-        p = stretch_body.pimu.Pimu()
-        p.startup()
+    def test_runstop_sync_disabled(self):
         a = stretch_body.arm.Arm()
-        a.startup()
-
-        #First verify can move w/o sync_mode
+        self.assertTrue(a.startup())
         a.motor.disable_sync_mode()
-        a.move_to(0.1)
         a.push_command()
-        a.motor.wait_until_at_setpoint(timeout=5.0)
-        a.pull_status()
-        self.assertAlmostEqual(a.status['pos'], 0.1, places=1)
 
-        #Now verify in sync mode it doesn't move until the Pimu triggers
-        a.motor.enable_sync_mode()
+        p = stretch_body.pimu.Pimu()
+        self.assertTrue(p.startup())
+
+        # Reset runstop and verify state
+        p.runstop_event_reset()
+        p.push_command()
+        p.pull_status()
+        a.pull_status()
+        self.assertFalse(p.status['runstop_event'])
+        time.sleep(0.1)  # Give time for arm to exit stop
+        self.assertFalse(a.motor.status['runstop_on'])
+        print('Runstop reset done')
+
+        # Should move right away
+        if abs(a.status['pos'] - 0.1) < .01:  # Make a small motion at least if already at 0.1
+            x_target = 0.11
+        else:
+            x_target = 0.1
+        a.move_to(x_target)
         a.push_command()
-        a.move_to(0.05)
-        a.push_command()
-        a.motor.wait_until_at_setpoint(timeout=2.0)
-        a.pull_status()
-        self.assertAlmostEqual(a.status['pos'], 0.1, places=1)
+        self.assertTrue(a.motor.wait_until_at_setpoint(timeout=5.0))
 
-        p.trigger_motor_sync()
-        time.sleep(2.0)
-        a.motor.wait_until_at_setpoint(timeout=2.0)
+        # Trigger runstop
+        p.runstop_event_trigger()
+        p.push_command()
+        p.pull_status()
+        self.assertTrue(p.status['runstop_event'])
+        time.sleep(0.1)  # Give time for arm to enter stop
         a.pull_status()
-        self.assertAlmostEqual(a.status['pos'], 0.05, places=1)
+        self.assertTrue(a.motor.status['runstop_on'])
+        print('Runstop trigger done')
 
-        #Now turn sync mode off and verify that moves still
-        a.motor.disable_sync_mode()
+        # Should not move
         a.move_to(0.15)
         a.push_command()
-        a.motor.wait_until_at_setpoint(timeout=2.0)
+        self.assertFalse(a.motor.wait_until_at_setpoint(timeout=2.0))
         a.pull_status()
-        self.assertAlmostEqual(a.status['pos'], 0.15, places=1)
+        self.assertAlmostEqual(a.status['pos'], x_target, places=2)
+        print('Not move done')
 
-        p.stop()
+        # Reset runstop
+        p.runstop_event_reset()
+        p.push_command()
+        p.pull_status()
+        self.assertFalse(p.status['runstop_event'])
+        time.sleep(0.1)  # Give time for arm to exit stop
+        a.pull_status()
+        self.assertFalse(a.motor.status['runstop_on'])
+        print('Runstop reset done')
+
+        # Should move
+        a.move_to(0.15)
+        a.push_command()
+        self.assertTrue(a.motor.wait_until_at_setpoint(timeout=2.0))
+        print("Move to done")
+
         a.stop()
+        p.stop()
+
+    def test_runstop_sync_enabled(self):
+        """
+        Check that runstop still works when using motor sync enable/disable
+        """
+        a = stretch_body.arm.Arm()
+        self.assertTrue(a.startup())
+        a.motor.enable_sync_mode()
+        a.push_command()
+
+        p = stretch_body.pimu.Pimu()
+        self.assertTrue(p.startup())
+
+        #Reset runstop and verify state
+        p.runstop_event_reset()
+        p.push_command()
+        p.pull_status()
+        a.pull_status()
+        self.assertFalse(p.status['runstop_event'])
+        time.sleep(0.1)  # Give time for arm to exit stop
+        self.assertFalse(a.motor.status['runstop_on'])
+        print('Runstop reset done')
+
+        #Should not move until sync signal is sent
+        if abs(a.status['pos']-0.1)<.01: #Make a small motion at least if already at 0.1
+            x_target=0.11
+        else:
+            x_target=0.1
+        a.move_to(x_target)
+        a.push_command()
+        self.assertFalse(a.motor.wait_until_at_setpoint(timeout=5.0))
+
+
+        #Trigger motion
+        p.trigger_motor_sync()
+        self.assertTrue(a.motor.wait_until_at_setpoint(timeout=2.0))
+        print('Move to done')
+
+        #Trigger runstop
+        p.runstop_event_trigger()
+        p.push_command()
+        p.pull_status()
+        self.assertTrue(p.status['runstop_event'])
+        time.sleep(0.1) #Give time for arm to enter stop
+        a.pull_status()
+        self.assertTrue(a.motor.status['runstop_on'])
+        print('Runstop trigger done')
+
+        #Should not move
+        a.move_to(0.15)
+        a.push_command()
+        p.trigger_motor_sync()
+        self.assertFalse(a.motor.wait_until_at_setpoint(timeout=2.0))
+        a.pull_status()
+        self.assertAlmostEqual(a.status['pos'], x_target, places=2)
+        print('Not move done')
+
+        #Reset runstop
+        p.runstop_event_reset()
+        p.push_command()
+        p.pull_status()
+        self.assertFalse(p.status['runstop_event'])
+        time.sleep(0.1) #Give time for arm to exit stop
+        a.pull_status()
+        self.assertFalse(a.motor.status['runstop_on'])
+        print('Runstop reset done')
+
+        #Should not move as the runstop will have nullifed the last move_to
+        p.trigger_motor_sync()
+        self.assertFalse(a.motor.wait_until_at_setpoint(timeout=2.0))
+        print('Not move done')
+
+        #Should move
+        a.move_to(0.15)
+        a.push_command()
+        p.trigger_motor_sync()
+        self.assertTrue(a.motor.wait_until_at_setpoint(timeout=2.0))
+        print("Move to done")
+
+        a.stop()
+        p.stop()
 
     def test_sync_stream(self):
         """Check that streaming sync pulses to

--- a/body/test/test_sync.py
+++ b/body/test/test_sync.py
@@ -177,3 +177,19 @@ class TestSync(unittest.TestCase):
             #time.sleep(0.01)
         self.assertAlmostEqual(r.arm.status['pos'], 0.3, places=1)
         r.stop()
+
+    def test_sync_when_disabled(self):
+        """Check that sending sync pulse to
+        Stepper in non-sync mode doesnt place in runstop
+        """
+        r = stretch_body.robot.Robot()
+        self.assertTrue(r.startup())
+        r.arm.move_to(0.0)
+        r.push_command()
+        self.assertTrue(r.arm.motor.wait_until_at_setpoint(timeout=5.0))
+        r.arm.motor.disable_sync_mode()
+        r.push_command()
+        r.arm.move_to(0.1)
+        r.push_command()
+        self.assertTrue(r.arm.motor.wait_until_at_setpoint(timeout=5.0))
+        r.stop()

--- a/body/test/test_sync.py
+++ b/body/test/test_sync.py
@@ -11,6 +11,48 @@ import time
 
 class TestSync(unittest.TestCase):
 
+    def test_motor_sync(self):
+        """Verify that the motor sync enable/disable works as expected
+        """
+        p = stretch_body.pimu.Pimu()
+        p.startup()
+        a = stretch_body.arm.Arm()
+        a.startup()
+
+        #First verify can move w/o sync_mode
+        a.motor.disable_sync_mode()
+        a.move_to(0.1)
+        a.push_command()
+        a.motor.wait_until_at_setpoint(timeout=5.0)
+        a.pull_status()
+        self.assertAlmostEqual(a.status['pos'], 0.1, places=1)
+
+        #Now verify in sync mode it doesn't move until the Pimu triggers
+        a.motor.enable_sync_mode()
+        a.push_command()
+        a.move_to(0.05)
+        a.push_command()
+        a.motor.wait_until_at_setpoint(timeout=2.0)
+        a.pull_status()
+        self.assertAlmostEqual(a.status['pos'], 0.1, places=1)
+
+        p.trigger_motor_sync()
+        time.sleep(2.0)
+        a.motor.wait_until_at_setpoint(timeout=2.0)
+        a.pull_status()
+        self.assertAlmostEqual(a.status['pos'], 0.05, places=1)
+
+        #Now turn sync mode off and verify that moves still
+        a.motor.disable_sync_mode()
+        a.move_to(0.15)
+        a.push_command()
+        a.motor.wait_until_at_setpoint(timeout=2.0)
+        a.pull_status()
+        self.assertAlmostEqual(a.status['pos'], 0.15, places=1)
+
+        p.stop()
+        a.stop()
+
     def test_sync_stream(self):
         """Check that streaming sync pulses to
         Stepper doesnt place it in runstop
@@ -31,4 +73,3 @@ class TestSync(unittest.TestCase):
             #time.sleep(0.01)
         self.assertAlmostEqual(r.arm.status['pos'], 0.3, places=1)
         r.stop()
-

--- a/body/test/test_timing_stats.py
+++ b/body/test/test_timing_stats.py
@@ -67,6 +67,7 @@ class TestTimingStats(unittest.TestCase):
         non_dxl_thread.run()
         self.assertAlmostEqual(non_dxl_thread.stats.status['loop_rate_av=g_hz'], target)
 
+    @unittest.skip(reason='Used to measure perf, doesnt test anything')
     def test_stepper_on_status_thread(self):
         class StatusThread(threading.Thread):
             def __init__(self, device, target_rate_hz=15.0):


### PR DESCRIPTION
This PR introduces methods to command the stepper motors into following a waypoint trajectory. A "waypoint trajectory" is a spline that a stepper joint attempts to track over time. The joint position spline is defined by an series of waypoints, where each waypoint consists of:

 - time from start of trajectory (seconds)
 - joint position (radians)
 - optional joint velocity (radians/sec)
 - optional joint acceleration (radians/sec^2)

Between two waypoints is a segment of the spline. Given just time/pos, this segment is linear. Adding velocity, it's cubic, and with acceleration, it's quintic. Coefficients representing the segments are sent down to the stepper hardware. With full waypoints, each segment is defined by a quintic polynomial, `f(t) = a0 + a1*t + a2*t^2 + a3*t^3 + a4*t^4 + a5*t^5`; the coefficient array `[a0, a1, a2, a3, a4, a5]` is part of what is sent down to the hardware. A sample trajectory (used in the unit tests) is visualized on [Desmos](https://www.desmos.com/calculator/atv5ilhodq), and used to calculate the coefficient arrays of the segments. 

This PR doesn't manage waypoints or compute segments from waypoints. It exposes an interface to the motors that accept the segments in a way that allows starting of a trajectory and preemption of the trajectory's next segment while a segment is actively being executed. The added methods are:

 1. Start a waypoint trajectory with a segment: `stepper.start_waypoint_trajectory([duration_s, a0, a1, a2, a3, a4, a5, segment_id])`
 2. Set the next segment of the trajectory: `stepper.set_next_trajectory_segment([duration_s, a0, a1, a2, a3, a4, a5, segment_id])`
      - This method is can be called many times in a loop while the previous segment is being executed, if preemption of the next segment is desired.
 3. Stop an active waypoint trajectory immediately: `stepper.stop_waypoint_trajectory()`

The benefit of waypoint trajectories is that the joints can be commanded with planned trajectories that coordinate the whole body of Stretch into performing some coordinated action (e.g. when the arm, lift, and mobile base must arrive to specific positions at specific times in order to perform a grasp).

~~Finally, note that the firmware does not check the "executability" of a given segment. The hardware will attempt to track a given segment, even if it's waypoints form a malformed segment (e.g. exceeding joint limits, exceeding joint dynamics).~~ Firmware checking of segment feasibility is now done in https://github.com/hello-robot/stretch_firmware/pull/6.

---

TODO:
 - ~~Merge in #77~~
 - Use `stepper.set_first_trajectory_segment()` instead
 - ~~Improve how `active_id` is tracked.~~
 - ~~Add firmware checking of segment "executability" and error reporting. Merge in #103~~