### PR TITLE
Velocity control for dxl joints + bugfixes

### DIFF
--- a/body/stretch_body/dynamixel_XL430.py
+++ b/body/stretch_body/dynamixel_XL430.py
@@ -764,6 +764,40 @@ class DynamixelXL430():
                 dxl_comm_result, dxl_error =   self.packet_handler.write2ByteTxRx(self.port_handler, self.dxl_id, XL430_ADDR_POS_I_GAIN, int(x))
         self.handle_comm_result('XL430_ADDR_POS_I_GAIN', dxl_comm_result, dxl_error)
 
+    def get_vel_I_gain(self):
+        if not self.hw_valid:
+            return 0
+        with self.pt_lock:
+            with DelayedKeyboardInterrupt():
+                p, dxl_comm_result, dxl_error = self.packet_handler.read2ByteTxRx(self.port_handler, self.dxl_id, XL430_ADDR_VELOCITY_I_GAIN)
+        self.handle_comm_result('XL430_ADDR_VELOCITY_I_GAIN', dxl_comm_result, dxl_error)
+        return p
+
+    def set_vel_I_gain(self,x):
+        if not self.hw_valid:
+            return
+        with self.pt_lock:
+            with DelayedKeyboardInterrupt():
+                dxl_comm_result, dxl_error =   self.packet_handler.write2ByteTxRx(self.port_handler, self.dxl_id, XL430_ADDR_VELOCITY_I_GAIN, int(x))
+        self.handle_comm_result('XL430_ADDR_VELOCITY_I_GAIN', dxl_comm_result, dxl_error)
+
+    def get_vel_P_gain(self):
+        if not self.hw_valid:
+            return 0
+        with self.pt_lock:
+            with DelayedKeyboardInterrupt():
+                p, dxl_comm_result, dxl_error = self.packet_handler.read2ByteTxRx(self.port_handler, self.dxl_id, XL430_ADDR_VELOCITY_P_GAIN)
+        self.handle_comm_result('XL430_ADDR_VELOCITY_P_GAIN', dxl_comm_result, dxl_error)
+        return p
+
+    def set_vel_P_gain(self,x):
+        if not self.hw_valid:
+            return
+        with self.pt_lock:
+            with DelayedKeyboardInterrupt():
+                dxl_comm_result, dxl_error =   self.packet_handler.write2ByteTxRx(self.port_handler, self.dxl_id, XL430_ADDR_VELOCITY_P_GAIN, int(x))
+        self.handle_comm_result('XL430_ADDR_VELOCITY_P_GAIN', dxl_comm_result, dxl_error)
+                
     def get_temperature_limit(self):
         if not self.hw_valid:
             return 0

--- a/body/stretch_body/dynamixel_XL430.py
+++ b/body/stretch_body/dynamixel_XL430.py
@@ -189,27 +189,31 @@ class DynamixelXL430():
             self.port_handler.closePort()
 
     def pretty_print(self):
