### PR TITLE
Fix dxl index error

### DIFF
--- a/body/stretch_body/dynamixel_X_chain.py
+++ b/body/stretch_body/dynamixel_X_chain.py
@@ -182,7 +182,11 @@ class DynamixelXChain(Device):
             raise DynamixelCommError
 
         def get_val(id_num):
-            b = reader.getData(id_num, reader.start_address, reader.data_length)
+            try:
+                b = reader.getData(id_num, reader.start_address, reader.data_length)
+            except IndexError:
+                #Bad data struct size possible to raise Index Error
+                raise DynamixelCommError
             # The error code seems to be 0, yet there are also
             # circumstances where b will be 0 without an error, such
             # as being at position = 0. For now, I am commenting out

--- a/body/stretch_body/version.py
+++ b/body/stretch_body/version.py
@@ -3,4 +3,4 @@
 # 2) we can import it in setup.py for the same reason
 # 3) we can import it into your module module
 
-__version__ = '0.1.12'
+__version__ = '0.1.13'


### PR DESCRIPTION
On rare occaision the DXL group sync read can toss an Index Error. This occurs if there's a bad read that isn't caught by the SDK (resulting in malformed data structure). This catches the error, which will be logged as a failure and retried.