### PR TITLE
Features/pid base vel

### DIFF
--- a/body/stretch_body/base.py
+++ b/body/stretch_body/base.py
@@ -333,11 +333,16 @@ class Base(Device):
         i_contact_l, i_contact_r = self.contact_thresh_to_motor_current(is_translate=True,
                                                                         contact_thresh=contact_thresh)
 
-        self.left_wheel.set_command(mode=Stepper.MODE_VEL_TRAJ, v_des=wl_r, a_des=a_mr,
+        if self.params['use_vel_traj']:
+            ctrl_mode =Stepper.MODE_VEL_TRAJ
+        else:
+            ctrl_mode =Stepper.MODE_VEL_PID
+
+        self.left_wheel.set_command(mode=ctrl_mode, v_des=wl_r, a_des=a_mr,
                                     i_feedforward=0,
                                     i_contact_pos=i_contact_l,
                                     i_contact_neg=-1 * i_contact_l)
-        self.right_wheel.set_command(mode=Stepper.MODE_VEL_TRAJ, v_des=wr_r, a_des=a_mr,
+        self.right_wheel.set_command(mode=ctrl_mode, v_des=wr_r, a_des=a_mr,
                                      stiffness=stiffness,
                                      i_feedforward=0,
                                      i_contact_pos=i_contact_r,

--- a/body/stretch_body/prismatic_joint.py
+++ b/body/stretch_body/prismatic_joint.py
@@ -196,7 +196,11 @@ class PrismaticJoint(Device):
                                    i_contact_pos=i_contact_pos,
                                    i_contact_neg=i_contact_neg)
         else:
-            self.motor.set_command(mode=Stepper.MODE_VEL_TRAJ,
+            if self.params['use_vel_traj']:
+                ctrl_mode = Stepper.MODE_VEL_TRAJ
+            else:
+                ctrl_mode = Stepper.MODE_VEL_PID
+            self.motor.set_command(mode=ctrl_mode,
                                 v_des=v_r,
                                 a_des=a_r,
                                 stiffness=stiffness,
@@ -246,7 +250,13 @@ class PrismaticJoint(Device):
             v_r = self.translate_m_to_motor_rad(v_m)
 
             self.logger.debug(f"Applied safety brakes near limits. reduced set_vel={v_m} m/s")
-            self.motor.set_command(mode=Stepper.MODE_VEL_TRAJ,
+
+            if self.params['use_vel_traj']:
+                ctrl_mode = Stepper.MODE_VEL_TRAJ
+            else:
+                ctrl_mode = Stepper.MODE_VEL_PID
+
+            self.motor.set_command(mode=ctrl_mode,
                                 v_des=v_r,
                                 a_des=a_des,
                                 stiffness=stiffness,

--- a/body/stretch_body/robot_params_RE1V0.py
+++ b/body/stretch_body/robot_params_RE1V0.py
@@ -76,6 +76,7 @@ configuration_params_template={
 nominal_params={
     'arm':{
         'usb_name': '/dev/hello-motor-arm',
+        'use_vel_traj': 1,
         'chain_pitch': 0.0167,
         'chain_sprocket_teeth': 10,
         'gr_spur': 3.875,
@@ -107,6 +108,7 @@ nominal_params={
         'usb_name_right_wheel': '/dev/hello-motor-right-wheel',
         'force_N_per_A': 21.18, #Legacy
         'gr': 3.4,
+        'use_vel_traj': 0,
         'motion':{
             'default':{
                 'accel_m': 0.2,
@@ -312,7 +314,7 @@ nominal_params={
             'vKd_d': 0,
             'vKi_d': 0.005,
             'vKi_limit': 200,
-            'vKp_d': 0.2,
+            'vKp_d': 0.17,
             'vLPF': 30,
             'vTe_d': 50,
             'vel_near_setpoint_d': 3.5,
@@ -386,7 +388,7 @@ nominal_params={
             'vKd_d': 0,
             'vKi_d': 0.005,
             'vKi_limit': 200,
-            'vKp_d': 0.2,
+            'vKp_d': 0.17,
             'vLPF': 30,
             'vTe_d': 50,
             'vel_near_setpoint_d': 3.5,
@@ -398,6 +400,7 @@ nominal_params={
         'rated_current': 2.8},
     'lift':{
         'usb_name': '/dev/hello-motor-lift',
+        'use_vel_traj': 1,
         'belt_pitch_m': 0.005,
         'contact_models': {
             'effort_pct': {

--- a/body/stretch_body/robot_params_RE2V0.py
+++ b/body/stretch_body/robot_params_RE2V0.py
@@ -68,6 +68,7 @@ configuration_params_template={
 nominal_params={
     'arm':{
         'usb_name': '/dev/hello-motor-arm',
+        'use_vel_traj': 1,
         'force_N_per_A': 55.9,  # Legacy
         'chain_pitch': 0.0167,
         'chain_sprocket_teeth': 10,
@@ -97,6 +98,7 @@ nominal_params={
     'base':{
         'usb_name_left_wheel': '/dev/hello-motor-left-wheel',
         'usb_name_right_wheel': '/dev/hello-motor-right-wheel',
+        'use_vel_traj': 1,
         'force_N_per_A': 21.18,  # Legacy
         'gr': 3.8,
         'motion':{
@@ -309,7 +311,7 @@ nominal_params={
             'vKd_d': 0,
             'vKi_d': 0.005,
             'vKi_limit': 200,
-            'vKp_d': 0.2,
+            'vKp_d': 0.17,
             'vLPF': 30,
             'vTe_d': 50,
             'vel_near_setpoint_d': 3.5,
@@ -383,7 +385,7 @@ nominal_params={
             'vKd_d': 0,
             'vKi_d': 0.005,
             'vKi_limit': 200,
-            'vKp_d': 0.2,
+            'vKp_d': 0.17,
             'vLPF': 30,
             'vTe_d': 50,
             'vel_near_setpoint_d': 3.5,
@@ -395,6 +397,7 @@ nominal_params={
         'rated_current': 2.8},
     'lift':{
         'usb_name': '/dev/hello-motor-lift',
+        'use_vel_traj': 1,
         'force_N_per_A': 75.0,  # Legacy
         'calibration_range_bounds': [1.094, 1.106],
         'contact_models': {

--- a/body/stretch_body/robot_params_SE3.py
+++ b/body/stretch_body/robot_params_SE3.py
@@ -68,6 +68,7 @@ configuration_params_template={
 nominal_params={
     'arm':{
         'usb_name': '/dev/hello-motor-arm',
+        'use_vel_traj': 1,
         'force_N_per_A': 55.9,  # Legacy
         'chain_pitch': 0.0167,
         'chain_sprocket_teeth': 10,
@@ -99,6 +100,7 @@ nominal_params={
         'usb_name_right_wheel': '/dev/hello-motor-right-wheel',
         'force_N_per_A': 21.18,  # Legacy
         'gr': 3.8,
+        'use_vel_traj': 0,
         'motion':{
             'default':{
                 'accel_m': 0.12,
@@ -309,7 +311,7 @@ nominal_params={
             'vKd_d': 0,
             'vKi_d': 0.005,
             'vKi_limit': 200,
-            'vKp_d': 0.2,
+            'vKp_d': 0.17,
             'vLPF': 30,
             'vTe_d': 50,
             'vel_near_setpoint_d': 3.5,
@@ -383,7 +385,7 @@ nominal_params={
             'vKd_d': 0,
             'vKi_d': 0.005,
             'vKi_limit': 200,
-            'vKp_d': 0.2,
+            'vKp_d': 0.17,
             'vLPF': 30,
             'vTe_d': 50,
             'vel_near_setpoint_d': 3.5,
@@ -395,6 +397,7 @@ nominal_params={
         'rated_current': 2.8},
     'lift':{
         'usb_name': '/dev/hello-motor-lift',
+        'use_vel_traj': 1,
         'force_N_per_A': 75.0,  # Legacy
         'calibration_range_bounds': [1.094, 1.106],
         'contact_models': {

--- a/body/stretch_body/version.py
+++ b/body/stretch_body/version.py
@@ -3,4 +3,4 @@
 # 2) we can import it in setup.py for the same reason
 # 3) we can import it into your module module
 
-__version__ = '0.6.2'
+__version__ = '0.6.3'


### PR DESCRIPTION
This adds the ability for the base, arm, and lift to use VEL_PID instead of VEL_TRAJ controllers when doing velocity control. 

For the base, this can remove the slight oscillations that it makes. (Note, new vKp_d PID tuning as well).

For the arm and lift, they don't benefit from this as they are lower mass. They also need more tuning for the controller to sound and perform nicely.

IMPORTANT: If the user doesn't also upgrade the base steppers to firmware Stepper.v0.6.2p4 or later, otherwise the joints will only move with maximum accelerations when using VEL_PID mode.

To use this feature, update the yaml to turn off VEL_TRAJ. For example, in user_yaml:

base:
  use_vel_traj: 0