-        print('-----XL430------')
-        print('ID', self.get_id())
-        print('Operating Mode',self.get_operating_mode())
-        print('Drive Mode', format(self.get_drive_mode(), '#010b'))
-        print('Temp: ', self.get_temp(), '°C')
-        print('Position', self.get_pos(), 'ticks')
-        print('Velocity',self.get_vel() * 0.229, 'rev/min')
-        print('Load ', self.get_load() * 0.1, '%')
-        print('PWM', self.get_pwm() * 0.113, '%')
-        print('Is Moving', self.is_moving() != 0)
-        print('Is Calibrated',self.is_calibrated() != 0)
-        print('Profile Velocity', self.get_profile_velocity() * 0.299, 'rev/min')
-        print('Profile Acceleration', self.get_profile_acceleration() * 214.577, 'rev/min^2')
-        h=self.get_hardware_error()
-        print('Hardware Error Status', format(h, '#010b'))
-        print('  Input Voltage Error: ', h & 1 != 0)
-        print('  Overheating Error: ',h & 4 != 0)
-        print('  Motor Encoder Error: ', h & 8 != 0)
-        print('  Electrical Shock Error: ', h & 16 != 0)
-        print('  Overload Error: ', h & 32 != 0)
-        print('Comm errors', self.comm_errors)
+        h = self.get_hardware_error()
+        status = {
+            'ID:': self.get_id(),
+            'Operating Mode:': self.get_operating_mode(),
+            'Drive Mode:': format(self.get_drive_mode(), '#010b'),
+            'Temperature:': f'{self.get_temp()} °C',
+            'Position:': f'{self.get_pos()} ticks',
+            'Velocity:': f'{self.get_vel() * 0.229:.3f} rev/min',
+            'Load:': f'{self.get_load() * 0.1:.3f} %',
+            'PWM:': f'{self.get_pwm() * 0.113:.3f} %',
+            'Is Moving:': str(self.is_moving() != 0),
+            'Is Calibrated:': str(self.is_calibrated() != 0),
+            'Profile Velocity:': f'{self.get_profile_velocity() * 0.299:.3f} rev/min',
+            'Profile Acceleration:': f'{self.get_profile_acceleration() * 214.577:.3f} rev/min^2',
+            'Hardware Error Status:': format(h, '#010b'),
+            '  Input Voltage Error:': str(h & 1 != 0),
+            '  Overheating Error: ': str(h & 4 != 0),
+            '  Motor Encoder Error:': str(h & 8 != 0),
+            '  Electrical Shock Error:': str(h & 16 != 0),
+            '  Overload Error:': str(h & 32 != 0),
+            '# Communication Errors:': self.comm_errors,
+        }
+        print('------------------- XL430 -------------------')
+        for elem, value in status.items():
+            print(f"{elem: <25}{value: >20}")
 
     # ##########################################
 

--- a/body/stretch_body/dynamixel_XL430.py
+++ b/body/stretch_body/dynamixel_XL430.py
@@ -108,15 +108,21 @@ class DelayedKeyboardInterrupt:
 
     def __enter__(self):
         self.signal_received = False
-        self.old_handler = signal.signal(signal.SIGINT, self.handler)
+        try:
+            self.old_handler = signal.signal(signal.SIGINT, self.handler)
+        except ValueError:
+            pass
 
     def handler(self, sig, frame):
         self.signal_received = (sig, frame)
 
     def __exit__(self, type, value, traceback):
-        signal.signal(signal.SIGINT, self.old_handler)
-        if self.signal_received:
-            self.old_handler(*self.signal_received)
+        try:
+            signal.signal(signal.SIGINT, self.old_handler)
+            if self.signal_received:
+                self.old_handler(*self.signal_received)
+        except (ValueError,AttributeError):
+            pass
 
 class DynamixelCommError(Exception):
     pass

--- a/body/stretch_body/dynamixel_XL430.py
+++ b/body/stretch_body/dynamixel_XL430.py
@@ -239,10 +239,10 @@ class DynamixelXL430():
             return True
 
         self.last_comm_success = False
-        self.comm_errors = self.comm_errors + 1
-        self.logger.debug('DXL Comm Error on %s ID %d. Attempted %s. Result %d. Error %d. Code %s. Total Errors %d.' %
-            (self.usb, self.dxl_id, fx, dxl_comm_result, dxl_error, COMM_CODES[dxl_comm_result], self.comm_errors))
-        raise DynamixelCommError
+        self.comm_errors += 1
+        comm_error_msg = f'DXL Comm Error on {self.usb} ID {self.dxl_id}. Attempted {fx}. Result {COMM_CODES[dxl_comm_result]}. Error {dxl_error}. Total Errors {self.comm_errors}.'
+        self.logger.debug(comm_error_msg)
+        raise DynamixelCommError(comm_error_msg)
 
 
     def get_comm_errors(self):

