### PR TITLE
Feature/alt usb names

### DIFF
--- a/body/stretch_body/arm.py
+++ b/body/stretch_body/arm.py
@@ -11,8 +11,8 @@ class Arm(PrismaticJoint):
     """
     API to the Stretch Arm
     """
-    def __init__(self):
-        PrismaticJoint.__init__(self, 'arm')
+    def __init__(self,usb=None):
+        PrismaticJoint.__init__(self, name='arm',usb=usb)
 
     # ######### Utilties ##############################
 

--- a/body/stretch_body/base.py
+++ b/body/stretch_body/base.py
@@ -12,10 +12,14 @@ class Base(Device):
     """
     API to the Stretch Mobile Base
     """
-    def __init__(self):
+    def __init__(self, usb_left=None, usb_right=None):
         Device.__init__(self, 'base')
-        self.left_wheel = Stepper(usb='/dev/hello-motor-left-wheel')
-        self.right_wheel = Stepper(usb='/dev/hello-motor-right-wheel')
+        if usb_left is None:
+            usb_left = self.params['usb_name_left_wheel']
+        if usb_right is None:
+            usb_right = self.params['usb_name_right_wheel']
+        self.left_wheel = Stepper(usb=usb_left, name='hello-motor-left-wheel')
+        self.right_wheel = Stepper(usb=usb_right, name='hello-motor-right-wheel')
         self.status = {'timestamp_pc':0,'x':0,'y':0,'theta':0,'x_vel':0,'y_vel':0,'theta_vel':0, 'pose_time_s':0,'effort': [0, 0], 'left_wheel': self.left_wheel.status, 'right_wheel': self.right_wheel.status, 'translation_force': 0, 'rotation_torque': 0}
         self.trajectory = DiffDriveTrajectory()
         self._waypoint_lwpos = None

--- a/body/stretch_body/dynamixel_hello_XL430.py
+++ b/body/stretch_body/dynamixel_hello_XL430.py
@@ -53,7 +53,7 @@ class DynamixelHelloXL430(Device):
     """
     Abstract the Dynamixel X-Series to handle calibration, radians, etc
     """
-    def __init__(self, name, chain=None):
+    def __init__(self, name, chain=None, usb=None):
         Device.__init__(self, name)
         try:
             self.chain = chain
@@ -66,10 +66,13 @@ class DynamixelHelloXL430(Device):
             self._waypoint_ts = None
             self._waypoint_vel = self.params['motion']['trajectory_max']['vel_r']
             self._waypoint_accel = self.params['motion']['trajectory_max']['accel_r']
