### PR TITLE
File locking + Tool to free robot body

### DIFF
--- a/body/setup.py
+++ b/body/setup.py
@@ -21,7 +21,7 @@ setuptools.setup(
     ],
     install_requires=['numpy<=1.23.2', 'scipy', 'matplotlib<=3.5.0', 'ipython', 'pandas', 'sympy', 'nose',
                       'inputs', 'drawnow', 'rplidar-roboticia', 'snakeviz', 'pyusb', 'SpeechRecognition', 'pixel-ring',
-                      'click', 'cma', 'colorama',
+                      'click', 'cma', 'colorama', 'filelock',
                       'scikit-image', 'open3d', 'pyrealsense2', 'pathlib', 'psutil', 'gitpython', 'urchin', 'urdf_parser_py', # urdfpy ==> urchin
                       'opencv-contrib-python', 'renamed-opencv-python-inference-engine; python_version >= "3.0.0"', # resolve cv2 conflict for py3
                       'jsonschema==2.6.0; python_version < "3.0"', 'qtconsole==4.7.7; python_version < "3.0"', 'jupyter', # required by juypter

--- a/body/stretch_body/robot.py
+++ b/body/stretch_body/robot.py
@@ -6,6 +6,7 @@ import importlib
 import asyncio
 import os
 import sys
+from IPython import get_ipython
 from filelock import FileLock, Timeout
 
 from stretch_body.device import Device
@@ -184,6 +185,8 @@ class Robot(Device):
                 f.write(str(os.getpid()))
         except Timeout:
             print('Another process is already using Stretch. Try running "stretch_free_robot_process.py"')
+            if get_ipython():
+                raise
             sys.exit(1)
 
         self.monitor = RobotMonitor(self)

--- a/tools/bin/stretch_free_robot_process.py
+++ b/tools/bin/stretch_free_robot_process.py
@@ -1,0 +1,22 @@
+import os
+import signal
+import time
+from filelock import FileLock, Timeout
+
+pid_file = "/tmp/stretch_body_robot_pid.txt"
+file_lock = FileLock(f"{pid_file}.lock")
+try:
+    file_lock.acquire(timeout=1)
+    file_lock.release()
+except Timeout:
+    with open(pid_file, 'r') as f:
+        tokill_pid = int(f.read())
+        # send SIGTERM a few times some processes (e.g. ipython)
+        # try to stall on exit
+        os.kill(tokill_pid, signal.SIGTERM)
+        time.sleep(0.2)
+        os.kill(tokill_pid, signal.SIGTERM)
+        time.sleep(0.2)
+        os.kill(tokill_pid, signal.SIGTERM)
+finally:
+    print('Done!')

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -28,6 +28,7 @@ setuptools.setup(
     install_requires=['numpy==1.23.2', 'scipy', 'matplotlib==3.5.0', 'ipython', 'pandas', 'sympy', 'nose', 'sh', 'packaging',
                       'inputs', 'drawnow', 'rplidar-roboticia', 'snakeviz', 'pyusb', 'SpeechRecognition', 'pixel-ring',
                       'click', 'cma', 'opencv-contrib-python', 'colorama', 'scikit-image', 'open3d', 'pyrealsense2',
+                      'filelock',
                       'pyglet == 1.4.10; python_version < "3.0"', 'trimesh==3.6.38', 'urchin', # urdfpy ==> urchin
                       'pyyaml>=5.1', # required for yaml.FullLoader
                       'hello-robot-stretch-body>=0.4.26']


### PR DESCRIPTION
This PR improves the workflow for dealing with the "a Stretch Body process is already running" error. In the past, trying to run Stretch Body while an instance of Stretch Body was already running would result in the following errors/warnings:

```
[ERROR] [pimu]: Port /dev/hello-pimu is busy. Check if another Stretch Body process is already running
[WARNING] [pimu]: Unable to open serial port for device /dev/hello-pimu
[ERROR] [hello-motor-left-wheel]: Port /dev/hello-motor-left-wheel is busy. Check if another Stretch Body process is already running
[WARNING] [hello-motor-left-wheel]: Unable to open serial port for device /dev/hello-motor-left-wheel
[ERROR] [hello-motor-lift]: Port /dev/hello-motor-lift is busy. Check if another Stretch Body process is already running
[WARNING] [hello-motor-lift]: Unable to open serial port for device /dev/hello-motor-lift
[ERROR] [hello-motor-arm]: Port /dev/hello-motor-arm is busy. Check if another Stretch Body process is already running
[WARNING] [hello-motor-arm]: Unable to open serial port for device /dev/hello-motor-arm
```

For novice Stretch users, this output is scary looking and doesn't clearly communicate **how** to check if another process is already running (since often, that process is running in the background). Additionally, the Dynamixel classes are not lock protected, so the background Stretch Body instance will start to have trouble pinging the Dxls:

```
[WARNING] [tool_stretch_dex_wrist]: Dynamixel communication error during pull_status on tool_stretch_dex_wrist: 
[WARNING] [head]: Dynamixel communication error during pull_status on head: 
[WARNING] [head]: Dynamixel communication error during pull_status on head: 
[WARNING] [head]: Dynamixel communication error during pull_status on head: 
[WARNING] [head]: Dynamixel communication error during pull_status on head: 
[WARNING] [head]: Dynamixel communication error during pull_status on head: 
[WARNING] [head]: Dynamixel communication error during pull_status on head:
repeats indefinitely...
```
---
To improve on this workflow, using the `Robot` class from Stretch Body will now acquire a lock from the filesystem and write its process ID using the lock. If another Stretch Body instance has already claimed the lock, the following error is printed out:

```
Another process is already using Stretch. Try running "stretch_free_robot_process.py"
```

The new `stretch_free_robot_process.py` tool reads the process ID of the Stretch Body instance holding the lock and terminates the process. This is more reliable than using `pkill -9 python` or similar because it actually knows the process ID and won't be fooled if the process running Stretch Body doesn't have "python" in the name. Additionally, other python processes (e.g. hello_robot_lrf_off.py) won't get killed unintentionally.

At the moment, the lock is acquired in `Robot.__init__()` and released in `Robot.stop()`, but after bug #217 is fixed, the lock acquiring logic can be moved to `Robot.startup()`.

Testing
---------
Stretch 2 running Ubuntu 22.04. Tested with Stretch Body tools, iPython, ROS, ROS2, and more.