### PR TITLE
Replace deprecated is_calibrated() with is_homed()

### DIFF
--- a/body/stretch_body/robot.py
+++ b/body/stretch_body/robot.py
@@ -393,7 +393,14 @@ class Robot(Device):
 
     def is_calibrated(self):
         """
-        Returns true if homing-calibration has been run all joints that require it
+        DEPRECATED: replaced by Robot.is_homed()
+        """
+        self.logger.warn('is_calibrated() has been replaced by is_homed()')
+        return self.is_homed()
+
+    def is_homed(self):
+        """
+        Returns true if homing has been run all joints that require it
         """
         ready = self.lift.motor.status['pos_calibrated']
         ready = ready and self.arm.motor.status['pos_calibrated']


### PR DESCRIPTION
This PR introduces a new method called `is_homed()` to the Robot class to better match the nomenclature used throughout the command line tools and Stretch Docs. Using the `is_calibrated()` method results in a deprecation warning.

An example script:

```python
import stretch_body.robot

r = stretch_body.robot.Robot()
r.startup()
if not r.is_homed():
    r.home()

r.stop()
```