### PR TITLE
Replace urdfpy with urchin

### DIFF
--- a/body/setup.py
+++ b/body/setup.py
@@ -22,7 +22,7 @@ setuptools.setup(
     install_requires=['numpy==1.23.2', 'scipy', 'matplotlib==3.5.0', 'ipython', 'pandas', 'sympy', 'nose',
                       'inputs', 'drawnow', 'rplidar-roboticia', 'snakeviz', 'pyusb', 'SpeechRecognition', 'pixel-ring',
                       'click', 'cma', 'colorama',
-                      'scikit-image', 'open3d', 'pyrealsense2', 'pathlib', 'psutil', 'gitpython', 'urdfpy', 'urdf_parser_py',
+                      'scikit-image', 'open3d', 'pyrealsense2', 'pathlib', 'psutil', 'gitpython', 'urchin', 'urdf_parser_py', # urdfpy ==> urchin
                       'opencv-contrib-python', 'renamed-opencv-python-inference-engine; python_version >= "3.0.0"', # resolve cv2 conflict for py3
                       'jsonschema==2.6.0; python_version < "3.0"', 'qtconsole==4.7.7; python_version < "3.0"', 'jupyter', # required by juypter
                       'llvmlite==0.31.0; python_version < "3.0"', 'numba', # numba required by stretch_funmap, depends on old llvmlite for py2

--- a/body/stretch_body/robot_collision.py
+++ b/body/stretch_body/robot_collision.py
@@ -2,7 +2,7 @@
 
 from stretch_body.device import Device
 import importlib
-import urdfpy
+import urchin as urdf_loader
 import numpy as np
 import os
 
@@ -54,7 +54,7 @@ class RobotCollision(Device):
     def __init__(self,robot):
         Device.__init__(self, name='robot_collision')
         #urdf_file = os.path.join(os.environ['HELLO_FLEET_PATH'], os.environ['HELLO_FLEET_ID'],'exported_urdf/stretch.urdf')
-        #self.robot_model = urdfpy.URDF.load(urdf_file) #Kinematic model available if needed
+        #self.robot_model = urdf_loader.URDF.load(urdf_file) #Kinematic model available if needed
         self.robot=robot
         self.models=[]
         self.models_enabled={}
@@ -140,7 +140,7 @@ class EndOfArmForwardKinematics():
     def __init__(self):
         urdf_file = os.path.join(os.environ['HELLO_FLEET_PATH'], os.environ['HELLO_FLEET_ID'],'exported_urdf/stretch.urdf')
         np.seterr(divide='ignore', invalid='ignore')
-        self.robot_model = urdfpy.URDF.load(urdf_file)
+        self.robot_model = urdf_loader.URDF.load(urdf_file)
 
     def tool_fk(self,cfg,link):
         # returns the 4x4 transform from <link> to link_arm_l0
@@ -156,7 +156,7 @@ class EndOfArmForwardKinematics():
         link_set = set()
         link_set.add(self.robot_model._link_map[link])
 
-        # This is a modified version of link_fk of urdfpy
+        # This is a modified version of link_fk of urdf_loader
         # That stops FK at the 'link_arm_l0' of Stretch
         for lnk in self.robot_model._reverse_topo:
             if lnk not in link_set:

--- a/tools/bin/stretch_robot_urdf_visualizer.py
+++ b/tools/bin/stretch_robot_urdf_visualizer.py
@@ -3,7 +3,7 @@ import argparse
 import math
 import yaml
 import pathlib
-import urdfpy
+import urchin as urdf_loader
 import pyrender
 import warnings
 
@@ -16,7 +16,7 @@ warnings.filterwarnings("ignore")
 
 class URDFVisualizer:
     """The `show` method in this class is modified from the
-    original implementation of `urdfpy.URDF.show`. This class
+    original implementation of `urdf_loader.URDF.show`. This class
     exists temporarily while the PR for this modification is
     in review.
     """
@@ -149,7 +149,7 @@ if __name__ == "__main__":
     calibration_dir = pathlib.Path(hu.get_fleet_directory()) / 'exported_urdf'
     urdf_path = calibration_dir / 'stretch.urdf'
     controller_params_path = calibration_dir / 'controller_calibration_head.yaml'
-    urdf = urdfpy.URDF.load(str(urdf_path.absolute()))
+    urdf = urdf_loader.URDF.load(str(urdf_path.absolute()))
     viz = URDFVisualizer(urdf)
     with open(str(controller_params_path.absolute()), 'r') as f:
         controller_params = yaml.load(f, Loader=yaml.FullLoader)

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -28,7 +28,7 @@ setuptools.setup(
     install_requires=['numpy==1.23.2', 'scipy', 'matplotlib==3.5.0', 'ipython', 'pandas', 'sympy', 'nose', 'sh', 'packaging',
                       'inputs', 'drawnow', 'rplidar-roboticia', 'snakeviz', 'pyusb', 'SpeechRecognition', 'pixel-ring',
                       'click', 'cma', 'opencv-contrib-python', 'colorama', 'scikit-image', 'open3d', 'pyrealsense2',
-                      'pyglet == 1.4.10; python_version < "3.0"', 'trimesh==3.6.38', 'urdfpy', # required for urdfpy viz in py2
+                      'pyglet == 1.4.10; python_version < "3.0"', 'trimesh==3.6.38', 'urchin', # urdfpy ==> urchin
                       'pyyaml>=5.1', # required for yaml.FullLoader
                       'hello-robot-stretch-body>=0.4.26']
 )


### PR DESCRIPTION
This PR updates references to the now stale urdfpy package to urchin which is a drop-in replacement and is being actively maintained.

Tested it with tools:
1. stretch_robot_urdf_visualizer.py - to check if the urdf is being loaded and visualized correctly
2. stretch_xbox_controller_teleop.py - to check if the urdf is being loaded and the robot collision manager is working correctly