### PR TITLE
Validate Waypoint trajectory segments

### DIFF
--- a/body/stretch_body/hello_utils.py
+++ b/body/stretch_body/hello_utils.py
@@ -263,3 +263,34 @@ def evaluate_polynomial_at(poly, t):
     vel = a[1] + (2*a[2]*t) + (3*a[3]*t**2) + (4*a[4]*t**3) + (5*a[5]*t**4)
     accel = (2*a[2]) + (6*a[3]*t) + (12*a[4]*t**2) + (20*a[5]*t**3)
     return (pos, vel, accel)
+
+def is_segment_feasible(segment, v_des, a_des, t=0.0, inc=0.1):
+    """Determine whether a segment adheres to dynamic limits.
+
+    Parameters
+    ----------
+    segment : List
+        Represents a segment of a waypoint trajectory as a list of length eight,
+        structured like [duration_s, a0, a1, a2, a3, a4, a5, segment_id].
+    v_des : float
+        Velocity limit that the segment shouldn't exceed
+    a_des : float
+        Acceleration limit that the segment shouldn't exceed
+    t : float
+        optional, time in seconds at which to begin checking segment
+    inc : float
+        optional, increment in seconds at which the polynomial is evaluated along the segment
+
+    Returns
+    -------
+    bool
+        whether the segment is feasible
+    """
+    while t < segment[0]:
+        _, vel_t, acc_t = evaluate_polynomial_at(segment[1:-1], t)
+        if abs(vel_t) > v_des or abs(acc_t) > a_des:
+            return False
+
+        t = min(segment[0], t + inc)
+
+    return True

--- a/body/stretch_body/stepper.py
+++ b/body/stretch_body/stepper.py
@@ -862,7 +862,7 @@ class Stepper_Protocol_P1(StepperBase):
         print('Firmware version:', self.board_info['firmware_version'])
 
     def enable_pos_traj_waypoint(self):
-        self.set_command(mode=self.MODE_POS_TRAJ_WAYPOINT, x_des=0)
+        self.set_command(mode=self.MODE_POS_TRAJ_WAYPOINT)
 
     def start_waypoint_trajectory(self, first_segment):
         """Starts execution of a waypoint trajectory on hardware

--- a/body/stretch_body/stepper.py
+++ b/body/stretch_body/stepper.py
@@ -881,10 +881,7 @@ class Stepper_Protocol_P1(StepperBase):
             True if uC successfully initiated a new trajectory
         """
         if len(first_segment) != 8:
-            self.logger.warning('Invalid waypoint segment arr length (must be 8) for %s' % self.name)
-            return False
-        if first_segment[7] != 2:
-            self.logger.warning('Invalid waypoint segment ID for first segment for %s' % self.name)
+            self.logger.warning('start_waypoint_trajectory: Invalid waypoint segment arr length (must be 8)')
             return False
         self._waypoint_traj_segment = first_segment
         with self.lock:
@@ -894,7 +891,7 @@ class Stepper_Protocol_P1(StepperBase):
                 self.transport.queue_rpc2(sidx, self.rpc_start_new_traj_reply)
             self.transport.step2()
             if not self._waypoint_traj_start_success:
-                self.logger.warning('%s: %s' % (self.name, self._waypoint_traj_start_error_msg))
+                self.logger.warning('start_waypoint_trajectory: %s' % self._waypoint_traj_start_error_msg.capitalize())
             return self._waypoint_traj_start_success
 
     def set_next_trajectory_segment(self, next_segment):
