### PR TITLE
Add robot.wait_command()

### DIFF
--- a/body/stretch_body/base.py
+++ b/body/stretch_body/base.py
@@ -101,10 +101,16 @@ class Base(Device):
             time.sleep(0.01)
         return False
 
+    def wait_while_is_moving(self,timeout=15.0):
+        left_done_moving = self.left_wheel.wait_while_is_moving(timeout=timeout)
+        right_done_moving = self.right_wheel.wait_while_is_moving(timeout=timeout)
+        return left_done_moving and right_done_moving
+
     def wait_until_at_setpoint(self, timeout=15.0):
         #Assume both are in motion. This will exit once both are at setpoints
-        self.left_wheel.wait_until_at_setpoint(timeout)
-        self.right_wheel.wait_until_at_setpoint(timeout)
+        left_at_setpoint = self.left_wheel.wait_until_at_setpoint(timeout)
+        right_at_setpoint = self.right_wheel.wait_until_at_setpoint(timeout)
+        return left_at_setpoint and right_at_setpoint
 
     def contact_thresh_to_motor_current(self,is_translate,contact_thresh):
         """

--- a/body/stretch_body/dynamixel_X_chain.py
+++ b/body/stretch_body/dynamixel_X_chain.py
@@ -103,6 +103,12 @@ class DynamixelXChain(Device):
             self.motors[motor].stop()
         self.hw_valid = False
 
+    def wait_until_at_setpoint(self, timeout=15.0):
+        at_setpoint = []
+        for motor in self.motors:
+            at_setpoint.append(self.motors[motor].wait_until_at_setpoint(timeout=timeout))
+        return all(at_setpoint)
+
     def is_trajectory_active(self):
         for motor in self.motors:
             if self.motors[motor].is_trajectory_active():

--- a/body/stretch_body/prismatic_joint.py
+++ b/body/stretch_body/prismatic_joint.py
@@ -537,7 +537,10 @@ class PrismaticJoint(Device):
         pass
 
     def wait_until_at_setpoint(self, timeout=15.0):
-        self.motor.wait_until_at_setpoint(timeout)
+        return self.motor.wait_until_at_setpoint(timeout=timeout)
+
+    def wait_while_is_moving(self,timeout=15.0):
+        return self.motor.wait_while_is_moving(timeout=timeout)
 
     def wait_for_contact(self, timeout=5.0):
         ts=time.time()

--- a/body/stretch_body/robot.py
+++ b/body/stretch_body/robot.py
@@ -344,6 +344,15 @@ class Robot(Device):
             if (self.pimu.ts_last_motor_sync is None or ( ready and sync_required)):
                 self.pimu.trigger_motor_sync()
 
+    def wait_command(self, timeout=15.0):
+        time.sleep(0.5)
+        base_done = self.base.wait_while_is_moving(timeout=timeout)
+        arm_done = self.arm.wait_while_is_moving(timeout=timeout)
+        lift_done = self.lift.wait_while_is_moving(timeout=timeout)
+        head_done = self.head.wait_until_at_setpoint(timeout=timeout)
+        eoa_done = self.end_of_arm.wait_until_at_setpoint(timeout=timeout)
+        return base_done and arm_done and lift_done and head_done and eoa_done
+
     # ######### Waypoint Trajectory Interface ##############################
 
 

--- a/body/stretch_body/stepper.py
+++ b/body/stretch_body/stepper.py
@@ -463,10 +463,10 @@ class StepperBase(Device):
         """
         ts = time.time()
         self.pull_status()
-        while self.status['is_moving'] and time.time() - ts < timeout:
+        while self.status['is_moving_filtered'] and time.time() - ts < timeout:
             time.sleep(0.1)
             self.pull_status()
-        return not self.status['is_moving']
+        return not self.status['is_moving_filtered']
 
     def wait_until_at_setpoint(self,timeout=15.0):
         """


### PR DESCRIPTION
After sending `move_to()` or `move_by()` commands to Stretch's joints, there are currently two ways to wait to block program flow until the commands are completed:

 1. Call the `wait_until_at_setpoint()` method belonging to the motor for which the motion was commanded. For example:
    ```python
    import time
    import stretch_body.robot
    r = stretch_body.robot.Robot()
    r.startup()
    r.end_of_arm.move_to('wrist_roll', 1.57, 0.1)
    time.sleep(0.5)
    r.end_of_arm.get_joint('wrist_roll').wait_until_at_setpoint()
    ``` 
    This requires the user to fetch the motor instance for the joint that was commanded (`r.end_of_arm.get_joint('wrist_roll')`). This approach also requires the user to sleep for a small amount of time before calling `wait_until_at_setpoint()` because the Python threads need time to perform the USB communication that fetches the latest status and update the robot's status dictionary.
 2. Sleep for some amount of time. This approach is easier as you don't need to query a specific joint. But this approach doesn't know whether the joint finished the commanded motion. It might block program execution longer than is necessary, or not long enough.

**This PR introduces `wait_command(timeout=15.0)` to the robot class. The method blocks program execution until all robot motion is complete.** Since users can call `robot.wait_command()`, they don't need to query specific joint(s) to find out if the motion completed. `wait_command()` takes in an argument called `timeout` determining how long the method waits for motion to complete. `wait_command()` returns a boolean, where True means all motion completed, and False means the motion is ongoing and `timeout` elapsed.

```python
import stretch_body.robot

r = stretch_body.robot.Robot()
r.startup()
assert(r.is_calibrated())

r.arm.move_to(0.5)
r.lift.move_to(0.5)
r.end_of_arm.move_to('wrist_yaw', 0.0)
r.push_command()
motion_done = r.wait_command()
print(f'All commanded motions completed in 15 seconds: {motion_done}')

r.stop()
```

## Testing

This method **hasn't** been tested with the waypoint trajectory or the velocity interfaces. This method relies on Python threads to update status dictionaries and Python is known to starve threads to prioritize computation in the main process. Depending on the computation running alongside the Robot class, you may see unexpected behavior from `wait_command()`.

This PR has been tested on a RE2 running Ubuntu 22.04 (Python 3.10), and P3 firmware.

```
---- Checking Software ----
[Pass] Ubuntu 22.04 is ready
[Pass] Firmware is up-to-date
         hello-pimu = v0.5.1p3
         hello-wacc = v0.5.1p3
         hello-motor-arm = v0.5.1p3
         hello-motor-lift = v0.5.1p3
         hello-motor-left-wheel = v0.5.1p3
         hello-motor-right-wheel = v0.5.1p3
[Pass] Python pkgs are up-to-date
         Stretch Body = 0.6.5 (installed locally at ~/repos/stretch_body/body)
         Stretch Body Tools = 0.6.0 (installed locally at ~/repos/stretch_body/tools)
         Stretch Tool Share = 0.2.8
         Stretch Factory = 0.4.12
         Stretch Diagnostics = 0.0.14
```