### PR TITLE
Debug log when move_to/by commands are clipped

### DIFF
--- a/body/stretch_body/arm.py
+++ b/body/stretch_body/arm.py
@@ -165,7 +165,10 @@ class Arm(Device):
             if not self.motor.status['pos_calibrated']:
                 self.logger.warning('Arm not calibrated')
                 return
+            old_x_m = x_m
             x_m = min(max(self.soft_motion_limits['current'][0], x_m), self.soft_motion_limits['current'][1]) #Only clip motion when calibrated
+            if x_m != old_x_m:
+                self.logger.debug('Clipping move_to({0}) with soft limits {1}'.format(old_x_m, self.soft_motion_limits['current']))
 
         if stiffness is not None:
             stiffness = max(0, min(1.0, stiffness))
@@ -213,10 +216,13 @@ class Arm(Device):
                 self.logger.warning('Arm not calibrated')
                 return
 
+            old_x_m = x_m
             if self.status['pos'] + x_m < self.soft_motion_limits['current'][0]:  #Only clip motion when calibrated
                 x_m = self.soft_motion_limits['current'][0] - self.status['pos']
             if self.status['pos'] + x_m > self.soft_motion_limits['current'][1]:
                 x_m = self.soft_motion_limits['current'][1] - self.status['pos']
+            if x_m != old_x_m:
+                self.logger.debug('Clipping {0} + move_by({1}) with soft limits {2}'.format(self.status['pos'], old_x_m, self.soft_motion_limits['current']))
 
         if stiffness is not None:
             stiffness = max(0, min(1.0, stiffness))

--- a/body/stretch_body/dynamixel_hello_XL430.py
+++ b/body/stretch_body/dynamixel_hello_XL430.py
@@ -382,7 +382,10 @@ class DynamixelHelloXL430(Device):
             return
         try:
             self.set_motion_params(v_des,a_des)
+            old_x_des = x_des
             x_des = min(max(self.get_soft_motion_limits()[0], x_des), self.get_soft_motion_limits()[1])
+            if x_des != old_x_des:
+                self.logger.debug('Clipping move_to({0}) with soft limits {1}'.format(old_x_des, self.soft_motion_limits['current']))
             t_des = self.world_rad_to_ticks(x_des)
             t_des = max(self.params['range_t'][0], min(self.params['range_t'][1], t_des))
             self.motor.go_to_pos(t_des)

--- a/body/stretch_body/lift.py
+++ b/body/stretch_body/lift.py
@@ -167,7 +167,11 @@ class Lift(Device):
             if not self.motor.status['pos_calibrated']:
                 self.logger.warning('Lift not calibrated')
                 return
+            old_x_m = x_m
             x_m = min(max(self.soft_motion_limits['current'][0], x_m), self.soft_motion_limits['current'][1]) #Only clip motion when calibrated
+            if x_m != old_x_m:
+                self.logger.debug('Clipping move_to({0}) with soft limits {1}'.format(old_x_m, self.soft_motion_limits['current']))
+
         if stiffness is not None:
             stiffness = max(0, min(1.0, stiffness))
         else:
@@ -214,10 +218,13 @@ class Lift(Device):
                 self.logger.warning('Lift not calibrated')
                 return
 
+            old_x_m = x_m
             if self.status['pos'] + x_m < self.soft_motion_limits['current'][0]:  #Only clip motion when calibrated
                 x_m = self.soft_motion_limits['current'][0] - self.status['pos']
             if self.status['pos'] + x_m > self.soft_motion_limits['current'][1]:
                 x_m = self.soft_motion_limits['current'][1] - self.status['pos']
+            if x_m != old_x_m:
+                self.logger.debug('Clipping {0} + move_by({1}) with soft limits {2}'.format(self.status['pos'], old_x_m, self.soft_motion_limits['current']))
 
         if stiffness is not None:
             stiffness = max(0, min(1.0, stiffness))


### PR DESCRIPTION
In this PR, the arm and lift classes log debug statements when `move_to` or `move_by` commands are clipped. For dxl motors, clipped commands are only logged by the `move_to` function since commands aren't clipped inside `move_by`.