@@ -920,10 +917,7 @@ class Stepper_Protocol_P1(StepperBase):
             True if uC successfully queued next trajectory
         """
         if len(next_segment) != 8:
-            self.logger.warning('Invalid waypoint segment arr length (must be 8) for %s' % self.name)
-            return False
-        if next_segment[7] < 3:
-            self.logger.warning('Invalid waypoint segment ID for next segment for %s' % self.name)
+            self.logger.warning('set_next_trajectory_segment: Invalid waypoint segment arr length (must be 8)')
             return False
         self._waypoint_traj_segment = next_segment
         with self.lock:
@@ -933,7 +927,7 @@ class Stepper_Protocol_P1(StepperBase):
                 self.transport.queue_rpc2(sidx, self.rpc_set_next_traj_seg_reply)
             self.transport.step2()
             if not self._waypoint_traj_set_next_traj_success:
-                self.logger.warning('%s: %s' % (self.name, self._waypoint_traj_set_next_error_msg))
+                self.logger.warning('set_next_trajectory_segment: %s' % self._waypoint_traj_set_next_error_msg.capitalize())
             return self._waypoint_traj_set_next_traj_success
 
     def stop_waypoint_trajectory(self):

--- a/body/stretch_body/stepper.py
+++ b/body/stretch_body/stepper.py
@@ -112,8 +112,8 @@ class StepperBase(Device):
         self._waypoint_traj_segment = [0] * 8
         self._waypoint_traj_start_success = False
         self._waypoint_traj_set_next_traj_success = False
-        self._waypoint_traj_start_error_msg = None
-        self._waypoint_traj_set_next_error_msg = None
+        self._waypoint_traj_start_error_msg = ""
+        self._waypoint_traj_set_next_error_msg = ""
 
         self._dirty_command = False
         self._dirty_gains = False

--- a/body/stretch_body/stepper.py
+++ b/body/stretch_body/stepper.py
@@ -881,7 +881,7 @@ class Stepper_Protocol_P1(StepperBase):
             True if uC successfully initiated a new trajectory
         """
         if len(first_segment) != 8:
-            self.logger.warning('start_waypoint_trajectory: Invalid waypoint segment arr length (must be 8)')
+            self.logger.warning('start_waypoint_trajectory: Invalid segment arr length (must be 8)')
             return False
         self._waypoint_traj_segment = first_segment
         with self.lock:
