### PR TITLE
Support overwriting subtypes of dictionary (e.g. defaultdict from collections module)

### DIFF
--- a/body/stretch_body/hello_utils.py
+++ b/body/stretch_body/hello_utils.py
@@ -6,6 +6,8 @@ import time
 import logging
 import numpy as np
 import sys
+import numbers
+
 
 def print_stretch_re_use():
     print("For use with S T R E T C H (R) RESEARCH EDITION from Hello Robot Inc.")
@@ -111,16 +113,14 @@ def write_fleet_yaml(fn,rp,fleet_dir=None,header=None):
 def overwrite_dict(overwritee_dict, overwriter_dict):
     for k in overwriter_dict.keys():
         if k in overwritee_dict:
-            if (type(overwritee_dict[k])==type(overwriter_dict[k])) or (type(overwritee_dict[k])==int and type(overwriter_dict[k])==float) or (type(overwritee_dict[k])==float and type(overwriter_dict[k])==int):
-                if type(overwritee_dict[k])==dict:
-                    overwrite_dict(overwritee_dict[k],overwriter_dict[k])
-                else:
-                    overwritee_dict[k]=overwriter_dict[k]
+            if (isinstance(overwritee_dict[k], dict) and isinstance(overwriter_dict[k], dict)):
+                overwrite_dict(overwritee_dict[k], overwriter_dict[k])
             else:
-                print('Overwritting Robot Params. Type mismatch for key:',k)
-                print('Overwriter',overwriter_dict[k])
-                print('Overwritee', overwritee_dict[k])
-        else: #If key not present, add anyhow (useful for adding new params)
+                if (type(overwritee_dict[k]) == type(overwriter_dict[k])) or (isinstance(overwritee_dict[k], numbers.Real) and isinstance(overwriter_dict[k], numbers.Real)):
+                    overwritee_dict[k] = overwriter_dict[k]
+                else:
+                    print('stretch_body.hello_utils.overwrite_dict ERROR: Type mismatch for key={0}, between overwritee={1} and overwriter={2}'.format(k, overwritee_dict[k], overwriter_dict[k]), file=sys.stderr)
+        else: #If key not present, add anyhow (useful for overlaying params)
             overwritee_dict[k] = overwriter_dict[k]
 
 def pretty_print_dict(title, d):

--- a/body/stretch_body/hello_utils.py
+++ b/body/stretch_body/hello_utils.py
@@ -111,17 +111,21 @@ def write_fleet_yaml(fn,rp,fleet_dir=None,header=None):
 
 
 def overwrite_dict(overwritee_dict, overwriter_dict):
+    no_mismatches = True
     for k in overwriter_dict.keys():
         if k in overwritee_dict:
             if (isinstance(overwritee_dict[k], dict) and isinstance(overwriter_dict[k], dict)):
-                overwrite_dict(overwritee_dict[k], overwriter_dict[k])
+                sub_no_mismatches = overwrite_dict(overwritee_dict[k], overwriter_dict[k])
+                no_mismatches = no_mismatches and sub_no_mismatches
             else:
                 if (type(overwritee_dict[k]) == type(overwriter_dict[k])) or (isinstance(overwritee_dict[k], numbers.Real) and isinstance(overwriter_dict[k], numbers.Real)):
                     overwritee_dict[k] = overwriter_dict[k]
                 else:
+                    no_mismatches = False
                     print('stretch_body.hello_utils.overwrite_dict ERROR: Type mismatch for key={0}, between overwritee={1} and overwriter={2}'.format(k, overwritee_dict[k], overwriter_dict[k]), file=sys.stderr)
         else: #If key not present, add anyhow (useful for overlaying params)
             overwritee_dict[k] = overwriter_dict[k]
