### PR TITLE
watchdog implementation for set_velocity

### DIFF
--- a/body/stretch_body/dynamixel_hello_XL430.py
+++ b/body/stretch_body/dynamixel_hello_XL430.py
@@ -438,7 +438,6 @@ class DynamixelHelloXL430(Device):
             self._step_vel_safety_brake()
 
             if not self.watchdog_enabled:
-                print("Watchdog Enabled!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
                 self.disable_torque()
                 self.motor.enable_watchdog()
                 self.watchdog_enabled = True
@@ -447,11 +446,10 @@ class DynamixelHelloXL430(Device):
             # disable watchdog if a set_velocity() command is not passed above 1s
             if self._prev_set_vel_ts:
                 if time.time() - self._prev_set_vel_ts >=1:
-                    print("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!Watchdog Disabled")
                     wd_error=self.motor.get_watchdog_error()
                     self.disable_torque()
                     self.motor.disable_watchdog()
-                    self.watchdog_enabled = True
+                    self.watchdog_enabled = False
                     self.enable_torque()
                     if wd_error:
                         self.logger.warning(f'Watchdog error during Velocity control for {self.name}.')

--- a/body/test/test_dxl_sine_vel.py
+++ b/body/test/test_dxl_sine_vel.py
@@ -65,7 +65,7 @@ total_time = 30
 interval = 1/30 # s
 freaquency = 0.1 #Hz
 
-phase = np.pi/2
+phase = 0
 max_vel_ticks = motor.motor.get_vel_limit()
 print(f"Vel Limit: {max_vel_ticks} ticks/s | {abs(motor.ticks_to_world_rad_per_sec(max_vel_ticks))} rad/s")
 print(f"Vel gains P: {motor.motor.get_vel_P_gain()} | I: {motor.motor.get_vel_I_gain()}")


### PR DESCRIPTION
This PR introduces a mechanism through the robot sentry to enable Dynamixel watchdog when using [set_velocity()](https://github.com/hello-robot/stretch_body/blob/2a1a150deef742dbfc6db70c3f9cea838e60355c/body/stretch_body/dynamixel_hello_XL430.py#L535) commands to handle accidental communication interruptions. The watchdog will be disabled if set_velocity() command is not issued above 1 second. The [watchdog_enabled](https://github.com/hello-robot/stretch_body/blob/2a1a150deef742dbfc6db70c3f9cea838e60355c/body/stretch_body/dynamixel_hello_XL430.py#L535) variable is used to track the watchdog status. Also [fixes](https://github.com/hello-robot/stretch_body/blob/4c3eea74facb8d3e2fb5e4cb5ea8d14c6fa155a6/body/stretch_body/dynamixel_hello_XL430.py#L193:L194) a bug where the watchdog resets on startup if the motor was already in watchdog error state.