### PR TITLE
Modify the devices Protocol class expansion through setattr() method

### DIFF
--- a/body/stretch_body/stepper.py
+++ b/body/stretch_body/stepper.py
@@ -1293,8 +1293,8 @@ class Stepper(StepperBase):
                                     'p2': (Stepper_Protocol_P2,Stepper_Protocol_P1,Stepper_Protocol_P0,),
                                     'p3': (Stepper_Protocol_P3,Stepper_Protocol_P2,Stepper_Protocol_P1,Stepper_Protocol_P0,)}
     
-    def expand_exclusive_methods(self, exclusive_class):
-        for attr_name, attr_value in exclusive_class.__dict__.items():
+    def expand_protocol_methods(self, protocol_class):
+        for attr_name, attr_value in protocol_class.__dict__.items():
             if callable(attr_value) and not attr_name.startswith("__"):
                 setattr(self, attr_name, attr_value.__get__(self, Stepper))
                 
@@ -1308,7 +1308,7 @@ class Stepper(StepperBase):
             if self.board_info['protocol_version'] in self.supported_protocols:
                 protocol_classes = self.supported_protocols[self.board_info['protocol_version']]
                 for p in protocol_classes[::-1]:
-                    self.expand_exclusive_methods(p)
+                    self.expand_protocol_methods(p)
             else:
                 if self.board_info['protocol_version'] is None:
                     protocol_msg = """

--- a/body/stretch_body/stepper.py
+++ b/body/stretch_body/stepper.py
@@ -1286,7 +1286,6 @@ class Stepper(StepperBase):
     API to the Stretch Stepper Board
     """
     def __init__(self,usb, name=None):
-        print(f"Initiated {name}......")
         StepperBase.__init__(self,usb,name)
         # Order in descending order so more recent protocols/methods override less recent
         self.supported_protocols = {'p0': (Stepper_Protocol_P0,),
@@ -1302,9 +1301,8 @@ class Stepper(StepperBase):
     def startup(self, threaded=False):
         """
         First determine which protocol version the uC firmware is running.
-        Based on that version, replaces PimuBase class inheritance with a inheritance to a child class of PimuBase that supports that protocol
+        Based on that version, populates Stepper class with the supported specific Stepper_protocol_P* class methods.
         """
-        print(f"Starting [{self.name}]")
         StepperBase.startup(self, threaded=threaded)
         if self.hw_valid:
             if self.board_info['protocol_version'] in self.supported_protocols:


### PR DESCRIPTION
## Addresses Issue
This PR addresses the [`Stepper`](https://github.com/hello-robot/stretch_body/blob/bugfix/exclusive_protocol_expand/body/stretch_body/stepper.py#L1284) class instances having the wrong protocol bases overwritten to all the other Stepper instances within the same process when different Firmware versions are present in the motors. Whenever the bases tuple of protocol classes is assigned to the [`Stepper.__bases__`](https://github.com/hello-robot/stretch_body/blob/feature/transport_v1_asyncio/body/stretch_body/stepper.py#L1304) of a specific instance, but all the instances of the [`Stepper`]() class's bases is overwritten, resulting in RPC errors. This is a Python Class Object instantiation behavior.
## Fix
The [`expand_protocol_methods()`](https://github.com/hello-robot/stretch_body/blob/bugfix/exclusive_protocol_expand/body/stretch_body/stepper.py#L1297) method is introduced to the `Stepper` class which would expand the class's methods by porting the methods from the supported Protocol Classes exclusive to each Stepper class object instance using the [`setattr()`](https://docs.python.org/3/library/functions.html#setattr) method.
