### PR TITLE
fix missing downsample increment

### DIFF
--- a/body/stretch_body/robot.py
+++ b/body/stretch_body/robot.py
@@ -91,6 +91,7 @@ class NonDXLStatusThread(threading.Thread):
             self.stats.mark_loop_end()
             if not self.shutdown_flag.is_set():
                 time.sleep(self.stats.get_loop_sleep_time())
+            self.titr=self.titr+1
         self.robot.logger.debug('Shutting down NonDXLStatusThread')
 
 

--- a/body/stretch_body/version.py
+++ b/body/stretch_body/version.py
@@ -3,4 +3,4 @@
 # 2) we can import it in setup.py for the same reason
 # 3) we can import it into your module module
 
-__version__ = '0.4.15'
+__version__ = '0.4.16'


### PR DESCRIPTION
This PR fixes the missing thread loop counter in the Robot object. This was deleted at some point errorneously, resulting in all Device.steps() (eg, Monitor and Collision detection) running at full rate (25hz) instead of a slow rate (12Hz, 5hz, etc). It may impact the perfomance of splined trajectories which are now running at 12.5hz default (as intended) rather than 25hz.