### PR TITLE
Bugfix/2001 bringup

### DIFF
--- a/body/stretch_body/pimu.py
+++ b/body/stretch_body/pimu.py
@@ -515,7 +515,7 @@ class Pimu_Protocol_P0(PimuBase):
             self.status['low_voltage_alert'] = (self.status['state'] & self.STATE_LOW_VOLTAGE_ALERT) != 0
             self.status['high_current_alert'] = (self.status['state'] & self.STATE_HIGH_CURRENT_ALERT) != 0
             self.status['over_tilt_alert'] = (self.status['state'] & self.STATE_OVER_TILT_ALERT) != 0
-            self.status['charger_detected'] = (self.status['state'] & self.STATE_CHARGER_CONNECTED) != 0
+            self.status['charger_connected'] = (self.status['state'] & self.STATE_CHARGER_CONNECTED) != 0
             self.status['boot_detected'] = (self.status['state'] & self.STATE_BOOT_DETECTED) != 0
             self.status['timestamp'] = self.timestamp.set(unpack_uint32_t(s[sidx:])); sidx += 4
             self.status['bump_event_cnt'] = unpack_uint16_t(s[sidx:]);sidx += 2
@@ -553,7 +553,7 @@ class Pimu_Protocol_P1(PimuBase):
             self.status['high_current_alert'] = (self.status['state'] & self.STATE_HIGH_CURRENT_ALERT) != 0
             self.status['over_tilt_alert'] = (self.status['state'] & self.STATE_OVER_TILT_ALERT) != 0
             if self.board_info['hardware_id']>0:
-                self.status['charger_detected'] = (self.status['state'] & self.STATE_CHARGER_CONNECTED) != 0
+                self.status['charger_connected'] = (self.status['state'] & self.STATE_CHARGER_CONNECTED) != 0
                 self.status['boot_detected'] = (self.status['state'] & self.STATE_BOOT_DETECTED) != 0
             self.status['timestamp'] = self.timestamp.set(unpack_uint64_t(s[sidx:])); sidx += 8
             self.imu.status['timestamp'] = self.status['timestamp']

--- a/tools/bin/stretch_audio_test.py
+++ b/tools/bin/stretch_audio_test.py
@@ -2,9 +2,13 @@
 from __future__ import print_function
 import os
 import stretch_body.hello_utils as hu
+import lsb_release
 hu.print_stretch_re_use()
 
 os.system('pactl set-default-sink alsa_output.pci-0000_00_1f.3.analog-stereo')
 os.system('amixer set Master 80%')
-os.system('paplay --device=alsa_output.pci-0000_00_1f.3.analog-stereo /usr/share/sounds/ubuntu/stereo/desktop-login.ogg')
+if lsb_release.get_distro_information()['RELEASE']=='20.04':
+    os.system('canberra-gtk-play --id="system-ready"')
+if lsb_release.get_distro_information()['RELEASE']=='18.04':
+    os.system('paplay --device=alsa_output.pci-0000_00_1f.3.analog-stereo /usr/share/sounds/ubuntu/stereo/desktop-login.ogg')
 


### PR DESCRIPTION
This makes the stretch_audio_play use 20.04 sound player. Also fixes typo in Pimu status.