### PR TITLE
Add automatic update checking to command line tools

### DIFF
--- a/body/stretch_body/robot_params.py
+++ b/body/stretch_body/robot_params.py
@@ -41,7 +41,11 @@ nominal_system_params={
                     "datefmt": "%m/%d/%Y %H:%M:%S"
                 }
             }
-        }}
+        },
+    "system_check": {
+            "show_sw_exc": False
+        },
+}
 
 class RobotParams:
     """Build the parameter dictionary that is available as stretch_body.Device().robot_params.

--- a/docs/robot_parameters.md
+++ b/docs/robot_parameters.md
@@ -9,8 +9,8 @@ Additional sources of parameters for Stretch Body to import in when organizing t
 The most common reason to set an additional parameter source is to supply parameters relating to a new [tool](#tool).
 
 | Parameter | Default Value |
-| --------- | ------------- |
-| params  | `[]`          |
+|-----------|---------------|
+| params    | `[]`          |
 
 ### tool
 
@@ -18,16 +18,16 @@ You can swap the tool (or "end-effector") on Stretch. There's a [repository of 3
 
 After attaching the hardware to Stretch's wrist, set this parameter to your tool class's name to change which tool class is imported into Stretch Body. See also [params](#params) for supplying parameters needed by your tool class.
 
-| Parameter    | Default Value            |
-| ------------ | ------------------------ |
+| Parameter  | Default Value            |
+|------------|--------------------------|
 | robot.tool | `'tool_stretch_gripper'` |
 
 ### use_multiturn
 
 The Dynamixel joints on the robot have a "multiturn" or "Extended Position Control" mode, which allows the Dynamixel servo to rotate many revolutions. This is in contrast to regular "Position Control" mode, where the servo is limited to 360° rotation. The joints where the servos have gear reductions operate in multiturn mode to achieve the desired range. In the other joints, the servo directly controls the position of the joint, so multiple revolutions are not required. More details on the Dynamixel's control modes are [available here](https://emanual.robotis.com/docs/en/dxl/x/xl430-w250/#operating-mode11).
 
-| Parameter                       | Default Value |
-| ------------------------------- | ------------- |
+| Parameter                     | Default Value |
+|-------------------------------|---------------|
 | head_pan.use_multiturn        | `0` *         |
 | head_tilt.use_multiturn       | `0`           |
 | stretch_gripper.use_multiturn | `1`           |
@@ -36,3 +36,13 @@ The Dynamixel joints on the robot have a "multiturn" or "Extended Position Contr
 | wrist_roll.use_multiturn      | `0`           |
 
 \* `head_pan.use_multiturn` is `0` for most Stretch robots, except for some early RE1s. For those robots, the parameter is set to `1` in "stretch_configuration_params.yaml". 
+
+## Parameters for Command Line Tools
+
+### show_sw_exc
+
+In the `stretch_robot_system_check.py` tool, the "Checking Software" section is wrapped in a try/except because of the experimental nature of the code. The tool is introspecting the system and relying on resources/files to be available in specific places with specific formats. Since the tool's output needs to be easily understood, the error or exception cannot be shown (hence the try/except block). This parameter allows the tool to raise the exception and display it in the terminal. This is useful for debugging purposes.
+
+| Parameter                | Default Value |
+|--------------------------|---------------|
+| system_check.show_sw_exc | False         |

--- a/tools/bin/stretch_robot_home.py
+++ b/tools/bin/stretch_robot_home.py
@@ -2,16 +2,121 @@
 from __future__ import print_function
 import stretch_body.robot as robot
 import argparse
+import sys
+import time
+import json
+import yaml
+import pathlib
+import requests
+import xmltodict
+import multiprocessing
+import http.client as httplib
+try:
+    import stretch_factory.firmware_available
+    factory_installed = True
+except:
+    factory_installed = False
 import stretch_body.hello_utils as hu
 hu.print_stretch_re_use()
 
 parser=argparse.ArgumentParser(description='Find zeros for all robot joints')
 args=parser.parse_args()
 
+def fetch_updates_in_background():
+    def have_internet():
+        conn = httplib.HTTPSConnection("8.8.8.8", timeout=5)
+        try:
+            conn.request("HEAD", "/")
+            return True
+        except Exception:
+            return False
+        finally:
+            conn.close()
+    def get_latest_pypi_version(url):
+        resp = requests.get(url)
+        if resp.status_code == 200:
+            releases = xmltodict.parse(resp.text)['rss']['channel']['item']
+            for i in range(len(releases)):
+                if 'dev' not in releases[i]['title']:
+                    return releases[i]['title']
+        return None
+    def get_latest_github_commit(url):
+        resp = requests.get(url)
+        if resp.status_code == 200:
+            return json.loads(resp.text)[0]['sha']
+        return None
+
+    try:
+        start = time.time()
+        scans_dir = pathlib.Path('~/stretch_user/log/updates_logger').expanduser()
+        if not scans_dir.is_dir():
+            scans_dir.mkdir(parents=True, exist_ok=True)
+        datetime_str = hu.create_time_string()
+        scan_file = scans_dir / f'updates_scan.{datetime_str}.yaml'
+        scan_log = scans_dir / f'log_updates_scan.{datetime_str}.log'
+
+        # override stdout/stderr
+        sys.stdout = open(str(scan_log), "a")
+        sys.stderr = open(str(scan_log), "a")
+
+        # check for Stretch Factory installed
+        if not factory_installed:
+            return
+        print('background: got factory installed!', time.time() - start, flush=True)
+
+        # check for internet connection
+        if not have_internet():
+            return
+        print('background: got internet!', time.time() - start, flush=True)
+
+        # check for firmware updates
+        use_device = {'hello-motor-arm': True, 'hello-motor-right-wheel': True, 'hello-motor-left-wheel': True, 'hello-pimu': True, 'hello-wacc': True,'hello-motor-lift': True}
+        fa = stretch_factory.firmware_available.FirmwareAvailable(use_device)
+        scan_dict = {
+            'firmware': {
+                'hello-pimu': str(fa.get_most_recent_version('hello-pimu', None)),
+                'hello-wacc': str(fa.get_most_recent_version('hello-wacc', None)),
+                'hello-motor-arm': str(fa.get_most_recent_version('hello-motor-arm', None)),
+                'hello-motor-lift': str(fa.get_most_recent_version('hello-motor-lift', None)),
+                'hello-motor-left-wheel': str(fa.get_most_recent_version('hello-motor-left-wheel', None)),
+                'hello-motor-right-wheel': str(fa.get_most_recent_version('hello-motor-right-wheel', None)),
+            }
+        }
+        print('background: got latest firmware!', time.time() - start, flush=True)
+
+        # check for pip updates
+        scan_dict['pip'] = {
+            'hello-robot-stretch-body': get_latest_pypi_version("https://pypi.org/rss/project/hello-robot-stretch-body/releases.xml"),
+            'hello-robot-stretch-body-tools': get_latest_pypi_version("https://pypi.org/rss/project/hello-robot-stretch-body-tools/releases.xml"),
+            'hello-robot-stretch-tool-share': get_latest_pypi_version("https://pypi.org/rss/project/hello-robot-stretch-tool-share/releases.xml"),
+            'hello-robot-stretch-factory': get_latest_pypi_version("https://pypi.org/rss/project/hello-robot-stretch-factory/releases.xml"),
+            'hello-robot-stretch-diagnostics': get_latest_pypi_version("https://pypi.org/rss/project/hello-robot-stretch-diagnostics/releases.xml"),
+            'hello-robot-stretch-urdf': get_latest_pypi_version("https://pypi.org/rss/project/hello-robot-stretch-urdf/releases.xml"),
+        }
+        print('background: got latest pip!', time.time() - start, flush=True)
+
+        # check latest pushed github commits
+        scan_dict['ros'] = {
+            'stretch_ros': get_latest_github_commit("https://api.github.com/repos/hello-robot/stretch_ros/commits"),
+            'stretch_ros2': get_latest_github_commit("https://api.github.com/repos/hello-robot/stretch_ros2/commits"),
+        }
+        print('background: got latest github!', time.time() - start, flush=True)
+
+        # save to updates_scan directory
+        with open(str(scan_file), 'w') as outfile:
+            yaml.dump(scan_dict, outfile)
+        print('background: saved to scan logger dir', time.time() - start, flush=True)
+    except:
+        pass
+background_process = multiprocessing.Process(target=fetch_updates_in_background)
+
 r=robot.Robot()
 r.startup()
 if not r.pimu.status['runstop_event']:
+    background_process.start()
     r.home()
+    background_process.terminate()
+    background_process.join()
 else:
     r.logger.warning('Cannot home while run-stopped')
 r.stop()

--- a/tools/bin/stretch_robot_home.py
+++ b/tools/bin/stretch_robot_home.py
@@ -80,7 +80,8 @@ def fetch_updates_in_background():
                 'hello-motor-lift': str(fa.get_most_recent_version('hello-motor-lift', None)),
                 'hello-motor-left-wheel': str(fa.get_most_recent_version('hello-motor-left-wheel', None)),
                 'hello-motor-right-wheel': str(fa.get_most_recent_version('hello-motor-right-wheel', None)),
-            }
+            },
+            'version': '0.0',
         }
         print('background: got latest firmware!', time.time() - start, flush=True)
 

--- a/tools/bin/stretch_robot_system_check.py
+++ b/tools/bin/stretch_robot_system_check.py
@@ -369,11 +369,12 @@ try: # TODO: remove try/catch after sw check verified to work reliably
             ws_path = ''
             if len(ws_paths) > 0:
                 ws_path = ws_paths[0].replace(str(pathlib.Path(p).home()), '~')
+                ws_path = str(pathlib.Path(ws_path) / 'stretch_ros')
             if pathlib.Path(ws_path).expanduser().is_dir():
                 if scan_dict:
                     latest_stretchros_git_commit = scan_dict['ros']['stretch_ros']
                     if latest_stretchros_git_commit is not None:
-                        repo = git.Repo(str((pathlib.Path(ws_path) / 'stretch_ros').expanduser()))
+                        repo = git.Repo(str(pathlib.Path(ws_path).expanduser()))
                         last200_localstretchros_git_commits = [str(repo.commit(f'HEAD~{i}')) for i in range(100)]
                         if latest_stretchros_git_commit not in last200_localstretchros_git_commits:
                             return True, ros_name, False, 'Stretch ROS not up-to-date', ws_path
@@ -391,12 +392,12 @@ try: # TODO: remove try/catch after sw check verified to work reliably
                     if is_install_expected:
                         return True, ros_name, False, f"{pkg} should be installed", ''
             p = get_package_prefix('stretch_core')
-            ws_path = str(pathlib.Path(p).parent.parent / 'src').replace(str(pathlib.Path(p).home()), '~')
+            ws_path = str(pathlib.Path(p).parent.parent / 'src' / 'stretch_ros2').replace(str(pathlib.Path(p).home()), '~')
             if pathlib.Path(ws_path).expanduser().is_dir():
                 if scan_dict:
                     latest_stretchros_git_commit = scan_dict['ros']['stretch_ros2']
                     if latest_stretchros_git_commit is not None:
-                        repo = git.Repo(str((pathlib.Path(ws_path) / 'stretch_ros2').expanduser()))
+                        repo = git.Repo(str(pathlib.Path(ws_path).expanduser()))
                         last200_localstretchros_git_commits = [str(repo.commit(f'HEAD~{i}')) for i in range(100)]
                         if latest_stretchros_git_commit not in last200_localstretchros_git_commits:
                             return True, ros_name, False, 'Stretch ROS2 not up-to-date', ws_path

--- a/tools/bin/stretch_robot_system_check.py
+++ b/tools/bin/stretch_robot_system_check.py
@@ -371,7 +371,7 @@ try: # TODO: remove try/catch after sw check verified to work reliably
             ws_path = ''
             if len(ws_paths) > 0:
                 ws_path = ws_paths[0].replace(str(pathlib.Path(p).home()), '~')
-                ws_path = str(pathlib.Path(ws_path) / 'stretch_ros')
+                ws_path = str(pathlib.Path(ws_path) / 'src' / 'stretch_ros')
             if pathlib.Path(ws_path).expanduser().is_dir():
                 if scan_dict:
                     latest_stretchros_git_commit = scan_dict['ros']['stretch_ros']

--- a/tools/bin/stretch_robot_system_check.py
+++ b/tools/bin/stretch_robot_system_check.py
@@ -17,6 +17,7 @@ from colorama import Fore, Back, Style
 import argparse
 import stretch_body.hello_utils as hu
 from stretch_body.dynamixel_XL430 import *
+import stretch_body.device
 hu.print_stretch_re_use()
 
 
@@ -440,6 +441,8 @@ try: # TODO: remove try/catch after sw check verified to work reliably
         else:
             print(Fore.YELLOW + '[Warn] No version of ROS enabled')
 except:
-    pass
+    show_sw_exc = stretch_body.device.Device(name='system_check', req_params=False).params.get('show_sw_exc', False)
+    if show_sw_exc:
+        raise
 
 r.stop()

--- a/tools/bin/stretch_robot_system_check.py
+++ b/tools/bin/stretch_robot_system_check.py
@@ -173,6 +173,21 @@ else:
     print(Fore.RED + '[Fail] : No device found')
 # #####################################################
 try: # TODO: remove try/catch after sw check verified to work reliably
+    def get_ip():
+        # https://stackoverflow.com/a/28950776
+        import socket
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        s.settimeout(0)
+        try:
+            # doesn't even have to be reachable
+            s.connect(('10.254.254.254', 1))
+            IP = s.getsockname()[0]
+        except Exception:
+            IP = '127.0.0.1'
+        finally:
+            s.close()
+        return IP
+
     scan_dict = None
     def find_latest_updates_scan():
         global scan_dict
@@ -382,6 +397,9 @@ try: # TODO: remove try/catch after sw check verified to work reliably
                             return True, ros_name, False, 'Stretch ROS not up-to-date', ws_path
             else:
                 return True, ros_name, False, 'Unable to find workspace', ''
+            ros_ip = os.getenv('ROS_IP')
+            if ros_ip and ros_ip != get_ip():
+                return True, ros_name, False, f'Remote master ROS_IP should be {get_ip()}', ws_path
             return True, ros_name, True, '', ws_path
         elif ros_distro in ros2_distros:
             from ament_index_python.packages import get_package_share_directory, get_package_prefix

--- a/tools/bin/stretch_robot_system_check.py
+++ b/tools/bin/stretch_robot_system_check.py
@@ -170,6 +170,17 @@ else:
     print(Fore.RED + '[Fail] : No device found')
 # #####################################################
 try: # TODO: remove try/catch after sw check verified to work reliably
+    def is_distribution_okay():
+        ubuntu_str = f'{distro.name()} {distro.version()}'
+        ubuntu_version = distro.version()
+        if ubuntu_version == '18.04':
+            return Fore.RED + f'[Fail] {ubuntu_str} is deprecated'
+        elif ubuntu_version == '20.04':
+            return Fore.GREEN + f'[Pass] {ubuntu_str} is ready'
+        elif ubuntu_version == '22.04':
+            return Fore.GREEN + f'[Pass] {ubuntu_str} is ready'
+        else:
+            return Fore.RED + f'[Fail] {ubuntu_str} is unknown'
     def all_apt_correct():
         apt_expectations = {
             '18.04': {
@@ -189,7 +200,7 @@ try: # TODO: remove try/catch after sw check verified to work reliably
         apt_list = apt.Cache()
         for pkg, is_install_expected in apt_expectations[distro.version()].items():
             if pkg not in apt_list or is_install_expected != apt_list[pkg].is_installed:
-                return False, f'{pkg} not set-up correctly'
+                return False, f"{pkg} should {'not' if not is_install_expected else ''} be installed"
         return True, ''
     def all_firmware_uptodate():
         def get_fw_version(hello_device):
@@ -303,13 +314,14 @@ try: # TODO: remove try/catch after sw check verified to work reliably
         return True, ros_name, True, '', ws_path
     print(Style.RESET_ALL)
     print ('---- Checking Software ----')
-    # Ubuntu APT
-    apt_ready, apt_err_msg = all_apt_correct()
-    ubuntu_str = f'{distro.name()} {distro.version()}'
-    if apt_ready:
-        print(Fore.GREEN + f'[Pass] {ubuntu_str} is ready')
+    # Ubuntu
+    print(is_distribution_okay())
+    # APT
+    apt_correct, apt_err_msg = all_apt_correct()
+    if apt_correct:
+        print(Fore.GREEN + f'[Pass] All APT pkgs are setup correctly')
     else:
-        print(Fore.YELLOW + f'[Warn] {ubuntu_str} not ready ({apt_err_msg})')
+        print(Fore.YELLOW + f'[Warn] Not all APT pkgs are setup correctly ({apt_err_msg})')
     # Firmware
     fw_uptodate, fw_versions = all_firmware_uptodate()
     if fw_uptodate:

--- a/tools/bin/stretch_robot_system_check.py
+++ b/tools/bin/stretch_robot_system_check.py
@@ -383,18 +383,8 @@ try: # TODO: remove try/catch after sw check verified to work reliably
         print(Fore.GREEN + '[Pass] Python pkgs are up-to-date')
     else:
         print(Fore.YELLOW + '[Warn] Python pkgs not up-to-date')
-    bname = 'hello-robot-stretch-body'
-    print(Fore.LIGHTBLUE_EX + f'         {bname} = ' + Fore.CYAN + f"{pip_versions[bname] if pip_versions[bname] else 'Not Installed'}" + Fore.LIGHTBLUE_EX + f"{f' (installed locally at {pip_editable_locations[bname]})' if pip_editable_locations[bname] else ''}")
-    bname = 'hello-robot-stretch-body-tools'
-    print(Fore.LIGHTBLUE_EX + f'         {bname} = ' + Fore.CYAN + f"{pip_versions[bname] if pip_versions[bname] else 'Not Installed'}" + Fore.LIGHTBLUE_EX + f"{f' (installed locally at {pip_editable_locations[bname]})' if pip_editable_locations[bname] else ''}")
-    bname = 'hello-robot-stretch-tool-share'
-    print(Fore.LIGHTBLUE_EX + f'         {bname} = ' + Fore.CYAN + f"{pip_versions[bname] if pip_versions[bname] else 'Not Installed'}" + Fore.LIGHTBLUE_EX + f"{f' (installed locally at {pip_editable_locations[bname]})' if pip_editable_locations[bname] else ''}")
-    bname = 'hello-robot-stretch-factory'
-    print(Fore.LIGHTBLUE_EX + f'         {bname} = ' + Fore.CYAN + f"{pip_versions[bname] if pip_versions[bname] else 'Not Installed'}" + Fore.LIGHTBLUE_EX + f"{f' (installed locally at {pip_editable_locations[bname]})' if pip_editable_locations[bname] else ''}")
-    bname = 'hello-robot-stretch-diagnostics'
-    print(Fore.LIGHTBLUE_EX + f'         {bname} = ' + Fore.CYAN + f"{pip_versions[bname] if pip_versions[bname] else 'Not Installed'}" + Fore.LIGHTBLUE_EX + f"{f' (installed locally at {pip_editable_locations[bname]})' if pip_editable_locations[bname] else ''}")
-    bname = 'hello-robot-stretch-urdf'
-    print(Fore.LIGHTBLUE_EX + f'         {bname} = ' + Fore.CYAN + f"{pip_versions[bname] if pip_versions[bname] else 'Not Installed'}" + Fore.LIGHTBLUE_EX + f"{f' (installed locally at {pip_editable_locations[bname]})' if pip_editable_locations[bname] else ''}")
+    for bname in ['hello-robot-stretch-body', 'hello-robot-stretch-body-tools', 'hello-robot-stretch-tool-share', 'hello-robot-stretch-factory', 'hello-robot-stretch-diagnostics', 'hello-robot-stretch-urdf']:
+        print(Fore.LIGHTBLUE_EX + f'         {bname} = ' + Fore.CYAN + f"{pip_versions[bname] if pip_versions[bname] else 'Not Installed'}" + Fore.LIGHTBLUE_EX + f"{f' (installed locally at {pip_editable_locations[bname]})' if pip_editable_locations[bname] else ''}")
     # ROS
     ros_enabled, ros_name, ros_ready, ros_err_msg, ros_ws_path = all_ros_correct()
     if ros_enabled:

--- a/tools/bin/stretch_robot_system_check.py
+++ b/tools/bin/stretch_robot_system_check.py
@@ -299,7 +299,7 @@ try: # TODO: remove try/catch after sw check verified to work reliably
             'hello-robot-stretch-urdf': version.parse('0.0.11'),
         }
         if scan_dict:
-            latest_pip_version = {p: version.parse(scan_dict['pip'][p]) for p in latest_pip_version}
+            latest_pip_version = {p: version.parse(scan_dict['pip'].get(p, '0.0.0')) for p in latest_pip_version}
 
         # check current against latest
         try: # The try/except catches pip pkgs that aren't installed
@@ -384,17 +384,17 @@ try: # TODO: remove try/catch after sw check verified to work reliably
     else:
         print(Fore.YELLOW + '[Warn] Python pkgs not up-to-date')
     bname = 'hello-robot-stretch-body'
-    print(Fore.LIGHTBLUE_EX + '         Stretch Body = ' + Fore.CYAN + f"{pip_versions[bname] if pip_versions[bname] else 'Not Installed'}" + Fore.LIGHTBLUE_EX + f"{f' (installed locally at {pip_editable_locations[bname]})' if pip_editable_locations[bname] else ''}")
+    print(Fore.LIGHTBLUE_EX + f'         {bname} = ' + Fore.CYAN + f"{pip_versions[bname] if pip_versions[bname] else 'Not Installed'}" + Fore.LIGHTBLUE_EX + f"{f' (installed locally at {pip_editable_locations[bname]})' if pip_editable_locations[bname] else ''}")
     bname = 'hello-robot-stretch-body-tools'
-    print(Fore.LIGHTBLUE_EX + '         Stretch Body Tools = ' + Fore.CYAN + f"{pip_versions[bname] if pip_versions[bname] else 'Not Installed'}" + Fore.LIGHTBLUE_EX + f"{f' (installed locally at {pip_editable_locations[bname]})' if pip_editable_locations[bname] else ''}")
+    print(Fore.LIGHTBLUE_EX + f'         {bname} = ' + Fore.CYAN + f"{pip_versions[bname] if pip_versions[bname] else 'Not Installed'}" + Fore.LIGHTBLUE_EX + f"{f' (installed locally at {pip_editable_locations[bname]})' if pip_editable_locations[bname] else ''}")
     bname = 'hello-robot-stretch-tool-share'
-    print(Fore.LIGHTBLUE_EX + '         Stretch Tool Share = ' + Fore.CYAN + f"{pip_versions[bname] if pip_versions[bname] else 'Not Installed'}" + Fore.LIGHTBLUE_EX + f"{f' (installed locally at {pip_editable_locations[bname]})' if pip_editable_locations[bname] else ''}")
+    print(Fore.LIGHTBLUE_EX + f'         {bname} = ' + Fore.CYAN + f"{pip_versions[bname] if pip_versions[bname] else 'Not Installed'}" + Fore.LIGHTBLUE_EX + f"{f' (installed locally at {pip_editable_locations[bname]})' if pip_editable_locations[bname] else ''}")
     bname = 'hello-robot-stretch-factory'
-    print(Fore.LIGHTBLUE_EX + '         Stretch Factory = ' + Fore.CYAN + f"{pip_versions[bname] if pip_versions[bname] else 'Not Installed'}" + Fore.LIGHTBLUE_EX + f"{f' (installed locally at {pip_editable_locations[bname]})' if pip_editable_locations[bname] else ''}")
+    print(Fore.LIGHTBLUE_EX + f'         {bname} = ' + Fore.CYAN + f"{pip_versions[bname] if pip_versions[bname] else 'Not Installed'}" + Fore.LIGHTBLUE_EX + f"{f' (installed locally at {pip_editable_locations[bname]})' if pip_editable_locations[bname] else ''}")
     bname = 'hello-robot-stretch-diagnostics'
-    print(Fore.LIGHTBLUE_EX + '         Stretch Diagnostics = ' + Fore.CYAN + f"{pip_versions[bname] if pip_versions[bname] else 'Not Installed'}" + Fore.LIGHTBLUE_EX + f"{f' (installed locally at {pip_editable_locations[bname]})' if pip_editable_locations[bname] else ''}")
+    print(Fore.LIGHTBLUE_EX + f'         {bname} = ' + Fore.CYAN + f"{pip_versions[bname] if pip_versions[bname] else 'Not Installed'}" + Fore.LIGHTBLUE_EX + f"{f' (installed locally at {pip_editable_locations[bname]})' if pip_editable_locations[bname] else ''}")
     bname = 'hello-robot-stretch-urdf'
-    print(Fore.LIGHTBLUE_EX + '         Stretch URDF = ' + Fore.CYAN + f"{pip_versions[bname] if pip_versions[bname] else 'Not Installed'}" + Fore.LIGHTBLUE_EX + f"{f' (installed locally at {pip_editable_locations[bname]})' if pip_editable_locations[bname] else ''}")
+    print(Fore.LIGHTBLUE_EX + f'         {bname} = ' + Fore.CYAN + f"{pip_versions[bname] if pip_versions[bname] else 'Not Installed'}" + Fore.LIGHTBLUE_EX + f"{f' (installed locally at {pip_editable_locations[bname]})' if pip_editable_locations[bname] else ''}")
     # ROS
     ros_enabled, ros_name, ros_ready, ros_err_msg, ros_ws_path = all_ros_correct()
     if ros_enabled:

--- a/tools/bin/stretch_robot_system_check.py
+++ b/tools/bin/stretch_robot_system_check.py
@@ -312,9 +312,9 @@ try: # TODO: remove try/catch after sw check verified to work reliably
             return False, pip_versions, pip_editable_locations
         return True, pip_versions, pip_editable_locations
     def all_ros_correct():
-        ros1_distros = ['melodic', 'noetic']
-        ros2_distros = ['humble']
-        ros_expectations = {
+        ros1_distros = ['noetic', 'melodic', 'lunar', 'kinetic', 'jade', 'indigo']
+        ros2_distros = ['rolling', 'jazzy', 'iron', 'humble', 'galactic', 'foxy', 'eloquent', 'dashing']
+        ros_expectations = { # the actual set of supported ROS distros
             'melodic': {
                 'stretch_core': True,
                 'realsense2_camera': True,
@@ -334,17 +334,27 @@ try: # TODO: remove try/catch after sw check verified to work reliably
             #     'ros2_numpy': True,
             #     'stretch_moveit_plugins': True,
             # },
-            'humble': { # rospkg only works on ROS1
+            'humble': {
                 'stretch_core': True,
                 'realsense2_camera': True,
                 'sllidar_ros2': True,
                 'ros2_numpy': True,
             }
         }
+        # create ros_distro
         ros_distro = os.getenv('ROS_DISTRO')
         if not ros_distro:
             return False, '', False, '', ''
-        ros_name = f'ROS {ros_distro.capitalize()}'
+
+        # create ros_name
+        if ros_distro in ros1_distros:
+            ros_name = f'ROS {ros_distro.capitalize()}'
+        elif ros_distro in ros2_distros:
+            ros_name = f'ROS2 {ros_distro.capitalize()}'
+        else:
+            ros_name = f'Unknown ROS {ros_distro.capitalize()}'
+
+        # check ros expectations
         if ros_distro not in ros_expectations:
             return False, ros_name, False, '', ''
         if ros_distro in ros1_distros:

--- a/tools/bin/stretch_robot_system_check.py
+++ b/tools/bin/stretch_robot_system_check.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 import sh
 import re
 import apt
+import git
 import distro
 import pathlib
 from packaging import version
@@ -357,6 +358,16 @@ try: # TODO: remove try/catch after sw check verified to work reliably
             ws_path = ''
             if len(ws_paths) > 0:
                 ws_path = ws_paths[0].replace(str(pathlib.Path(p).home()), '~')
+            if pathlib.Path(ws_path).expanduser().is_dir():
+                if scan_dict:
+                    latest_stretchros_git_commit = scan_dict['ros']['stretch_ros']
+                    if latest_stretchros_git_commit is not None:
+                        repo = git.Repo(str((pathlib.Path(ws_path) / 'stretch_ros').expanduser()))
+                        last200_localstretchros_git_commits = [str(repo.commit(f'HEAD~{i}')) for i in range(100)]
+                        if latest_stretchros_git_commit not in last200_localstretchros_git_commits:
+                            return True, ros_name, False, 'Stretch ROS not up-to-date', ws_path
+            else:
+                return True, ros_name, False, 'Unable to find workspace', ''
             return True, ros_name, True, '', ws_path
         elif ros_distro in ros2_distros:
             from ament_index_python.packages import get_package_share_directory, get_package_prefix
@@ -370,6 +381,16 @@ try: # TODO: remove try/catch after sw check verified to work reliably
                         return True, ros_name, False, f"{pkg} should be installed", ''
             p = get_package_prefix('stretch_core')
             ws_path = str(pathlib.Path(p).parent.parent / 'src').replace(str(pathlib.Path(p).home()), '~')
+            if pathlib.Path(ws_path).expanduser().is_dir():
+                if scan_dict:
+                    latest_stretchros_git_commit = scan_dict['ros']['stretch_ros2']
+                    if latest_stretchros_git_commit is not None:
+                        repo = git.Repo(str((pathlib.Path(ws_path) / 'stretch_ros2').expanduser()))
+                        last200_localstretchros_git_commits = [str(repo.commit(f'HEAD~{i}')) for i in range(100)]
+                        if latest_stretchros_git_commit not in last200_localstretchros_git_commits:
+                            return True, ros_name, False, 'Stretch ROS2 not up-to-date', ws_path
+            else:
+                return True, ros_name, False, 'Unable to find workspace', ''
             return True, ros_name, True, '', ws_path
         return True, ros_name, False, 'Unable to list pkgs for this distribution', ''
     print(Style.RESET_ALL)
@@ -411,6 +432,8 @@ try: # TODO: remove try/catch after sw check verified to work reliably
                 print(Fore.LIGHTBLUE_EX + f'         Workspace at {ros_ws_path}')
         else:
             print(Fore.YELLOW + f'[Warn] {ros_name} not ready ({ros_err_msg})')
+            if ros_ws_path:
+                print(Fore.LIGHTBLUE_EX + f'         Workspace at {ros_ws_path}')
     else:
         if ros_name:
             print(Fore.YELLOW + f'[Warn] {ros_name} not supported')

--- a/tools/bin/stretch_robot_system_check.py
+++ b/tools/bin/stretch_robot_system_check.py
@@ -220,7 +220,9 @@ try: # TODO: remove try/catch after sw check verified to work reliably
         }
         apt_list = apt.Cache()
         for pkg, is_install_expected in apt_expectations[distro.version()].items():
-            if pkg not in apt_list or is_install_expected != apt_list[pkg].is_installed:
+            if pkg not in apt_list and is_install_expected:
+                return False, f"{pkg} should be installed"
+            if pkg in apt_list and is_install_expected != apt_list[pkg].is_installed:
                 return False, f"{pkg} should {'not' if not is_install_expected else ''} be installed"
         return True, ''
     def all_firmware_uptodate():

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -28,12 +28,8 @@ setuptools.setup(
     install_requires=['numpy==1.23.2', 'scipy', 'matplotlib==3.5.0', 'ipython', 'pandas', 'sympy', 'nose', 'sh', 'packaging',
                       'inputs', 'drawnow', 'rplidar-roboticia', 'snakeviz', 'pyusb', 'SpeechRecognition', 'pixel-ring',
                       'click', 'cma', 'opencv-contrib-python', 'colorama', 'scikit-image', 'open3d', 'pyrealsense2', 'gitpython'
+                      'xmltodict',
                       'pyglet == 1.4.10; python_version < "3.0"', 'trimesh==3.6.38', 'urchin', # urdfpy ==> urchin
                       'pyyaml>=5.1', # required for yaml.FullLoader
                       'hello-robot-stretch-body>=0.4.26']
 )
-
-#classifiers = [
-#    "Programming Language :: Python :: 2",
-#    "License :: OSI Approved :: BSD License",
-#    "Operating System :: OS Independent",

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -27,7 +27,7 @@ setuptools.setup(
     ],
     install_requires=['numpy==1.23.2', 'scipy', 'matplotlib==3.5.0', 'ipython', 'pandas', 'sympy', 'nose', 'sh', 'packaging',
                       'inputs', 'drawnow', 'rplidar-roboticia', 'snakeviz', 'pyusb', 'SpeechRecognition', 'pixel-ring',
-                      'click', 'cma', 'opencv-contrib-python', 'colorama', 'scikit-image', 'open3d', 'pyrealsense2',
+                      'click', 'cma', 'opencv-contrib-python', 'colorama', 'scikit-image', 'open3d', 'pyrealsense2', 'gitpython'
                       'pyglet == 1.4.10; python_version < "3.0"', 'trimesh==3.6.38', 'urchin', # urdfpy ==> urchin
                       'pyyaml>=5.1', # required for yaml.FullLoader
                       'hello-robot-stretch-body>=0.4.26']

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -27,7 +27,7 @@ setuptools.setup(
     ],
     install_requires=['numpy==1.23.2', 'scipy', 'matplotlib==3.5.0', 'ipython', 'pandas', 'sympy', 'nose', 'sh', 'packaging',
                       'inputs', 'drawnow', 'rplidar-roboticia', 'snakeviz', 'pyusb', 'SpeechRecognition', 'pixel-ring',
-                      'click', 'cma', 'opencv-contrib-python', 'colorama', 'scikit-image', 'open3d', 'pyrealsense2', 'gitpython'
+                      'click', 'cma', 'opencv-contrib-python', 'colorama', 'scikit-image', 'open3d', 'pyrealsense2', 'gitpython',
                       'xmltodict',
                       'pyglet == 1.4.10; python_version < "3.0"', 'trimesh==3.6.38', 'urchin', # urdfpy ==> urchin
                       'pyyaml>=5.1', # required for yaml.FullLoader


### PR DESCRIPTION
This PR introduces automatic checking for software updates to the Stretch Body command line tools. The aim is to enable the `stretch_robot_system_check.py` tool (commonly used by Stretch users) to inform the user when SDK-level updates are available (i.e. updates to the Python or ROS packages). The user doesn't need to do anything special.

The changes in this PR are primarily made to the `stretch_robot_system_check.py` and `stretch_robot_home.py` tools. Checking for updates requires an internet connection and can be slow. To avoid slowing down the system check, the checking for software updates happens in the background while the robot is homing. When the `stretch_robot_home.py` tool is called, a background process begins, checks for an internet connection, looks for updates online, and saves the result to "~/stretch_user/log/updates_logger". This usually takes <10 seconds on a good connection, while a homing procedure takes ~30 seconds. However, if the process takes longer than the homing procedure takes, the process is sent a SIGTERM, the results are not saved, and homing completes normally.

When the `stretch_robot_system_check.py` tool is called, it looks in the "~/stretch_user/log/updates_logger" directory for information about these updates and informs the user accordingly. Here's an example output from the tool:

![Screenshot from 2023-11-28 02-51-28](https://github.com/hello-robot/stretch_body/assets/64861565/fbb89469-5811-43f3-a1f0-f24fa7db5cd0)

The output informs you if your firmware, Python pkgs, or Stretch ROS git repo, are out-of-date.

## Testing

Tested on an RE2, running Ubuntu 22.04, and the above SDK configuration.

## TODOs

- [x] Test on Ubuntu 20.04
- [x] Look into importing `stretch_*.version` instead of using `sh.pip.list` to speed up printing (UPDATE: can't do since `stretch_*.version` wouldn't tell us the editable install location of the repo)
- [x] Instead of "ROS Humble is ready", it should be "ROS**2** Humble is ready"
- [x] Check ROS_IP matches actual IPV4
- [ ] Check stretch.urdf and robot.tool parameter match actual installed tool (**edit:** tackle in the future)
- [x] Include Stretch Body Tools Version in updates YAML