### PR TITLE
Add individual device threading

### DIFF
--- a/body/stretch_body/arm.py
+++ b/body/stretch_body/arm.py
@@ -29,12 +29,14 @@ class Arm(Device):
 
     # ###########  Device Methods #############
 
-    def startup(self):
-        success= self.motor.startup()
+    def startup(self, threaded=False):
+        Device.startup(self, threaded=threaded)
+        success = self.motor.startup(threaded=False)
         self.__update_status()
         return success
 
     def stop(self):
+        Device.stop(self)
         self.motor.stop()
 
     def pull_status(self):

--- a/body/stretch_body/base.py
+++ b/body/stretch_body/base.py
@@ -28,12 +28,14 @@ class Base(Device):
         self.fast_motion_allowed = True
     # ###########  Device Methods #############
 
-    def startup(self):
-        success=self.left_wheel.startup() and self.right_wheel.startup()
+    def startup(self, threaded=False):
+        Device.startup(self, threaded=threaded)
+        success=self.left_wheel.startup(threaded=False) and self.right_wheel.startup(threaded=False)
         self.__update_status()
         return success
 
     def stop(self):
+        Device.stop(self)
         self.left_wheel.stop()
         self.right_wheel.stop()
 

--- a/body/stretch_body/dynamixel_XL430.py
+++ b/body/stretch_body/dynamixel_XL430.py
@@ -7,7 +7,6 @@ from dynamixel_sdk.robotis_def import *
 import dynamixel_sdk.port_handler as prh
 import dynamixel_sdk.packet_handler as pch
 import threading
-from stretch_body.device import Device
 import serial
 
 # The code can be found in the following directory:

--- a/body/stretch_body/dynamixel_X_chain.py
+++ b/body/stretch_body/dynamixel_X_chain.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 import stretch_body.hello_utils as hello_utils
+from stretch_body.device import Device
 import time
 
 # The code can be found in the following directory:
@@ -51,7 +52,8 @@ class DynamixelXChain(Device):
         except (AttributeError, KeyError):
             return None
 
-    def startup(self):
+    def startup(self, threaded=False):
+        Device.startup(self, threaded=threaded)
         for mk in self.motors.keys():  # Provide nop data in case comm failures
             self.status[mk] = self.motors[mk].status
         if not self.hw_valid:
@@ -75,7 +77,7 @@ class DynamixelXChain(Device):
                                 self.logger.error('Dynamixel X sync read initialization failed.')
                                 raise DynamixelCommError
                 for mk in self.motors.keys():
-                    if not self.motors[mk].startup():
+                    if not self.motors[mk].startup(threaded=False):
                         raise DynamixelCommError
                     self.status[mk] = self.motors[mk].status
                 self.pull_status()
@@ -86,6 +88,7 @@ class DynamixelXChain(Device):
         return True
 
     def stop(self):
+        Device.stop(self)
         if not self.hw_valid:
             return
         for mk in self.motors.keys():

--- a/body/stretch_body/dynamixel_hello_XL430.py
+++ b/body/stretch_body/dynamixel_hello_XL430.py
@@ -128,7 +128,8 @@ class DynamixelHelloXL430(Device):
     def do_ping(self, verbose=False):
         return self.motor.do_ping(verbose)
 
-    def startup(self):
+    def startup(self, threaded=False):
+        Device.startup(self, threaded=threaded)
         try:
             if self.motor.do_ping(verbose=False):
                 self.hw_valid = True
@@ -166,6 +167,7 @@ class DynamixelHelloXL430(Device):
 
 
     def stop(self):
+        Device.stop(self)
         if self.hw_valid:
             self.disable_torque()
             self.hw_valid = False

--- a/body/stretch_body/lift.py
+++ b/body/stretch_body/lift.py
@@ -28,12 +28,14 @@ class Lift(Device):
         self.motor.set_motion_limits(self.translate_to_motor_rad(self.soft_motion_limits['current'][0]),
                                      self.translate_to_motor_rad(self.soft_motion_limits['current'][1]))
     # ###########  Device Methods #############
-    def startup(self):
-        success= self.motor.startup()
+    def startup(self, threaded=False):
+        Device.startup(self, threaded=threaded)
+        success= self.motor.startup(threaded=False)
         self.__update_status()
         return success
 
     def stop(self):
+        Device.stop(self)
         self.motor.stop()
 
     def pull_status(self):

