### PR TITLE
turn off roll pos_current_ctl

### DIFF
--- a/body/stretch_body/wrist_roll.py
+++ b/body/stretch_body/wrist_roll.py
@@ -9,7 +9,7 @@ class WristRoll(DynamixelHelloXL430):
     def __init__(self, chain=None, usb=None, name='wrist_roll'):
         DynamixelHelloXL430.__init__(self, name, chain, usb)
         self.poses = {'cw_90': hu.deg_to_rad(90.0), 'forward': hu.deg_to_rad(0.0), 'ccw_90': hu.deg_to_rad(-90.0)}
-        self.pos_current_ctrl_on_startup = True
+        self.pos_current_ctrl_on_startup = False
 
     def enable_float_mode(self):
         """


### PR DESCRIPTION
This PR turns off the pos_current_ctrl mode of the DW3 roll joint due to vibration behavior. May still turn it back on with better tuning in the future (for safety)