+            self.usb = usb
+            if self.usb is None:
+                self.usb = self.params['usb_name']
 
             #Share bus resource amongst many XL430s
             self.motor = DynamixelXL430(dxl_id=self.params['id'],
-                                        usb=self.params['usb_name'],
+                                        usb=self.usb,
                                         port_handler=None if chain is None else chain.port_handler,
                                         pt_lock=None if chain is None else chain.pt_lock,
                                         baud=self.params['baud'],

--- a/body/stretch_body/end_of_arm.py
+++ b/body/stretch_body/end_of_arm.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 from stretch_body.dynamixel_X_chain import DynamixelXChain
 import importlib
+from stretch_body.robot_params import RobotParams
 
 class EndOfArm(DynamixelXChain):
     """
@@ -10,8 +11,10 @@ class EndOfArm(DynamixelXChain):
     simply deriving it from DynamixelHelloXL430 and declaring the class name / Python module name
     in the User YAML file
     """
-    def __init__(self, name='end_of_arm'):
-        DynamixelXChain.__init__(self, usb='/dev/hello-dynamixel-wrist', name=name)
+    def __init__(self, name='end_of_arm', usb=None):
+        if usb is None:
+            usb = RobotParams.get_params()[1]['end_of_arm']['usb_name']
+        DynamixelXChain.__init__(self, usb=usb, name=name)
         self.joints = self.params.get('devices', {}).keys()
         for j in self.joints:
             module_name = self.params['devices'][j]['py_module_name']

--- a/body/stretch_body/head.py
+++ b/body/stretch_body/head.py
@@ -2,13 +2,16 @@ from __future__ import print_function
 from stretch_body.dynamixel_hello_XL430 import DynamixelHelloXL430
 from stretch_body.hello_utils import *
 from stretch_body.dynamixel_X_chain import DynamixelXChain
+from stretch_body.robot_params import RobotParams
 
 class Head(DynamixelXChain):
     """
     API to the Stretch RE1 Head
     """
-    def __init__(self):
-        DynamixelXChain.__init__(self, usb='/dev/hello-dynamixel-head', name='head')
+    def __init__(self, usb=None):
+        if usb is None:
+            usb = RobotParams.get_params()[1]['head']['usb_name']
+        DynamixelXChain.__init__(self, usb=usb, name='head')
         self.joints = ['head_pan', 'head_tilt']
         for j in self.joints:
             self.add_motor(DynamixelHelloXL430(name=j, chain=self))

--- a/body/stretch_body/lift.py
+++ b/body/stretch_body/lift.py
@@ -11,8 +11,8 @@ class Lift(PrismaticJoint):
     """
     API to the Stretch Lift
     """
-    def __init__(self):
-        PrismaticJoint.__init__(self, 'lift')
+    def __init__(self,usb=None):
+        PrismaticJoint.__init__(self, name='lift',usb=usb)
 
     # ######### Utilties ##############################
 

--- a/body/stretch_body/pimu.py
+++ b/body/stretch_body/pimu.py
@@ -161,7 +161,7 @@ class PimuBase(Device):
     TRIGGER_LIGHTBAR_TEST = 1024
 
 
-    def __init__(self, event_reset=False):
+    def __init__(self, event_reset=False, usb=None):
         Device.__init__(self, 'pimu')
         self.config = self.params['config']
         self.lock = threading.RLock()
@@ -170,7 +170,9 @@ class PimuBase(Device):
         self._dirty_trigger = False
         self.frame_id_last = None
         self.frame_id_base = 0
-        self.transport = Transport(usb='/dev/hello-pimu', logger=self.logger)
+        if usb is None:
+            usb='/dev/hello-pimu'
+        self.transport = Transport(usb=usb, logger=self.logger)
         self.status = {'voltage': 0, 'current': 0, 'temp': 0,'cpu_temp': 0, 'cliff_range':[0,0,0,0], 'frame_id': 0,
                        'timestamp': 0,'at_cliff':[False,False,False,False], 'runstop_event': False, 'bump_event_cnt': 0,
                        'cliff_event': False, 'fan_on': False, 'buzzer_on': False, 'low_voltage_alert':False,'high_current_alert':False,'over_tilt_alert':False,
@@ -588,8 +590,8 @@ class Pimu(PimuBase):
     """
     API to the Stretch Power and IMU board (Pimu)
     """
-    def __init__(self, event_reset=False):
-        PimuBase.__init__(self, event_reset)
+    def __init__(self, event_reset=False, usb=None):
+        PimuBase.__init__(self, event_reset,usb)
         # Order in descending order so more recent protocols/methods override less recent
         self.supported_protocols = {'p0': (Pimu_Protocol_P0,), 'p1': (Pimu_Protocol_P1,Pimu_Protocol_P0,)}
 

--- a/body/stretch_body/pimu.py
+++ b/body/stretch_body/pimu.py
@@ -171,7 +171,7 @@ class PimuBase(Device):
         self.frame_id_last = None
         self.frame_id_base = 0
         if usb is None:
-            usb='/dev/hello-pimu'
+            usb = self.params['usb_name']
         self.transport = Transport(usb=usb, logger=self.logger)
         self.status = {'voltage': 0, 'current': 0, 'temp': 0,'cpu_temp': 0, 'cliff_range':[0,0,0,0], 'frame_id': 0,
                        'timestamp': 0,'at_cliff':[False,False,False,False], 'runstop_event': False, 'bump_event_cnt': 0,

--- a/body/stretch_body/prismatic_joint.py
+++ b/body/stretch_body/prismatic_joint.py
@@ -14,8 +14,13 @@ class PrismaticJoint(Device):
     def __init__(self,name,usb=None):
         Device.__init__(self,name )
         if usb is None:
-            usb='/dev/hello-motor-'+name
-        self.motor = Stepper(usb=usb)
+            usb=self.params['usb_name']
+        motor_name = None
+        if name == 'lift':
+            motor_name = 'hello-motor-lift'
+        elif name == 'arm':
+            motor_name = 'hello-motor-arm'
+        self.motor = Stepper(usb=usb, name=motor_name)
         self.status = {'timestamp_pc':0,'pos': 0.0, 'vel': 0.0, 'force':0.0,'motor': self.motor.status}
         self.trajectory = PrismaticTrajectory()
         self.thread_rate_hz = 5.0

--- a/body/stretch_body/prismatic_joint.py
+++ b/body/stretch_body/prismatic_joint.py
@@ -11,9 +11,11 @@ class PrismaticJoint(Device):
     """
     API to the Stretch Prismatic Joints
     """
-    def __init__(self,name):
+    def __init__(self,name,usb=None):
         Device.__init__(self,name )
-        self.motor = Stepper(usb='/dev/hello-motor-'+name)
+        if usb is None:
+            usb='/dev/hello-motor-'+name
+        self.motor = Stepper(usb=usb)
         self.status = {'timestamp_pc':0,'pos': 0.0, 'vel': 0.0, 'force':0.0,'motor': self.motor.status}
         self.trajectory = PrismaticTrajectory()
         self.thread_rate_hz = 5.0

--- a/body/stretch_body/robot_params_RE1V0.py
+++ b/body/stretch_body/robot_params_RE1V0.py
@@ -583,7 +583,9 @@ nominal_params={
         'use_multiturn': 1,
         'retry_on_comm_failure': 1,
         'enable_runstop': 1,
-        'disable_torque_on_stop': 1}
+        'disable_torque_on_stop': 1},
+    'respeaker': {'usb_name': '/dev/hello-respeaker'},
+    'lidar': {'usb_name': '/dev/hello-lrf'}
 }
 # ###################### OLDER: FACTORY PARAMS #####################################################
 #The deprecated factory params dictionary for RE1.0 (5.1.2022)

--- a/body/stretch_body/robot_params_RE1V0.py
+++ b/body/stretch_body/robot_params_RE1V0.py
@@ -75,6 +75,7 @@ configuration_params_template={
 #Parameters that are common across the RE1.0 fleet
 nominal_params={
     'arm':{
+        'usb_name': '/dev/hello-motor-arm',
         'chain_pitch': 0.0167,
         'chain_sprocket_teeth': 10,
         'gr_spur': 3.875,
@@ -100,6 +101,8 @@ nominal_params={
                 'vel_m': 0.3,
                 'accel_m': 0.5}}},
     'base':{
+        'usb_name_left_wheel': '/dev/hello-motor-left-wheel',
+        'usb_name_right_wheel': '/dev/hello-motor-right-wheel',
         'force_N_per_A': 21.18, #Legacy
         'gr': 3.4,
         'motion':{
@@ -378,6 +381,7 @@ nominal_params={
             'vel': 25},
         'rated_current': 2.8},
     'lift':{
+        'usb_name': '/dev/hello-motor-lift',
         'belt_pitch_m': 0.005,
         'contact_models': {
             'effort_pct': {
@@ -403,6 +407,7 @@ nominal_params={
                 'accel_m': 0.3}},
         'pinion_t': 12},
     'pimu':{
+      'usb_name': '/dev/hello-pimu',
       'base_fan_off': 70,
       'base_fan_on': 82,
       'max_sync_rate_hz':20.0,
@@ -532,6 +537,7 @@ nominal_params={
         },
         'collision_models': ['collision_stretch_gripper']},
     'wacc':{
+        'usb_name': '/dev/hello-wacc',
         'config': {
         'accel_LPF': 10.0,
         'accel_range_g': 4,

--- a/body/stretch_body/robot_params_RE1V0.py
+++ b/body/stretch_body/robot_params_RE1V0.py
@@ -147,6 +147,7 @@ nominal_params={
         'warn_above_rate': 0.1,
         'verbose': 0},
     'end_of_arm':{
+        'usb_name': '/dev/hello-dynamixel-wrist',
         'devices':{
             'wrist_yaw':{
               'py_class_name': 'WristYaw',
@@ -156,6 +157,7 @@ nominal_params={
         'dxl_latency_timer': 64,
         'stow': {'wrist_yaw': 3.4}},
     'head':{
+        'usb_name': '/dev/hello-dynamixel-head',
         'use_group_sync_read': 1,
         'retry_on_comm_failure': 1,
         'dxl_latency_timer':64},

--- a/body/stretch_body/robot_params_RE2V0.py
+++ b/body/stretch_body/robot_params_RE2V0.py
@@ -428,7 +428,7 @@ nominal_params={
             'NonDXLStatusThread_sentry_downrate_int': 2,
             'NonDXLStatusThread_trajectory_downrate_int': 2},
         'tool': 'tool_stretch_gripper',
-        'use_collision_manager': 0,
+        'use_collision_manager': 1,
         'stow':{
         'arm': 0.0,
         'head_pan': 0.0,

--- a/body/stretch_body/robot_params_RE2V0.py
+++ b/body/stretch_body/robot_params_RE2V0.py
@@ -428,7 +428,7 @@ nominal_params={
             'NonDXLStatusThread_sentry_downrate_int': 2,
             'NonDXLStatusThread_trajectory_downrate_int': 2},
         'tool': 'tool_stretch_gripper',
-        'use_collision_manager': 1,
+        'use_collision_manager': 0,
         'stow':{
         'arm': 0.0,
         'head_pan': 0.0,

--- a/body/stretch_body/robot_params_RE2V0.py
+++ b/body/stretch_body/robot_params_RE2V0.py
@@ -584,5 +584,7 @@ nominal_params={
         'baud': 115200,
         'enable_runstop': 1,
         'disable_torque_on_stop': 1,
-        'range_pad_t': [50.0, -50.0]}
+        'range_pad_t': [50.0, -50.0]},
+    'respeaker': {'usb_name': '/dev/hello-respeaker'},
+    'lidar': {'usb_name': '/dev/hello-lrf'}
 }

--- a/body/stretch_body/robot_params_RE2V0.py
+++ b/body/stretch_body/robot_params_RE2V0.py
@@ -67,6 +67,7 @@ configuration_params_template={
 #Parameters that are common across the RE2 fleet
 nominal_params={
     'arm':{
+        'usb_name': '/dev/hello-motor-arm',
         'force_N_per_A': 55.9,  # Legacy
         'chain_pitch': 0.0167,
         'chain_sprocket_teeth': 10,
@@ -92,6 +93,8 @@ nominal_params={
                 'vel_m': 0.4,
                 'accel_m': 0.4}}},
     'base':{
+        'usb_name_left_wheel': '/dev/hello-motor-left-wheel',
+        'usb_name_right_wheel': '/dev/hello-motor-right-wheel',
         'force_N_per_A': 21.18,  # Legacy
         'gr': 3.8,
         'motion':{
@@ -375,6 +378,7 @@ nominal_params={
             'vel': 25},
         'rated_current': 2.8},
     'lift':{
+        'usb_name': '/dev/hello-motor-lift',
         'force_N_per_A': 75.0,  # Legacy
         'calibration_range_bounds': [1.094, 1.106],
         'contact_models': {
@@ -400,6 +404,7 @@ nominal_params={
               'vel_m': 0.15}},
           'pinion_t': 12},
     'pimu':{
+      'usb_name': '/dev/hello-pimu',
       'base_fan_off': 70,
       'base_fan_on': 82,
       'max_sync_rate_hz': 80.0,
@@ -532,6 +537,7 @@ nominal_params={
         },
         'collision_models': ['collision_stretch_gripper']},
     'wacc':{
+        'usb_name': '/dev/hello-wacc',
         'config': {
         'accel_LPF': 10.0,
         'accel_range_g': 4,

--- a/body/stretch_body/robot_params_RE2V0.py
+++ b/body/stretch_body/robot_params_RE2V0.py
@@ -139,6 +139,7 @@ nominal_params={
         'warn_above_rate': 0.1,
         'verbose': 0},
     'end_of_arm':{
+        'usb_name': '/dev/hello-dynamixel-wrist',
         'devices':{
             'wrist_yaw':{
               'py_class_name': 'WristYaw',
@@ -149,6 +150,7 @@ nominal_params={
         'dxl_latency_timer': 64,
         'stow': {'wrist_yaw': 3.4}},
     'head':{
+        'usb_name': '/dev/hello-dynamixel-head',
         'use_group_sync_read': 1,
         'retry_on_comm_failure': 1,
         'dxl_latency_timer':64,

--- a/body/stretch_body/stepper.py
+++ b/body/stretch_body/stepper.py
@@ -480,12 +480,13 @@ class StepperBase(Device):
         enc_data=read_fleet_yaml(fn)
         return enc_data
 
-    def write_encoder_calibration_to_YAML(self,data):
+    def write_encoder_calibration_to_YAML(self,data,filename=None, fleet_dir=None):
         device_name = self.usb[5:]
-        sn = self.robot_params[device_name]['serial_no']
-        fn = 'calibration_steppers/'+device_name + '_' + sn + '.yaml'
-        print('Writing encoder calibration: %s'%fn)
-        write_fleet_yaml(fn,data)
+        if filename is None:
+            sn = self.robot_params[device_name]['serial_no']
+            fn = 'calibration_steppers/'+device_name + '_' + sn + '.yaml'
+        print('Writing encoder calibration: %s'%filename)
+        write_fleet_yaml(filename,data,fleet_dir=fleet_dir)
 
     def read_encoder_calibration_from_flash(self):
         self.turn_menu_interface_on()
@@ -570,7 +571,10 @@ class StepperBase(Device):
             while self.transport.ser.inWaiting():
                 r=self.transport.ser.readline()
                 if do_print:
-                    print(r, end=' ')
+                    if type(r)==bytes:
+                        print(r.decode('UTF-8'), end=' ')
+                    else:
+                        print(r, end=' ')
                 reply.append(r)
             return reply
 
@@ -1038,8 +1042,8 @@ class Stepper(StepperBase):
     """
     API to the Stretch Stepper Board
     """
-    def __init__(self,usb):
-        StepperBase.__init__(self,usb)
+    def __init__(self,usb, name=None):
+        StepperBase.__init__(self,usb,name)
         # Order in descending order so more recent protocols/methods override less recent
         self.supported_protocols = {'p0': (Stepper_Protocol_P0,), 'p1': (Stepper_Protocol_P1,Stepper_Protocol_P0,)}
 

--- a/body/stretch_body/stepper.py
+++ b/body/stretch_body/stepper.py
@@ -430,7 +430,7 @@ class StepperBase(Device):
     def current_to_effort_ticks(self,i_A):
         if self.board_info['hardware_id']==0: # I = Vref / (10 * R), Rs = 0.10 Ohm, Vref = 3.3V -->3.3A
             mA_per_tick = (3300 / 255) / (10 * 0.1)
-        if self.board_info['hardware_id']==1: # I = Vref / (5 * R), Rs = 0.150 Ohm, Vref = 3.3V -->4.4A
+        if self.board_info['hardware_id']>=1: # I = Vref / (5 * R), Rs = 0.150 Ohm, Vref = 3.3V -->4.4A
             mA_per_tick = (3300 / 255) / (5 * 0.15)
         effort_ticks = (i_A * 1000.0) / mA_per_tick
         return min(255,max(-255,int(effort_ticks)))
@@ -438,7 +438,7 @@ class StepperBase(Device):
     def effort_ticks_to_current(self,e):
         if self.board_info['hardware_id'] == 0:  # I = Vref / (10 * R), Rs = 0.10 Ohm, Vref = 3.3V -->3.3A
             mA_per_tick = (3300 / 255) / (10 * 0.1)
-        if self.board_info['hardware_id'] == 1:  # I = Vref / (5 * R), Rs = 0.150 Ohm, Vref = 3.3V -->4.4A
+        if self.board_info['hardware_id'] >= 1:  # I = Vref / (5 * R), Rs = 0.150 Ohm, Vref = 3.3V -->4.4A
             mA_per_tick = (3300 / 255) / (5 * 0.15)
         return e * mA_per_tick / 1000.0
 

--- a/body/stretch_body/stepper.py
+++ b/body/stretch_body/stepper.py
@@ -98,8 +98,10 @@ class StepperBase(Device):
     TRIGGER_POS_CALIBRATED = 32
     TRIGGER_MARK_POS_ON_CONTACT=64
 
-    def __init__(self, usb):
-        Device.__init__(self, name=usb[5:])
+    def __init__(self, usb,name=None):
+        if name is None:
+            name=usb[5:] #Pull from usb device name
+        Device.__init__(self, name=name)
         self.usb=usb
         self.lock=threading.RLock()
         self.transport = Transport(usb=self.usb, logger=self.logger)

--- a/body/stretch_body/stepper.py
+++ b/body/stretch_body/stepper.py
@@ -484,7 +484,7 @@ class StepperBase(Device):
         device_name = self.usb[5:]
         if filename is None:
             sn = self.robot_params[device_name]['serial_no']
-            fn = 'calibration_steppers/'+device_name + '_' + sn + '.yaml'
+            filename = 'calibration_steppers/'+device_name + '_' + sn + '.yaml'
         print('Writing encoder calibration: %s'%filename)
         write_fleet_yaml(filename,data,fleet_dir=fleet_dir)
 

--- a/body/stretch_body/stretch_gripper.py
+++ b/body/stretch_body/stretch_gripper.py
@@ -10,8 +10,8 @@ class StretchGripper(DynamixelHelloXL430):
     The Pct ranges from approximately -100 (fully closed) to approximately +50 (fully open)
     A Pct of zero is the fingertips just touching
     """
-    def __init__(self, chain=None):
-        DynamixelHelloXL430.__init__(self, 'stretch_gripper', chain)
+    def __init__(self, chain=None, usb=None):
+        DynamixelHelloXL430.__init__(self, 'stretch_gripper', chain, usb)
         self.status['pos_pct']= 0.0
         self.pct_max_open=self.world_rad_to_pct(self.ticks_to_world_rad(self.params['range_t'][1])) #May be a bit greater than 50 given non-linear calibration
         self.poses = {'zero': 0,

--- a/body/stretch_body/wacc.py
+++ b/body/stretch_body/wacc.py
@@ -32,7 +32,7 @@ class WaccBase(Device):
 
     TRIGGER_BOARD_RESET = 1
 
-    def __init__(self, ext_status_cb=None, ext_command_cb=None):
+    def __init__(self, ext_status_cb=None, ext_command_cb=None, usb=None):
         Device.__init__(self, 'wacc')
         self.ext_status_cb=ext_status_cb
         self.ext_command_cb=ext_command_cb
@@ -40,7 +40,9 @@ class WaccBase(Device):
         self._dirty_config = True #Force push down
         self._dirty_command = False
         self._command = {'d2':0,'d3':0, 'trigger':0}
-        self.transport = Transport(usb='/dev/hello-wacc', logger=self.logger)
+        if usb is None:
+            usb='/dev/hello-wacc'
+        self.transport = Transport(usb=usb, logger=self.logger)
         self.status = { 'ax':0,'ay':0,'az':0,'a0':0,'d0':0,'d1':0, 'd2':0,'d3':0,'single_tap_count': 0, 'state':0, 'debug':0,
                        'timestamp': 0,
                        'transport': self.transport.status}
@@ -264,8 +266,8 @@ class Wacc(WaccBase):
     """
     API to the Stretch Wrist Accelerometer (Wacc) Board
     """
-    def __init__(self):
-        WaccBase.__init__(self)
+    def __init__(self, usb=None):
+        WaccBase.__init__(self, usb)
         #Order in descending order so more recent protocols/methods override less recent
         self.supported_protocols = {'p0': (Wacc_Protocol_P0,), 'p1': (Wacc_Protocol_P1,Wacc_Protocol_P0,)}
 

--- a/body/stretch_body/wacc.py
+++ b/body/stretch_body/wacc.py
@@ -267,7 +267,7 @@ class Wacc(WaccBase):
     API to the Stretch Wrist Accelerometer (Wacc) Board
     """
     def __init__(self, usb=None):
-        WaccBase.__init__(self, usb)
+        WaccBase.__init__(self, usb=usb)
         #Order in descending order so more recent protocols/methods override less recent
         self.supported_protocols = {'p0': (Wacc_Protocol_P0,), 'p1': (Wacc_Protocol_P1,Wacc_Protocol_P0,)}
 

--- a/body/stretch_body/wacc.py
+++ b/body/stretch_body/wacc.py
@@ -41,7 +41,7 @@ class WaccBase(Device):
         self._dirty_command = False
         self._command = {'d2':0,'d3':0, 'trigger':0}
         if usb is None:
-            usb='/dev/hello-wacc'
+            usb = self.params['usb_name']
         self.transport = Transport(usb=usb, logger=self.logger)
         self.status = { 'ax':0,'ay':0,'az':0,'a0':0,'d0':0,'d1':0, 'd2':0,'d3':0,'single_tap_count': 0, 'state':0, 'debug':0,
                        'timestamp': 0,

--- a/body/stretch_body/wrist_yaw.py
+++ b/body/stretch_body/wrist_yaw.py
@@ -8,8 +8,8 @@ class WristYaw(DynamixelHelloXL430):
     """
     API to the Stretch wrist yaw joint
     """
-    def __init__(self, chain=None):
-        DynamixelHelloXL430.__init__(self, 'wrist_yaw', chain)
+    def __init__(self, chain=None, usb=None):
+        DynamixelHelloXL430.__init__(self, 'wrist_yaw', chain, usb)
         self.poses = {'side': deg_to_rad(90.0),
                       'forward': deg_to_rad(0.0),
                       'stow': deg_to_rad(180.0)}

--- a/tools/bin/stretch_rp_lidar_jog.py
+++ b/tools/bin/stretch_rp_lidar_jog.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 from rplidar import *
 import argparse
 import stretch_body.hello_utils as hu
+from stretch_body.device import Device
 hu.print_stretch_re_use()
 
 parser=argparse.ArgumentParser(description='Tool to control the RP-Lidar')
@@ -15,7 +16,9 @@ parser.add_argument("--range", help="Print range reading",action="store_true")
 args=parser.parse_args()
 
 try:
-    lidar = RPLidar('/dev/hello-lrf')
+    lidar_dev = Device('lidar')
+    lidar_usb = lidar_dev.params['usb_name']
+    lidar = RPLidar(lidar_usb)
 except RPLidarException:
     print ('RPLidar not present')
     exit()


### PR DESCRIPTION
This PR modifies all the stretch body device classes to support initialization with alternative USB port address (e.g. `usb='/dev/ttyACM*'`) instead of the default `hello-*` symbolic device names defined.