--- a/body/stretch_body/pimu.py
+++ b/body/stretch_body/pimu.py
@@ -189,7 +189,8 @@ class PimuBase(Device):
 
     # ###########  Device Methods #############
 
-    def startup(self):
+    def startup(self, threaded=False):
+        Device.startup(self, threaded=threaded)
         with self.lock:
             self.hw_valid = self.transport.startup()
             if self.hw_valid:
@@ -201,6 +202,7 @@ class PimuBase(Device):
             return False
 
     def stop(self):
+        Device.stop(self)
         if not self.hw_valid:
             return
         with self.lock:
@@ -558,12 +560,12 @@ class Pimu(PimuBase):
         # Order in descending order so more recent protocols/methods override less recent
         self.supported_protocols = {'p0': (Pimu_Protocol_P0,), 'p1': (Pimu_Protocol_P1,Pimu_Protocol_P0,)}
 
-    def startup(self):
+    def startup(self, threaded=False):
         """
         First determine which protocol version the uC firmware is running.
         Based on that version, replaces PimuBase class inheritance with a inheritance to a child class of PimuBase that supports that protocol
         """
-        PimuBase.startup(self)
+        PimuBase.startup(self, threaded=threaded)
         if self.hw_valid:
             if self.board_info['protocol_version'] in self.supported_protocols:
                 Pimu.__bases__ = self.supported_protocols[self.board_info['protocol_version']]

--- a/body/stretch_body/robot.py
+++ b/body/stretch_body/robot.py
@@ -150,7 +150,7 @@ class Robot(Device):
         success = True
         for k in self.devices.keys():
             if self.devices[k] is not None:
-                if not self.devices[k].startup():
+                if not self.devices[k].startup(threaded=False):
                     success = False
 
         # Register the signal handlers

--- a/body/stretch_body/robot_collision.py
+++ b/body/stretch_body/robot_collision.py
@@ -60,6 +60,7 @@ class RobotCollision(Device):
         self.models_enabled={}
 
     def startup(self):
+        Device.startup(self, threaded=False)
         model_names = []
         if self.params.get('models'):
             model_names=model_names+self.params.get('models')

--- a/body/stretch_body/robot_monitor.py
+++ b/body/stretch_body/robot_monitor.py
@@ -15,6 +15,7 @@ class RobotMonitor(Device):
         self.robot=robot
 
     def startup(self):
+        Device.startup(self, threaded=False)
         if self.robot.wacc is not None:
             stc=self.robot.wacc.status['single_tap_count']
         else:

--- a/body/stretch_body/stepper.py
+++ b/body/stretch_body/stepper.py
@@ -127,7 +127,8 @@ class StepperBase(Device):
         self.gains = self.params['gains'].copy()
 
     # ###########  Device Methods #############
-    def startup(self):
+    def startup(self, threaded=False):
+        Device.startup(self, threaded=threaded)
         with self.lock:
             self.hw_valid = self.transport.startup()
             if self.hw_valid:
@@ -140,6 +141,7 @@ class StepperBase(Device):
 
     #Configure control mode prior to calling this on process shutdown (or default to freewheel)
     def stop(self):
+        Device.stop(self)
         if not self.hw_valid:
             return
         with self.lock:
@@ -978,12 +980,12 @@ class Stepper(StepperBase):
         # Order in descending order so more recent protocols/methods override less recent
         self.supported_protocols = {'p0': (Stepper_Protocol_P0,), 'p1': (Stepper_Protocol_P1,Stepper_Protocol_P0,)}
 
-    def startup(self):
+    def startup(self, threaded=False):
         """
         First determine which protocol version the uC firmware is running.
         Based on that version, replaces PimuBase class inheritance with a inheritance to a child class of PimuBase that supports that protocol
         """
-        StepperBase.startup(self)
+        StepperBase.startup(self, threaded=threaded)
         if self.hw_valid:
             if self.board_info['protocol_version'] in self.supported_protocols:
                 Stepper.__bases__ = self.supported_protocols[self.board_info['protocol_version']]

--- a/body/stretch_body/transport.py
+++ b/body/stretch_body/transport.py
@@ -91,6 +91,20 @@ class Transport():
 
 
     def startup(self):
