### PR TITLE
Fix NoneType error when contact_thresh_pos is None

### DIFF
--- a/body/stretch_body/prismatic_joint.py
+++ b/body/stretch_body/prismatic_joint.py
@@ -140,7 +140,7 @@ class PrismaticJoint(Device):
         This model converts from a specified percentage effort (-100 to 100) in the motor frame to motor currents
         """
         e_cn = self.params['contact_models']['effort_pct']['contact_thresh_default'][0] if contact_thresh_neg is None else contact_thresh_neg
-        e_cp = self.params['contact_models']['effort_pct']['contact_thresh_default'][1] if contact_thresh_neg is None else contact_thresh_pos
+        e_cp = self.params['contact_models']['effort_pct']['contact_thresh_default'][1] if contact_thresh_pos is None else contact_thresh_pos
         i_contact_neg = self.motor.effort_pct_to_current(max(e_cn, self.params['contact_models']['effort_pct']['contact_thresh_max'][0]))
         i_contact_pos = self.motor.effort_pct_to_current(min(e_cp, self.params['contact_models']['effort_pct']['contact_thresh_max'][1]))
         return i_contact_pos, i_contact_neg


### PR DESCRIPTION
The conditional now checks for the contact_thresh_pos value to set the e_cp value.

Previous behavior:
If contact_thresh_pos was not supplied, the value of e_cp was set as None (line 143). This resulted in comparison with NoneType error in the min() method on line 145.

Updated behavior:
If contact_thresh_pos is not supplied, the value of e_cp is set as the contact_thresh_default from stretch_params. This resolves the comparison with NoneType error.