### PR TITLE
Fix py2 terminado error by pinning v0.8.3

### DIFF
--- a/body/setup.py
+++ b/body/setup.py
@@ -25,6 +25,7 @@ setuptools.setup(
                       'scikit-image', 'open3d', 'pyrealsense2', 'pathlib', 'psutil', 'gitpython', 'urdfpy',
                       'jsonschema==2.6.0; python_version < "3.0"', 'qtconsole==4.7.7; python_version < "3.0"', 'jupyter', # required by juypter
                       'llvmlite==0.31.0; python_version < "3.0"', 'numba', # numba required by stretch_funmap, depends on old llvmlite for py2
+                      'terminado==0.8.3; python_version < "3.0"', # depend on old terminado for py2
                       'dynamixel-sdk>=3.1; python_version >= "3.0.0"', # py2 gets dynamixel-sdk through ROS
                       'pyyaml>=5.1', # required for yaml.FullLoader
                       'hello-robot-stretch-tool-share>=0.2.0' # defines other Stretch end effectors


### PR DESCRIPTION
A fresh Stretch Body install (`python -m pip install --upgrade --no-cache-dir hello-robot-stretch-body`) in Python2 causes the following error with terminado:

```
Collecting terminado>=0.8.1 (from notebook->open3d->hello-robot-stretch-body==0.2.1)
  Downloading https://files.pythonhosted.org/packages/c0/8b/afc8646aa8dedf561bad37cfa9bf95bbb2d3671207e79954e14a556b98b9/terminado-0.13.0.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-UAFe5F/terminado/setup.py", line 2, in <module>
        setup()
      File "/home/hello-robot/.local/lib/python2.7/site-packages/setuptools/__init__.py", line 162, in setup
        return distutils.core.setup(**attrs)
      File "/usr/lib/python2.7/distutils/core.py", line 124, in setup
        dist.parse_config_files()
      File "/home/hello-robot/.local/lib/python2.7/site-packages/setuptools/dist.py", line 702, in parse_config_files
        ignore_option_errors=ignore_option_errors)
      File "/home/hello-robot/.local/lib/python2.7/site-packages/setuptools/config.py", line 121, in parse_configuration
        meta.parse()
      File "/home/hello-robot/.local/lib/python2.7/site-packages/setuptools/config.py", line 426, in parse
        section_parser_method(section_options)
      File "/home/hello-robot/.local/lib/python2.7/site-packages/setuptools/config.py", line 399, in parse_section
        self[name] = value
      File "/home/hello-robot/.local/lib/python2.7/site-packages/setuptools/config.py", line 184, in __setitem__
        value = parser(value)
      File "/home/hello-robot/.local/lib/python2.7/site-packages/setuptools/config.py", line 515, in _parse_version
        version = self._parse_attr(value, self.package_dir)
      File "/home/hello-robot/.local/lib/python2.7/site-packages/setuptools/config.py", line 349, in _parse_attr
        module = import_module(module_name)
      File "/usr/lib/python2.7/importlib/__init__.py", line 37, in import_module
        __import__(name)
      File "/tmp/pip-build-UAFe5F/terminado/terminado/__init__.py", line 7, in <module>
        from .websocket import TermSocket
      File "/tmp/pip-build-UAFe5F/terminado/terminado/websocket.py", line 87
        self.log_terminal_output(f'STDOUT: {content[1]}')
                                                       ^
    SyntaxError: invalid syntax
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-UAFe5F/terminado/
```

This PR fixes the issue by pinning terminado to an older version that supports py2.