### PR TITLE
Clean up of base trajectory startup and trajectory error reporting fo…

### DIFF
--- a/body/stretch_body/prismatic_joint.py
+++ b/body/stretch_body/prismatic_joint.py
@@ -38,9 +38,11 @@ class PrismaticJoint(Device):
 
     # ###########  Device Methods #############
     def startup(self, threaded=True):
-        Device.startup(self, threaded=threaded)
-        success= self.motor.startup(threaded=False)
-        self.__update_status()
+        # Startup stepper first so that status is populated before this Device thread begins (if threaded==true)
+        success = self.motor.startup(threaded=False)
+        if success:
+            Device.startup(self, threaded=threaded)
+            self.__update_status()
         return success
 
     def stop(self):

--- a/body/stretch_body/version.py
+++ b/body/stretch_body/version.py
@@ -3,4 +3,4 @@
 # 2) we can import it in setup.py for the same reason
 # 3) we can import it into your module module
 
-__version__ = '0.4.17'
+__version__ = '0.4.18'

--- a/tools/bin/stretch_trajectory_jog.py
+++ b/tools/bin/stretch_trajectory_jog.py
@@ -202,9 +202,6 @@ if args.base_translate or args.base_rotate:
     import stretch_body.base
     j = stretch_body.base.Base()
     j.startup(threaded=True)
-    j_req_calibration = False
-    j.first_step = True #Reset odometry
-    j.pull_status()
     j.right_wheel.disable_sync_mode()
     j.left_wheel.disable_sync_mode()
     j.push_command()


### PR DESCRIPTION
This PR fixes issue where base splined trajectory validation wasn't catching a simultaneous translate and rotate. 

It also cleans up the startup() of the lift, arm, and base so that the stepper status values are popluated before their thread starts. 

This was causing an issue where the odometery was being initialized with invalid stepper position data.