### PR TITLE
fix fleet dir stuff

### DIFF
--- a/body/stretch_body/device.py
+++ b/body/stretch_body/device.py
@@ -60,8 +60,8 @@ class Device:
         print('----- {0} ------ '.format(self.name))
         hello_utils.pretty_print_dict("params", self.params)
 
-    def write_device_params(self,device_name, params):
-        rp=hello_utils.read_fleet_yaml(self.user_params['factory_params'])
+    def write_device_params(self,device_name, params,fleet_dir=None):
+        rp=hello_utils.read_fleet_yaml(self.user_params['factory_params'],fleet_dir=fleet_dir)
         rp[device_name]=params
-        hello_utils.write_fleet_yaml(self.user_params['factory_params'],rp)
+        hello_utils.write_fleet_yaml(self.user_params['factory_params'],rp,fleet_dir=fleet_dir)
 

--- a/body/stretch_body/hello_utils.py
+++ b/body/stretch_body/hello_utils.py
@@ -60,7 +60,7 @@ def get_stretch_directory(sub_directory=''):
     full_path = base_path + '/' + sub_directory if base_path is not None else '/tmp/'
     return full_path
 
-def read_fleet_yaml(f):
+def read_fleet_yaml(f,fleet_dir=None):
     """Reads yaml by filename from fleet directory
 
     Parameters
@@ -74,14 +74,18 @@ def read_fleet_yaml(f):
         yaml as dictionary if valid file, else empty dict
     """
     try:
-        with open(get_fleet_directory()+f, 'r') as s:
+        if fleet_dir is None:
+            fleet_dir=get_fleet_directory()
+        with open(fleet_dir+f, 'r') as s:
             p = yaml.load(s,Loader=yaml.FullLoader)
             return {} if p is None else p
     except IOError:
         return {}
 
-def write_fleet_yaml(fn,rp):
-    with open(get_fleet_directory()+fn, 'w') as yaml_file:
+def write_fleet_yaml(fn,rp,fleet_dir=None):
+    if fleet_dir is None:
+        fleet_dir = get_fleet_directory()
+    with open(fleet_dir+fn, 'w') as yaml_file:
         yaml.dump(rp, yaml_file, default_flow_style=False)
 
 def overwrite_dict(overwritee_dict, overwriter_dict):

--- a/body/stretch_body/stepper.py
+++ b/body/stretch_body/stepper.py
@@ -419,6 +419,7 @@ class StepperBase(Device):
         device_name = self.usb[5:]
         sn = self.robot_params[device_name]['serial_no']
         fn = 'calibration_steppers/'+device_name + '_' + sn + '.yaml'
+        print('Writing encoder calibration: %s'%fn)
         write_fleet_yaml(fn,data)
 
     def read_encoder_calibration_from_flash(self):

--- a/body/stretch_body/version.py
+++ b/body/stretch_body/version.py
@@ -3,4 +3,4 @@
 # 2) we can import it in setup.py for the same reason
 # 3) we can import it into your module module
 
-__version__ = '0.1.14'
+__version__ = '0.1.15'


### PR DESCRIPTION
In production the HELLO_FLEET_PATH may change. Currently the Device.write_device_params() didn't allow for custom paths as needed by production. This update allows the path to be provided as an option (without changing the prior API).

