### PR TITLE
make monitor log on INFO and improve DXL warnings

### DIFF
--- a/body/stretch_body/dynamixel_hello_XL430.py
+++ b/body/stretch_body/dynamixel_hello_XL430.py
@@ -189,7 +189,24 @@ class DynamixelHelloXL430(Device):
                 self.is_calibrated=self.motor.is_calibrated()
                 self.check_homing_offset()
                 self.enable_torque()
+                #Pull 3 times given mux / init the status dict
                 self.pull_status()
+                self.pull_status()
+                self.pull_status()
+
+                if self.status['overload_error']:
+                    msg='WARNING: Servo %s in error state: overload_error. Servo requires reboot'%self.name
+                    print(msg)
+                    self.logger.warning(msg)
+                    self.hw_valid = False
+                    return False
+
+                if self.status['overheating_error'] :
+                    msg='WARNING: Servo %s in error state: overheating_error. Servo requires reboot'%self.name
+                    print(msg)
+                    self.logger.warning(msg)
+                    self.hw_valid = False
+                    return False
                 return True
             else:
                 self.logger.warning('DynamixelHelloXL430 Ping failed... %s' % self.name)

--- a/body/stretch_body/robot_monitor.py
+++ b/body/stretch_body/robot_monitor.py
@@ -60,28 +60,28 @@ class RobotMonitor(Device):
     def monitor_base_cliff_event(self):
         if self.robot.pimu is not None:
             if self.robot.pimu.status['cliff_event'] and  self.monitor_history['monitor_base_cliff_event']==0:
-                self.logger.debug("Base cliff event")
+                self.logger.info("Base cliff event")
             self.monitor_history['monitor_base_cliff_event'] = self.robot.pimu.status['cliff_event']
 
     # ##################################
     def monitor_base_bump_event(self):
         if self.robot.pimu is not None:
             if self.robot.pimu.status['bump_event_cnt'] != self.monitor_history['monitor_base_bump_event']:
-                self.logger.debug("Base bump event")
+                self.logger.info("Base bump event")
             self.monitor_history['monitor_base_bump_event'] = self.robot.pimu.status['bump_event_cnt']
 
     # ##################################
     def monitor_over_tilt_alert(self):
         if self.robot.pimu is not None:
             if self.robot.pimu.status['over_tilt_alert'] and self.monitor_history['monitor_over_tilt_alert'] == 0:
-                self.logger.debug("Over Tilt Alert")
+                self.logger.info("Over Tilt Alert")
             self.monitor_history['monitor_over_tilt_alert'] = self.robot.pimu.status['over_tilt_alert']
 
     # ##################################
     def monitor_wrist_single_tap(self):
         if self.robot.wacc is not None:
             if self.robot.wacc.status['single_tap_count']!=self.monitor_history['monitor_wrist_single_tap']:
-                self.logger.debug("Wrist single tap: %d" % self.robot.wacc.status['single_tap_count'])
+                self.logger.info("Wrist single tap: %d" % self.robot.wacc.status['single_tap_count'])
             self.monitor_history['monitor_wrist_single_tap']=self.robot.wacc.status['single_tap_count']
 
     # ##################################
@@ -94,7 +94,7 @@ class RobotMonitor(Device):
                     self.monitor_history[mn][j.name] = 0
                 if j is not None:
                     if self.monitor_history[mn][j.name]==0 and j.motor.status['in_guarded_event']:
-                        self.logger.debug("Guarded contact %s"%j.name)
+                        self.logger.info("Guarded contact %s"%j.name)
                 self.monitor_history[mn][j.name] =j.motor.status['in_guarded_event']
 
     # ##################################
@@ -115,16 +115,16 @@ class RobotMonitor(Device):
                 for k in c.motors.keys():
                     for e in errs:
                         if c.motors[k].status[e] and not self.monitor_history[mn][c.name][k][e]:
-                            self.logger.debug("Dynamixel %s on %s:%s"%(e,c.name,k))
+                            self.logger.info("Dynamixel %s on %s:%s"%(e,c.name,k))
                         self.monitor_history[mn][c.name][k][e] = c.motors[k].status[e]
 
     # ##################################
     def monitor_runstop(self):
         if self.robot.status['pimu']['runstop_event'] != self.monitor_history['monitor_runstop']:
             if self.robot.status['pimu']['runstop_event']:
-                self.logger.debug("Runstop activated")
+                self.logger.info("Runstop activated")
             else:
-                self.logger.debug("Runstop deactivated")
+                self.logger.info("Runstop deactivated")
         self.monitor_history['monitor_runstop']=self.robot.status['pimu']['runstop_event']
 
     # ##################################
@@ -132,7 +132,7 @@ class RobotMonitor(Device):
         v=self.robot.pimu.status['voltage']
         if v < self.robot.pimu.config['low_voltage_alert']:
             if v-self.monitor_history['monitor_voltage']<-0.5:#every 0.5V of drop allow to report
-                self.logger.debug('Low voltage of: %.2f'%v)
+                self.logger.info('Low voltage of: %.2f'%v)
                 self.monitor_history['monitor_voltage']=v
         else:
             self.monitor_history['monitor_voltage'] =v
@@ -142,7 +142,7 @@ class RobotMonitor(Device):
         i=self.robot.pimu.status['current']
         if i > self.robot.pimu.config['high_current_alert']:
             if i-self.monitor_history['monitor_current']>0.25:#every 0.25A of rise allow to report
-                self.logger.debug('High current of: %.2f'%i)
+                self.logger.info('High current of: %.2f'%i)
                 self.monitor_history['monitor_current']=i
         else:
             self.monitor_history['monitor_current'] =i

--- a/tools/bin/stretch_robot_monitor.py
+++ b/tools/bin/stretch_robot_monitor.py
@@ -1,15 +1,18 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from __future__ import print_function
+import stretch_body.robot_params
+#stretch_body.robot_params.RobotParams.set_logging_level("DEBUG")
 from stretch_body.robot import Robot
 from stretch_body.hello_utils import *
 import argparse
 print_stretch_re_use()
+import time
 
 parser=argparse.ArgumentParser(description='Run the Robot Monitor and print to console')
 args=parser.parse_args()
 
 r=Robot()
-r.params['log_to_console']=1
+
 print('Starting Robot Monitor. Ctrl-C to exit')
 r.startup()
 


### PR DESCRIPTION
This makes the Monitor messages log at INFO level so that they display to the console by default. While this clutters the command line it will also help users catch issues quicker.