+    return no_mismatches
 
 def pretty_print_dict(title, d):
     """Print human readable representation of dictionary to terminal

--- a/body/stretch_body/hello_utils.py
+++ b/body/stretch_body/hello_utils.py
@@ -111,6 +111,22 @@ def write_fleet_yaml(fn,rp,fleet_dir=None,header=None):
 
 
 def overwrite_dict(overwritee_dict, overwriter_dict):
+    """Merge two dictionaries while overwriting common keys and
+    report errors when values of the same key differ in Python
+    type. The result gets stored in `overwritee_dict`.
+
+    Parameters
+    ----------
+    overwritee_dict : dict
+        The dictionary which will be overwritten. Use this as the merged result.
+    overwriter_dict : dict
+        The dictionary which will overwrite.
+
+    Returns
+    -------
+    bool
+        True if no mismatches were found during the overwrite, False otherwise.
+    """
     no_mismatches = True
     for k in overwriter_dict.keys():
         if k in overwritee_dict:

--- a/body/test/test_hello_utils.py
+++ b/body/test/test_hello_utils.py
@@ -30,54 +30,63 @@ class TestHelloUtils(unittest.TestCase):
         """
         dee1 = {'param1': 1}
         der1 = {'param2': 2}
-        stretch_body.hello_utils.overwrite_dict(dee1, der1)
+        no_mismatches1 = stretch_body.hello_utils.overwrite_dict(dee1, der1)
         self.assertEqual(dee1, {'param1': 1, 'param2': 2})
+        self.assertTrue(no_mismatches1)
 
         dee2 = {'param1': 'to_override'}
         der2 = {'param1': 'over'}
-        stretch_body.hello_utils.overwrite_dict(dee2, der2)
+        no_mismatches2 = stretch_body.hello_utils.overwrite_dict(dee2, der2)
         self.assertEqual(dee2, {'param1': 'over'})
+        self.assertTrue(no_mismatches2)
 
         dee3 = {'param1': {'motion': 'to_override', 'no_change': 1}}
         der3 = {'param1': {'motion': 'over'}}
-        stretch_body.hello_utils.overwrite_dict(dee3, der3)
+        no_mismatches3 = stretch_body.hello_utils.overwrite_dict(dee3, der3)
         self.assertEqual(dee3, {'param1': {'motion': 'over', 'no_change': 1}})
+        self.assertTrue(no_mismatches3)
 
         dee4 = {'param1': {'motion': 'same', 'no_change': 1}}
         der4 = {'param1': {'motion': {}}}
-        stretch_body.hello_utils.overwrite_dict(dee4, der4)
+        no_mismatches4 = stretch_body.hello_utils.overwrite_dict(dee4, der4)
         self.assertEqual(dee4, {'param1': {'motion': 'same', 'no_change': 1}})
+        self.assertFalse(no_mismatches4)
 
         dee5 = {'param1': {'motion': {}, 'no_change': 1}}
         der5 = {'param1': {'motion': 2}}
-        stretch_body.hello_utils.overwrite_dict(dee5, der5)
+        no_mismatches5 = stretch_body.hello_utils.overwrite_dict(dee5, der5)
         self.assertEqual(dee5, {'param1': {'motion': {}, 'no_change': 1}})
+        self.assertFalse(no_mismatches5)
 
         dee6 = {'param1': {'motion': 1}}
         der6 = {'param1': {'motion': 'stringtype'}}
-        stretch_body.hello_utils.overwrite_dict(dee6, der6)
+        no_mismatches6 = stretch_body.hello_utils.overwrite_dict(dee6, der6)
         self.assertEqual(dee6, {'param1': {'motion': 1}})
+        self.assertFalse(no_mismatches6)
 
         # int and float and overwrite each other
         dee7 = {'param1': {'motion': 1}}
         der7 = {'param1': {'motion': 2.0}}
-        stretch_body.hello_utils.overwrite_dict(dee7, der7)
+        no_mismatches7 = stretch_body.hello_utils.overwrite_dict(dee7, der7)
         self.assertEqual(dee7, {'param1': {'motion': 2.0}})
+        self.assertTrue(no_mismatches7)
 
         dee8 = {'param1': {'param2': 0}}
         param2dict = defaultdict()
         param2dict['param2'] = 2
         der8 = {'param1': param2dict}
-        stretch_body.hello_utils.overwrite_dict(dee8, der8)
+        no_mismatches8 = stretch_body.hello_utils.overwrite_dict(dee8, der8)
         self.assertEqual(dee8, {'param1': {'param2': 2}})
