### PR TITLE
update how the trigger motor sync is handled

### DIFF
--- a/body/stretch_body/hello_utils.py
+++ b/body/stretch_body/hello_utils.py
@@ -58,6 +58,7 @@ def set_fleet_directory(fleet_path,fleet_id):
     os.environ['HELLO_FLEET_ID'] = fleet_id
     os.environ['HELLO_FLEET_PATH'] = fleet_path
 
+
 def get_stretch_directory(sub_directory=''):
     """Returns path to stretch_user dir if HELLO_FLEET_PATH env var exists
 

--- a/body/stretch_body/stepper.py
+++ b/body/stretch_body/stepper.py
@@ -179,6 +179,9 @@ class StepperBase(Device):
             self.transport.stop()
             self.hw_valid = False
 
+    def is_sync_required(self,ts_last_sync):
+        return self.status['in_sync_mode'] and self.ts_last_syncd_motion>ts_last_sync
+
     def push_command(self,exiting=False):
         if not self.hw_valid:
             return


### PR DESCRIPTION
This PR modifies how the trigger_motor_sync is handled. Previously the method that computed the rate at which the sync was triggered was inaccurate as it could vary per lock acquisition time, RPC communication time, etc. Now the trigger is measured relative to the call to push_command in Robot. The code below verifies that calling push_command at 20Hz no longer generates Trigger Motor Sync warnings.

```
#!/usr/bin/env python3

import time
import stretch_body.robot


def run_at_rate(target_rate, n=1000000, inner_work=lambda: None, outer_work=lambda: None):
    init = time.time()
    prev = init
    for i in range(n):
        outer_work()
        curr = time.time()
        diff = curr - prev
        if diff > (1 / target_rate):
            rate = None if diff == 0.0 else 1 / diff
            print('###########')
            print(f'LOOP! prev={prev - init:.2f} curr={curr - init:.2f} rate={rate:.2f} i={i}')
            print('Dropped: %d Rate: %f'%(r.pimu.status['motor_sync_drop'],r.pimu.status['motor_sync_rate']))
            inner_work()
            prev = time.time()

r=stretch_body.robot.Robot()
r.startup()

def move():
    r.lift.move_to(0.5)
    r.push_command()


def foo():
    pass


try:
    print('---------------')
    run_at_rate(target_rate=20.0, n=10000000, inner_work=move, outer_work=foo)
except (SystemExit, KeyboardInterrupt):
    r.stop()```