### PR TITLE
fix respeaker tostring warnings

### DIFF
--- a/tools/bin/stretch_respeaker_test.py
+++ b/tools/bin/stretch_respeaker_test.py
@@ -129,7 +129,8 @@ class Tuning:
             usb.util.CTRL_IN | usb.util.CTRL_TYPE_VENDOR | usb.util.CTRL_RECIPIENT_DEVICE,
             0, cmd, id, length, self.TIMEOUT)
 
-        response = struct.unpack(b'ii', response.tostring())
+        #response = struct.unpack(b'ii', response.tostring())
+        response = struct.unpack(b'ii', response.tobytes())
 
         if data[2] == 'int':
             result = response[0]
@@ -194,8 +195,10 @@ def record_audio(seconds=3):
     frames = []
     for i in range(0, int(RESPEAKER_RATE / CHUNK * seconds)):
         data = stream.read(CHUNK)
-        a = np.fromstring(data,dtype=np.int16)[0::6] # extracts fused channel 0
-        frames.append(a.tostring())
+        #a = np.fromstring(data,dtype=np.int16)[0::6] # extracts fused channel 0
+        #frames.append(a.tostring())
+        a = np.frombuffer(data, dtype=np.int16)[0::6]  # extracts fused channel 0
+        frames.append(a.tobytes())
 
     stream.stop_stream()
     stream.close()

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -11,7 +11,7 @@ stretch_scripts={script_path+'/'+f for f in listdir(script_path) if isfile(join(
 
 setuptools.setup(
     name="hello_robot_stretch_body_tools",
-    version="0.4.2",
+    version="0.4.3",
     author="Hello Robot Inc",
     author_email="support@hello-robot.com",
     description="Stretch Body Tools",


### PR DESCRIPTION
Updates the Respeaker tool to use frombuffer / tobytes as recommended per the warning