+        self.assertTrue(no_mismatches8)
 
     def test_overwriting_vs_updating_params(self):
         """Verify the difference between overwrite_dict and updating a dict.
         """
         overider1 = {"robot": {"motion": {"max": 100}}}
         overidee1 = {"robot": {"motion": {"min": -100}}}
-        stretch_body.hello_utils.overwrite_dict(overidee1, overider1)
+        no_mismatches1 = stretch_body.hello_utils.overwrite_dict(overidee1, overider1)
         self.assertEqual(overidee1, {"robot": {"motion": {"max": 100, "min": -100}}})
+        self.assertTrue(no_mismatches1)
 
         overider2 = {"robot": {"motion": {"max": 100}}}
         overidee2 = {"robot": {"motion": {"min": -100}}}

--- a/body/test/test_hello_utils.py
+++ b/body/test/test_hello_utils.py
@@ -82,16 +82,16 @@ class TestHelloUtils(unittest.TestCase):
     def test_overwriting_vs_updating_params(self):
         """Verify the difference between overwrite_dict and updating a dict.
         """
-        overider1 = {"robot": {"motion": {"max": 100}}}
         overidee1 = {"robot": {"motion": {"min": -100}}}
+        overider1 = {"robot": {"motion": {"max": 100}}}
         no_mismatches1 = stretch_body.hello_utils.overwrite_dict(overidee1, overider1)
         self.assertEqual(overidee1, {"robot": {"motion": {"max": 100, "min": -100}}})
         self.assertTrue(no_mismatches1)
 
-        overider2 = {"robot": {"motion": {"max": 100}}}
         overidee2 = {"robot": {"motion": {"min": -100}}}
+        overider2 = {"robot": {"motion": {"max": 100}}}
         overidee2.update(overider2)
-        self.assertNotEqual(overidee1, overidee2)
+        self.assertNotEqual(overidee2, {"robot": {"motion": {"max": 100, "min": -100}}})
 
     def test_pretty_print_dict(self):
         dict1 = {"param1": 1, "param2": 2}

--- a/body/test/test_hello_utils.py
+++ b/body/test/test_hello_utils.py
@@ -5,6 +5,7 @@ import time
 import math
 import random
 import warnings
+from collections import defaultdict
 
 
 class TestHelloUtils(unittest.TestCase):
@@ -51,6 +52,24 @@ class TestHelloUtils(unittest.TestCase):
         der5 = {'param1': {'motion': 2}}
         stretch_body.hello_utils.overwrite_dict(dee5, der5)
         self.assertEqual(dee5, {'param1': {'motion': {}, 'no_change': 1}})
+
+        dee6 = {'param1': {'motion': 1}}
+        der6 = {'param1': {'motion': 'stringtype'}}
+        stretch_body.hello_utils.overwrite_dict(dee6, der6)
+        self.assertEqual(dee6, {'param1': {'motion': 1}})
+
+        # int and float and overwrite each other
+        dee7 = {'param1': {'motion': 1}}
+        der7 = {'param1': {'motion': 2.0}}
+        stretch_body.hello_utils.overwrite_dict(dee7, der7)
+        self.assertEqual(dee7, {'param1': {'motion': 2.0}})
+
+        dee8 = {'param1': {'param2': 0}}
+        param2dict = defaultdict()
+        param2dict['param2'] = 2
+        der8 = {'param1': param2dict}
+        stretch_body.hello_utils.overwrite_dict(dee8, der8)
+        self.assertEqual(dee8, {'param1': {'param2': 2}})
 
     def test_overwriting_vs_updating_params(self):
         """Verify the difference between overwrite_dict and updating a dict.


### PR DESCRIPTION
This PR enables the `stretch_body.hello_utils.overwrite_dict(...)` method to overwrite dictionaries with subtypes of dictionary, such as a `defaultdict` or `OrderedDict` from the `collections` package. It also allowed the method to report if any type mismatches were found in a return value. Finally, the related unit tests are updated and a docstring is added to the method.