+        try:
+            self.ser = serial.Serial(self.usb, write_timeout=1.0)#PosixPollSerial(self.usb)#Serial(self.usb)# 115200)  # , write_timeout=1.0)  # Baud not important since USB comms
+            if self.ser.isOpen():
+                try:
+                    fcntl.flock(self.ser.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                except IOError:
+                    self.logger.error('Port %s is busy. Check if another Stretch Body process is already running'%self.usb)
+                    self.ser.close()
+                    self.ser=None
+        except serial.SerialException as e:
+            self.logger.error("SerialException({0}): {1}".format(e.errno, e.strerror))
+            self.ser = None
+        if self.ser==None:
+            self.logger.warning('Unable to open serial port for device %s'%self.usb)
         return self.ser is not None #return if hardware connection valid
 
     def stop(self):

--- a/body/stretch_body/wacc.py
+++ b/body/stretch_body/wacc.py
@@ -49,7 +49,9 @@ class WaccBase(Device):
         self.hw_valid = False
 
     # ###########  Device Methods #############
-    def startup(self):
+
+    def startup(self, threaded=False):
+        Device.startup(self, threaded=threaded)
         with self.lock:
             self.hw_valid = self.transport.startup()
             if self.hw_valid:
@@ -61,6 +63,7 @@ class WaccBase(Device):
             return False
 
     def stop(self):
+        Device.stop(self)
         if not self.hw_valid:
             return
         with self.lock:
@@ -257,12 +260,12 @@ class Wacc(WaccBase):
         #Order in descending order so more recent protocols/methods override less recent
         self.supported_protocols = {'p0': (Wacc_Protocol_P0,), 'p1': (Wacc_Protocol_P1,Wacc_Protocol_P0,)}
 
-    def startup(self):
+    def startup(self, threaded=False):
         """
         First determine which protocol version the uC firmware is running.
         Based on that version, replaces PimuBase class inheritance with a inheritance to a child class of PimuBase that supports that protocol
         """
-        WaccBase.startup(self)
+        WaccBase.startup(self, threaded=threaded)
         if self.hw_valid:
             if self.board_info['protocol_version'] in self.supported_protocols:
                 Wacc.__bases__ = self.supported_protocols[self.board_info['protocol_version']]

--- a/body/test/test_device.py
+++ b/body/test/test_device.py
@@ -1,6 +1,8 @@
 import unittest
 import stretch_body.device
 
+import time
+
 
 class TestDevice(unittest.TestCase):
 
@@ -18,3 +20,38 @@ class TestDevice(unittest.TestCase):
         d2.logger.info('hi')
         # TODO: capture logging with https://testfixtures.readthedocs.io/en/latest/logging.html
         #       verify output is '[INFO][wrist_yaw]hi\n[INFO][stretch_gripper]hi\n'
+
+    def test_threaded(self):
+        class SometimesThreadedDevice(stretch_body.device.Device):
+            def __init__(self):
+                stretch_body.device.Device.__init__(self)
+            def startup(self, threaded=False):
+                self.pulling_status = False
+                stretch_body.device.Device.startup(self, threaded=threaded)
+            def pull_status(self):
+                self.pulling_status = True
+
+        # not threaded
+        d = SometimesThreadedDevice()
+        d.startup()
+        time.sleep(0.1)
+        self.assertFalse(d.pulling_status)
+        time.sleep(0.1)
+        self.assertFalse(d.pulling_status)
+        d.stop()
+
+        # threaded
+        d.startup(threaded=True)
+        time.sleep(0.1)
+        self.assertTrue(d.pulling_status)
+        time.sleep(0.1)
+        self.assertTrue(d.pulling_status)
+        d.stop()
+
+        # not threaded
+        d.startup()
+        time.sleep(0.1)
+        self.assertFalse(d.pulling_status)
+        time.sleep(0.1)
+        self.assertFalse(d.pulling_status)
+        d.stop()


### PR DESCRIPTION
This PR gives the `Device` class threading support similar to what exists in the `Robot` class. When using `stretch_body.robot.Robot`, threads are spun up to pull status and step sentry in the background for all devices (devices are joints that have a uC) on the robot. With this PR, all Stretch Body joints that subclass `Device` can spin up a thread to perform an action in the background. To maintain compatibility with previous behavior, this thread is not active by default and is launched with `.startup(threaded=True)`. In future PRs, devices that support waypoint trajectories will have threads launched by default (when not using Robot).

Each thread also has `LoopStats`, which automatically logs to the "stretch_user" directory. Additionally, a issue with transport with Stepper devices is fixed. Lastly, a unit test is added.