--- a/body/stretch_body/dynamixel_XL430.py
+++ b/body/stretch_body/dynamixel_XL430.py
@@ -18,6 +18,8 @@ import dynamixel_sdk.group_sync_read as gsr
 # #########################
 # XL430-W250
 # http://emanual.robotis.com/docs/en/dxl/x/xl430-w250/#control-table
+# XM540-W270
+# https://emanual.robotis.com/docs/en/dxl/x/xm540-w270/#control-table
 
 
 # Control table address
@@ -190,23 +192,23 @@ class DynamixelXL430():
         print('-----XL430------')
         print('ID', self.get_id())
         print('Operating Mode',self.get_operating_mode())
-        print('Drive Mode', self.get_drive_mode())
-        print('Temp: ', self.get_temp())
-        print('Position', self.get_pos())
-        print('Velocity',self.get_vel())
-        print('Load ', self.get_load())
-        print('PWM', self.get_pwm())
-        print('Is Moving', self.is_moving())
-        print('Is Calibrated',self.is_calibrated())
-        print('Profile Velocity', self.get_profile_velocity())
-        print('Profile Acceleration', self.get_profile_acceleration())
+        print('Drive Mode', format(self.get_drive_mode(), '#010b'))
+        print('Temp: ', self.get_temp(), '°C')
+        print('Position', self.get_pos(), 'ticks')
+        print('Velocity',self.get_vel() * 0.229, 'rev/min')
+        print('Load ', self.get_load() * 0.1, '%')
+        print('PWM', self.get_pwm() * 0.113, '%')
+        print('Is Moving', self.is_moving() != 0)
+        print('Is Calibrated',self.is_calibrated() != 0)
+        print('Profile Velocity', self.get_profile_velocity() * 0.299, 'rev/min')
+        print('Profile Acceleration', self.get_profile_acceleration() * 214.577, 'rev/min^2')
         h=self.get_hardware_error()
-        print('Hardware Error Status', h)
-        print('Hardware Error: Input Voltage Error: ', h & 1 != 0)
-        print('Hardware Error: Overheating Error: ',h & 4 != 0)
-        print('Hardware Error: Motor Encoder Error: ', h & 8 != 0)
-        print('Hardware Error: Electrical Shock Error: ', h & 16 != 0)
-        print('Hardware Error: Overload Error: ', h & 32 != 0)
+        print('Hardware Error Status', format(h, '#010b'))
+        print('  Input Voltage Error: ', h & 1 != 0)
+        print('  Overheating Error: ',h & 4 != 0)
+        print('  Motor Encoder Error: ', h & 8 != 0)
+        print('  Electrical Shock Error: ', h & 16 != 0)
+        print('  Overload Error: ', h & 32 != 0)
         print('Comm errors', self.comm_errors)
 
     # ##########################################

--- a/body/stretch_body/dynamixel_hello_XL430.py
+++ b/body/stretch_body/dynamixel_hello_XL430.py
@@ -464,9 +464,6 @@ class DynamixelHelloXL430(Device):
         success = False
         for i in range(nretry):
             try:
-                self.motor.disable_torque()
-                self.motor.enable_vel()
-                self.motor.enable_torque()
                 t_des = self.world_rad_to_ticks_per_sec(v_des)
                 self.motor.set_vel(t_des)
                 success = True
@@ -476,6 +473,11 @@ class DynamixelHelloXL430(Device):
                 self.comm_errors.add_error(rx=True, gsr=False)
                 if self.bubble_up_comm_exception:
                     raise DynamixelCommError
+    
+    def enable_velocity_ctrl(self):
+            self.motor.disable_torque()
+            self.motor.enable_vel()
+            self.motor.enable_torque()
 
     def move_to(self,x_des, v_des=None, a_des=None):
         nretry = 2

--- a/body/stretch_body/dynamixel_hello_XL430.py
+++ b/body/stretch_body/dynamixel_hello_XL430.py
@@ -462,6 +462,8 @@ class DynamixelHelloXL430(Device):
             print('Dynamixel not calibrated:', self.name)
             return
         success = False
