### PR TITLE
Default to low contact sensitivity

### DIFF
--- a/body/stretch_body/prismatic_joint.py
+++ b/body/stretch_body/prismatic_joint.py
@@ -26,6 +26,7 @@ class PrismaticJoint(Device):
         self.thread_rate_hz = 5.0
 
         # Default controller params
+        self.thresh_param_set = self.params['contact_models']['effort_pct']['thresh_param_set']
         self.stiffness = 1.0
         self.i_feedforward=self.params['i_feedforward']
         self.vel_r = self.translate_m_to_motor_rad(self.params['motion']['default']['vel_m'])
@@ -130,8 +131,8 @@ class PrismaticJoint(Device):
         """
         This model converts from a specified percentage effort (-100 to 100) in the motor frame to motor currents
         """
-        e_cn = self.params['contact_models']['effort_pct']['contact_thresh_default'][0] if contact_thresh_neg is None else contact_thresh_neg
-        e_cp = self.params['contact_models']['effort_pct']['contact_thresh_default'][1] if contact_thresh_neg is None else contact_thresh_pos
+        e_cn = self.params['contact_models']['effort_pct'][self.thresh_param_set][0] if contact_thresh_neg is None else contact_thresh_neg
+        e_cp = self.params['contact_models']['effort_pct'][self.thresh_param_set][1] if contact_thresh_neg is None else contact_thresh_pos
         i_contact_neg = self.motor.effort_pct_to_current(max(e_cn, self.params['contact_models']['effort_pct']['contact_thresh_max'][0]))
         i_contact_pos = self.motor.effort_pct_to_current(min(e_cp, self.params['contact_models']['effort_pct']['contact_thresh_max'][1]))
         return i_contact_pos, i_contact_neg

--- a/body/stretch_body/robot_params_RE1V0.py
+++ b/body/stretch_body/robot_params_RE1V0.py
@@ -83,7 +83,11 @@ nominal_params={
         'force_N_per_A': 55.9, #Legacy
         'calibration_range_bounds': [0.514, 0.525],
         'contact_models':{
-            'effort_pct': {'contact_thresh_calibration_margin':10.0,'contact_thresh_max': [-90.0, 90.0]}},
+            'effort_pct': {
+                'thresh_param_set': 'contact_thresh_low_sensitivity',
+                'contact_thresh_calibration_margin':10.0,
+                'contact_thresh_low_sensitivity': [-45.0, 65.0],
+                'contact_thresh_max': [-90.0, 90.0]}},
         'motion':{
             'default':{
                 'accel_m': 0.14,
@@ -391,7 +395,9 @@ nominal_params={
         'belt_pitch_m': 0.005,
         'contact_models': {
             'effort_pct': {
+                'thresh_param_set': 'contact_thresh_low_sensitivity',
                 'contact_thresh_calibration_margin': 10.0,
+                'contact_thresh_low_sensitivity': [-45.0, 65.0],
                 'contact_thresh_max': [-100, 100]}},
         'calibration_range_bounds': [1.094, 1.106],
         'force_N_per_A': 75.0, #Legacy

--- a/body/stretch_body/robot_params_RE2V0.py
+++ b/body/stretch_body/robot_params_RE2V0.py
@@ -75,7 +75,11 @@ nominal_params={
         'i_feedforward': 0,
         'calibration_range_bounds':[0.514, 0.525],
         'contact_models':{
-            'effort_pct': {'contact_thresh_calibration_margin':10.0,'contact_thresh_max': [-90.0, 90.0]}},
+            'effort_pct': {
+                'thresh_param_set': 'contact_thresh_low_sensitivity',
+                'contact_thresh_calibration_margin':10.0,
+                'contact_thresh_low_sensitivity': [-45.0, 65.0],
+                'contact_thresh_max': [-90.0, 90.0]}},
         'motion':{
             'default':{
                 'accel_m': 0.14,
@@ -389,7 +393,9 @@ nominal_params={
         'calibration_range_bounds': [1.094, 1.106],
         'contact_models': {
             'effort_pct':{
+                'thresh_param_set': 'contact_thresh_low_sensitivity',
                 'contact_thresh_calibration_margin': 10.0,
+                'contact_thresh_low_sensitivity': [-45.0, 65.0],
                 'contact_thresh_max': [-100, 100]}},
         'belt_pitch_m': 0.005,
           'motion':{

--- a/tools/bin/stretch_xbox_controller_teleop.py
+++ b/tools/bin/stretch_xbox_controller_teleop.py
@@ -557,6 +557,8 @@ def main():
     xbox_controller.start()
     check_usb_devices(wait_timeout=5)
     robot = rb.Robot()
+    robot.arm.thresh_param_set = 'contact_thresh_default'
+    robot.lift.thresh_param_set = 'contact_thresh_default'
     try:
         robot.startup()
         print('Using key mapping for tool: %s' % robot.end_of_arm.name)


### PR DESCRIPTION
In this PR, Stretch Body is configured to use a "low sensitivity" pair of positive/negative contact thresholds by default. This new default will mean the robot will report a lower rate of false positive contact detections, at the cost of lower contact sensitivity. For most applications, this is good tradeoff to make. For applications that require higher contact sensitivity, they can change the `thresh_param_set` parameter in user YAML to use the calibrated set of contact thresholds. This would look like:

```yaml
lift:
  contact_models:
    effort_pct:
      thresh_param_set: 'contact_thresh_default'
```

It's also possible to change the `thresh_param_set` at runtime by changing the `robot.<arm/lift>.thresh_param_set` attribute. The edit to `stretch_xbox_controller_teleop.py` in this PR uses this approach to run xbox teleop with the higher sensitivity contact thresholds, because that script is often uses to demo contact sensitivity of the arm and lift.