@@ -917,7 +917,7 @@ class Stepper_Protocol_P1(StepperBase):
             True if uC successfully queued next trajectory
         """
         if len(next_segment) != 8:
-            self.logger.warning('set_next_trajectory_segment: Invalid waypoint segment arr length (must be 8)')
+            self.logger.warning('set_next_trajectory_segment: Invalid segment arr length (must be 8)')
             return False
         self._waypoint_traj_segment = next_segment
         with self.lock:

--- a/body/test/test_steppers.py
+++ b/body/test/test_steppers.py
@@ -382,7 +382,7 @@ class TestSteppers(unittest.TestCase):
         s.push_command()
         s.start_waypoint_trajectory(first_segment)
         s.pull_status()
-        # self.assertAlmostEqual(s.status['pos'], position_rad, places=1) # TODO: fails on G2, not sure why
+        self.assertAlmostEqual(s.status['pos'], position_rad, places=1)
         s.logger.debug(s.status['waypoint_traj'])
         self.assertEqual(s.status['waypoint_traj']['state'], 'active')
         self.assertEqual(s.status['waypoint_traj']['segment_id'], 2)

--- a/body/test/test_steppers.py
+++ b/body/test/test_steppers.py
@@ -547,7 +547,7 @@ class TestSteppers(unittest.TestCase):
         s.pull_status()
         self.assertAlmostEqual(s.status['pos'], position_rad, places=0)
 
-        # send waypoint trajectory
+        # send waypoint trajectory that we expect to be able to execute
         first_segment = [3.0, 22.425, 0, 0, -3.731, 1.866, -0.249, 2]
         second_segment = [3.0, 12.35, 0, 0, 3.731, -1.866, 0.249, 3]
         s.enable_pos_traj_waypoint()
@@ -562,6 +562,19 @@ class TestSteppers(unittest.TestCase):
         while s.status['waypoint_traj']['state'] == 'active':
             time.sleep(0.1)
             s.pull_status()
+        s.stop_waypoint_trajectory()
+
+        # send waypoint trajectory that we don't expect to be able to execute
+        first_segment = [3.0, 22.425, 0, 0, -3.731, 1.866, -0.249, 2]
+        second_segment = [3.0, 12.35, 0, 0, 3.731, -1.866, 0.249, 3]
+        s.enable_pos_traj_waypoint()
+        velocity_rad = 5.0 # will exceed this bound
+        acceleration_rad = 10.0
+        s.set_command(v_des=velocity_rad,
+                      a_des=acceleration_rad)
+        s.push_command()
+        time.sleep(0.1)
+        self.assertFalse(s.start_waypoint_trajectory(first_segment))
 
         s.pull_status()
         self.assertAlmostEqual(s.status['pos'], position_rad, places=1)

--- a/body/test/test_steppers.py
+++ b/body/test/test_steppers.py
@@ -371,18 +371,19 @@ class TestSteppers(unittest.TestCase):
         self.assertEqual(s.status['waypoint_traj']['segment_id'], 0)
 
         # send waypoint trajectory's first segment
-        first_segment  = [3.0, 10.0, 0.0, 0.0, 0.0, 0.0, 0.0, 2]
-        second_segment = [3.0, 10.0, 0.0, 0.0, 0.0, 0.0, 0.0, 3]
-        third_segment  = [3.0, 10.0, 0.0, 0.0, 0.0, 0.0, 0.0, 4]
-        fourth_segment = [3.0, 10.0, 0.0, 0.0, 0.0, 0.0, 0.0, 5]
-        fifth_segment  = [3.0, 10.0, 0.0, 0.0, 0.0, 0.0, 0.0, 43]
+        first_segment  = [3.0, position_rad, 0.0, 0.0, 0.0, 0.0, 0.0, 2]
+        second_segment = [3.0, position_rad, 0.0, 0.0, 0.0, 0.0, 0.0, 3]
+        third_segment  = [3.0, position_rad, 0.0, 0.0, 0.0, 0.0, 0.0, 4]
+        fourth_segment = [3.0, position_rad, 0.0, 0.0, 0.0, 0.0, 0.0, 5]
+        fifth_segment  = [3.0, position_rad, 0.0, 0.0, 0.0, 0.0, 0.0, 43]
         s.enable_pos_traj_waypoint()
         s.set_command(v_des=velocity_rad,
                       a_des=acceleration_rad)
         s.push_command()
+        time.sleep(1)
         s.start_waypoint_trajectory(first_segment)
         s.pull_status()
-        self.assertAlmostEqual(s.status['pos'], position_rad, places=1)
+        self.assertAlmostEqual(s.status['pos'], position_rad, places=1) # TODO: fails on G2 when time.sleep(1) two lines above is commented, not sure why
         s.logger.debug(s.status['waypoint_traj'])
         self.assertEqual(s.status['waypoint_traj']['state'], 'active')
         self.assertEqual(s.status['waypoint_traj']['segment_id'], 2)

--- a/body/test/test_steppers.py
+++ b/body/test/test_steppers.py
@@ -76,9 +76,8 @@ class TestSteppers(unittest.TestCase):
         i_feedforward = 0.54
         i_contact_neg = -1.46
         i_contact_pos = 2.54
-        MODE_POS_TRAJ = 5
 
-        s.set_command(mode=MODE_POS_TRAJ,
+        s.set_command(mode=s.MODE_POS_TRAJ,
                       x_des=position_rad,
                       v_des=velocity_rad,
                       a_des=acceleration_rad,
@@ -110,12 +109,12 @@ class TestSteppers(unittest.TestCase):
         i_feedforward = 0.54
         i_contact_neg = -1.46
         i_contact_pos = 2.54
-        MODE_POS_TRAJ = 5
+
         ################################################################
         #stop by sending a duration=0 second segment
         #bring motor to starting position
         print('Waypoint stop test 1')
-        s.set_command(mode=MODE_POS_TRAJ,
+        s.set_command(mode=s.MODE_POS_TRAJ,
                       x_des=position_rad,
                       v_des=velocity_rad,
                       a_des=acceleration_rad,
@@ -158,7 +157,7 @@ class TestSteppers(unittest.TestCase):
         # stop by sending only one segment
         # bring motor to starting position
         print('Waypoint stop test 2')
-        s.set_command(mode=MODE_POS_TRAJ,
+        s.set_command(mode=s.MODE_POS_TRAJ,
                       x_des=position_rad,
                       v_des=velocity_rad,
                       a_des=acceleration_rad,
@@ -198,7 +197,7 @@ class TestSteppers(unittest.TestCase):
         print('Waypoint stop test 3')
         # stop by terminating directly
         # bring motor to starting position
-        s.set_command(mode=MODE_POS_TRAJ,
+        s.set_command(mode=s.MODE_POS_TRAJ,
                       x_des=position_rad,
                       v_des=velocity_rad,
                       a_des=acceleration_rad,
@@ -238,8 +237,9 @@ class TestSteppers(unittest.TestCase):
 
 
     def test_malicious_waypoint_trajectory_interface(self):
-        #Send bad values to trajectory interface
-        #Joint should not move
+        """Send bad values to trajectory interface
+        Joint should not move
+        """
         s = stretch_body.stepper.Stepper('/dev/hello-motor-lift')
         s.disable_sync_mode()
         self.assertTrue(s.startup())
@@ -279,8 +279,7 @@ class TestSteppers(unittest.TestCase):
         i_feedforward = 0.54
         i_contact_neg = -1.46
         i_contact_pos = 2.54
-        MODE_POS_TRAJ = 5
-        s.set_command(mode=MODE_POS_TRAJ,
+        s.set_command(mode=s.MODE_POS_TRAJ,
                       x_des=position_rad,
                       v_des=velocity_rad,
                       a_des=acceleration_rad,
@@ -334,4 +333,118 @@ class TestSteppers(unittest.TestCase):
 
         s.pull_status()
         self.assertAlmostEqual(s.status['pos'], position_rad, places=1)
+        s.stop()
+
+    def test_zeros_waypoint_trajectory(self):
+        """Test no motion on zeros segments using the
+        waypoint trajectory interface
+        """
+        s = stretch_body.stepper.Stepper('/dev/hello-motor-arm')
+        s.disable_sync_mode()
+        self.assertTrue(s.startup())
+        s.reset_pos_calibrated()
+        s.push_command()
+
+        # bring motor to starting position
+        position_rad = 10.0
+        velocity_rad = 9.948
+        acceleration_rad = 15.707
+        stiffness = 1.0
+        i_feedforward = 0.54
+        i_contact_neg = -1.46
+        i_contact_pos = 2.54
+        s.set_command(mode=s.MODE_POS_TRAJ,
+                      x_des=position_rad,
+                      v_des=velocity_rad,
+                      a_des=acceleration_rad,
+                      stiffness=stiffness,
+                      i_feedforward=i_feedforward,
+                      i_contact_pos=i_contact_pos,
+                      i_contact_neg=i_contact_neg)
+        s.push_command()
+        s.wait_until_at_setpoint()
+        time.sleep(0.5)
+        s.pull_status()
+        self.assertAlmostEqual(s.status['pos'], position_rad, places=1)
+        s.logger.debug(s.status['waypoint_traj'])
+        self.assertEqual(s.status['waypoint_traj']['state'], 'idle')
+        self.assertEqual(s.status['waypoint_traj']['segment_id'], 0)
+
+        # send waypoint trajectory's first segment
+        first_segment  = [3.0, 10.0, 0.0, 0.0, 0.0, 0.0, 0.0, 2]
+        second_segment = [3.0, 10.0, 0.0, 0.0, 0.0, 0.0, 0.0, 3]
+        third_segment  = [3.0, 10.0, 0.0, 0.0, 0.0, 0.0, 0.0, 4]
+        fourth_segment = [3.0, 10.0, 0.0, 0.0, 0.0, 0.0, 0.0, 5]
+        fifth_segment  = [3.0, 10.0, 0.0, 0.0, 0.0, 0.0, 0.0, 43]
+        s.enable_pos_traj_waypoint()
+        s.set_command(v_des=velocity_rad,
+                      a_des=acceleration_rad)
+        s.push_command()
+        s.start_waypoint_trajectory(first_segment)
+        s.pull_status()
+        # self.assertAlmostEqual(s.status['pos'], position_rad, places=1) # TODO: fails on G2, not sure why
+        s.logger.debug(s.status['waypoint_traj'])
+        self.assertEqual(s.status['waypoint_traj']['state'], 'active')
+        self.assertEqual(s.status['waypoint_traj']['segment_id'], 2)
+
+        time.sleep(1.5) # wait until half way into first segment
+        self.assertEqual(s.set_next_trajectory_segment(second_segment), 1)
+        s.pull_status()
+        self.assertAlmostEqual(s.status['pos'], position_rad, places=1)
+        s.logger.debug(s.status['waypoint_traj'])
+        self.assertEqual(s.status['waypoint_traj']['state'], 'active')
+        self.assertEqual(s.status['waypoint_traj']['segment_id'], 2)
+
+        time.sleep(1.6) # wait until first segment done, into second segment
+        s.pull_status()
+        self.assertAlmostEqual(s.status['pos'], position_rad, places=1)
+        s.logger.debug(s.status['waypoint_traj'])
+        self.assertEqual(s.status['waypoint_traj']['state'], 'active')
+        self.assertEqual(s.status['waypoint_traj']['segment_id'], 3)
+
+        time.sleep(1.5) # wait until ~ half way into second segment
+        self.assertEqual(s.set_next_trajectory_segment(third_segment), 1)
+        s.pull_status()
+        self.assertAlmostEqual(s.status['pos'], position_rad, places=1)
+        s.logger.debug(s.status['waypoint_traj'])
+        self.assertEqual(s.status['waypoint_traj']['state'], 'active')
+        self.assertEqual(s.status['waypoint_traj']['segment_id'], 3)
+
+        time.sleep(1.6) # wait until second segment done, into third segment
+        s.pull_status()
+        self.assertAlmostEqual(s.status['pos'], position_rad, places=1)
+        s.logger.debug(s.status['waypoint_traj'])
+        self.assertEqual(s.status['waypoint_traj']['state'], 'active')
+        self.assertEqual(s.status['waypoint_traj']['segment_id'], 4)
+
+        time.sleep(1.5) # wait until ~ half way into third segment
+        self.assertEqual(s.set_next_trajectory_segment(fourth_segment), 1)
+        s.pull_status()
+        self.assertAlmostEqual(s.status['pos'], position_rad, places=1)
+        s.logger.debug(s.status['waypoint_traj'])
+        self.assertEqual(s.status['waypoint_traj']['state'], 'active')
+        self.assertEqual(s.status['waypoint_traj']['segment_id'], 4)
+
+        time.sleep(1.6) # wait until third segment done, into fourth segment
+        s.pull_status()
+        self.assertAlmostEqual(s.status['pos'], position_rad, places=1)
+        s.logger.debug(s.status['waypoint_traj'])
+        self.assertEqual(s.status['waypoint_traj']['state'], 'active')
+        self.assertEqual(s.status['waypoint_traj']['segment_id'], 5)
+
+        time.sleep(1.5) # wait until ~ half way into fouth segment
+        self.assertEqual(s.set_next_trajectory_segment(fifth_segment), 0) # expect the fifth segment to be rejected
+        s.pull_status()
+        self.assertAlmostEqual(s.status['pos'], position_rad, places=1)
+        s.logger.debug(s.status['waypoint_traj'])
+        self.assertEqual(s.status['waypoint_traj']['state'], 'active')
+        self.assertEqual(s.status['waypoint_traj']['segment_id'], 5)
+
+        time.sleep(1.6) # wait until fourth segment done
+        s.pull_status()
+        self.assertAlmostEqual(s.status['pos'], position_rad, places=1)
+        s.logger.debug(s.status['waypoint_traj'])
+        self.assertEqual(s.status['waypoint_traj']['state'], 'idle')
+        self.assertEqual(s.status['waypoint_traj']['segment_id'], 0)
+
         s.stop()


### PR DESCRIPTION
This PR introduces changes to the waypoint trajectory RPC calls to handle another argument, 'error_message', a character array 100 bytes long. This PR is tested with https://github.com/hello-robot/stretch_firmware/pull/6, which is firmware that validates that the trajectory is actually executable, and reports errors back via the 'error_message'.

This PR also includes three additional unit tests that have been tested on Python2, Ubuntu 18.04. These tests are:
 * `test_zeros_waypoint_trajectory`: issues zeros segments to ensure joint doesn't move
 * `test_waypoint_trajectory_firmware_errors`: causes every error the firmware catches to occur and verifies the appropriate 'error_message' is returned
 * `test_arm_waypoint_trajectory`: send a valid arm trajectory with valid dynamic limit, and then invalid dynamic limits. Velocity and acceleration curves plotted on desmos here: https://www.desmos.com/calculator/h6qlt496sr.