+        if self.motor.get_operating_mode()!=1:
+            self.enable_velocity_ctrl()
         for i in range(nretry):
             try:
                 t_des = self.world_rad_to_ticks_per_sec(v_des)

--- a/body/test/test_dxl_vel.py
+++ b/body/test/test_dxl_vel.py
@@ -1,4 +1,6 @@
+# Logging level must be set before importing any stretch_body class
 import stretch_body.robot_params
+stretch_body.robot_params.RobotParams.set_logging_level("DEBUG")
 import unittest
 from stretch_body import dynamixel_hello_XL430
 import time
@@ -45,7 +47,7 @@ class TestDynamixelVelocity(unittest.TestCase):
             if set_vel_method=="DynamixelXL430":
                 self.dynamixel.motor.set_vel(v_Des)
             self.dynamixel.pull_status()
-            # print(f"Target Vel: {vel} rad/s | Target V_Des: {v_Des} ticks/s | Monitor Vel_ticks: {self.dynamixel.status['vel_ticks']} rad/s")
+            print(f"Target Vel: {vel} rad/s | Target V_Des: {v_Des} ticks/s | Monitor Vel_ticks: {self.dynamixel.status['vel_ticks']} rad/s")
             time.sleep(0.05)
             
         self.dynamixel.pull_status()
@@ -63,12 +65,14 @@ class TestDynamixelVelocity(unittest.TestCase):
         """
         Test the Higher level DynamixelHelloXL430()->set_velocity()
         """
+        print("Testing the Higher-Level DynamixelHelloXL430.set_velocity() method.")
         self.velocity_control_test(set_vel_method="DynamixelHelloXL430")
     
     def test_DynamixelXL430_set_vel(self):
         """
         Test the Lower level DynamixelXL430()->set_vel()
         """
+        print("Testing the Lower-Level DynamixelXL430.set_vel() method.")
         self.dynamixel.motor.disable_torque()
         self.dynamixel.motor.enable_vel()
         self.dynamixel.motor.enable_torque()

--- a/body/test/test_dxl_vel.py
+++ b/body/test/test_dxl_vel.py
@@ -28,10 +28,9 @@ class TestDynamixelVelocity(unittest.TestCase):
         self.dynamixel.stop()
     
     def velocity_control_test(self, set_vel_method):
-        
-        print("\n\nStarting Constant Velocity Control...")
         max_vel = self.dynamixel.motor.get_vel_limit()
         print(f"Vel Limit: {max_vel} ticks/s | {degrees(self.dynamixel.ticks_to_rad(max_vel))} deg/s")
+        print(f"Vel gains P: {self.dynamixel.motor.get_vel_P_gain()} | I: {self.dynamixel.motor.get_vel_I_gain()}")
         
         # rotate X deg in Ts with constant Vel i.e. X == Vel*total_time
         X = 1.57 #rad (90 deg)
@@ -40,6 +39,7 @@ class TestDynamixelVelocity(unittest.TestCase):
 
         self.dynamixel.pull_status()
         start_pos = self.dynamixel.status['pos']
+        print("\n\nStarting Constant Velocity Control...")
         print(f"Start pos: {start_pos} rad")
         start = time.time()
         while time.time()-start < total_time:

--- a/body/test/test_dxl_vel.py
+++ b/body/test/test_dxl_vel.py
@@ -1,0 +1,75 @@
+import stretch_body.robot_params
+import unittest
+from stretch_body import dynamixel_hello_XL430
+import time
+
+
+class TestDynamixelVelocity(unittest.TestCase):
+    """
+    This script tests the accuracy of velocity control interface for Dynamixel servos
+    The test is designed to rotate the wrist_yaw joint at a constant velocity for given period time
+    and is expected to cover the distance==velocity*time.
+    This tests the higher level DynamixelHelloXL430()->set_velocity() and the lower level DynamixelXL430()->set_vel()
+    """
+    
+    @classmethod
+    def setUpClass(self):
+        self.dynamixel = dynamixel_hello_XL430.DynamixelHelloXL430('wrist_yaw')
+        self.dynamixel.startup()
+        if not self.dynamixel.is_calibrated:
+            self.dynamixel.home()
+        while self.dynamixel.is_homing:
+            time.sleep(0.1)
+            
+    @classmethod
+    def tearDownClass(self):
+        self.dynamixel.stop()
+    
+    def velocity_control_test(self, set_vel_method):
+        
+        print("\n\nStarting Constant Velocity Control...")
+        print(f"Vel Limit: {self.dynamixel.motor.get_vel_limit()} ticks/s")
+        
+        # rotate 90deg in 5s i.e. 1.57 rad == vel*total_time
+        vel = 0.314 #rad 
+        total_time = 5 #s
+
+        self.dynamixel.pull_status()
+        start_pos = self.dynamixel.status['pos']
+        print(f"Start pos: {start_pos} rad")
+        start = time.time()
+        while time.time()-start < total_time:
+            v_Des = self.dynamixel.world_rad_to_ticks_per_sec(vel)
+            if set_vel_method=="DynamixelHelloXL430":
+                self.dynamixel.set_velocity(vel) 
+            if set_vel_method=="DynamixelXL430":
+                self.dynamixel.motor.set_vel(v_Des)
+            self.dynamixel.pull_status()
+            # print(f"Target Vel: {vel} rad/s | Target V_Des: {v_Des} ticks/s | Monitor Vel_ticks: {self.dynamixel.status['vel_ticks']} rad/s")
+            time.sleep(0.05)
+            
+        self.dynamixel.pull_status()
+        end_pos = self.dynamixel.status['pos']
+
+        print(f"End pos: {end_pos} rad")
+        print(f"\nTotal Rotation: {abs(start_pos-end_pos)} rad | Expected: {vel*total_time} rad")
+        print(f"Avg Velocity: {abs(end_pos-start_pos)/total_time} rad/s | Expected: {vel} rad/s\n")
+        
+        self.assertAlmostEqual(abs(start_pos-end_pos),vel*total_time, 1)
+        self.assertAlmostEqual(abs(end_pos-start_pos)/total_time, vel, 1)
+        
+    
+    def test_DynamixelHelloXL430_set_velocity(self):
+        """
+        Test the Higher level DynamixelHelloXL430()->set_velocity()
+        """
+        self.velocity_control_test(set_vel_method="DynamixelHelloXL430")
+    
+    def test_DynamixelXL430_set_vel(self):
+        """
+        Test the Lower level DynamixelXL430()->set_vel()
+        """
+        self.dynamixel.motor.disable_torque()
+        self.dynamixel.motor.enable_vel()
+        self.dynamixel.motor.enable_torque()
+        self.velocity_control_test(set_vel_method="DynamixelXL430")


### PR DESCRIPTION
This PR introduces the `set_velocity()` API to the Dynamixel joints, including the head pan/tilt and wrist yaw/pitch/roll/gripper. This is the same velocity control API used by the other joints/mobile base. Additionally, this PR fixes a bug where interrupting a low-level communication with the Dxls (e.g. through a SIGINT) would cause the dxl to become inaccessible until the Linux process was killed.

An example script using the new API:
```python
import stretch_body.robot

r = stretch_body.robot.Robot()
r.startup()
assert(r.is_calibrated()) # the robot must be homed

# move the wrist_yaw counter clockwise at 0.1 rad/s
r.end_of_arm.get_joint('wrist_yaw').set_velocity(0.1)
```

How to test
----------
 1. Install this branch locally using [the instructions here](https://github.com/hello-robot/stretch_body/blob/master/body/README.md#developing).
 2. Run the example script above and verify the wrist yaw joint rotates at 0.1 rad/s