### PR TITLE
Features/urdf params cleanup

### DIFF
--- a/body/setup.py
+++ b/body/setup.py
@@ -30,7 +30,7 @@ setuptools.setup(
                       'dynamixel-sdk>=3.1; python_version >= "3.0.0"', # py2 gets dynamixel-sdk through ROS
                       'pyyaml>=5.1', # required for yaml.FullLoader
                       'hello-robot-stretch-tool-share>=0.2.6', # defines other Stretch end effectors
-                      'hello-robot-stretch-factory>=0.3.5','hello-robot-stretch-body-tools>=0.4.2',
+                      'hello-robot-stretch-factory>=0.3.5','hello-robot-stretch-body-tools>=0.7.2',
                       'hello-robot-stretch-urdf>=0.0.16',
                       'aioserial', 'meshio','numpy-stl','playsound', 'pyrender'
                       ]

--- a/body/stretch_body/dynamixel_hello_XL430.py
+++ b/body/stretch_body/dynamixel_hello_XL430.py
@@ -577,6 +577,15 @@ class DynamixelHelloXL430(Device):
             self.watchdog_enabled = True
             self.enable_torque()
         v = min(self.params['motion']['max']['vel'],abs(v_des))
+
+        if self.in_collision_stop['pos'] and v_des>0:
+            self.logger.warning('set_velocity in collision . Motion disabled in direction %s for %s. Not executing set_velocity'%('pos',self.name))
+            return
+
+        if self.in_collision_stop['neg'] and v_des<0:
+            self.logger.warning('set_velocity in collision. Motion disabled in direction %s for %s. Not executing set_velocity'%('neg',self.name))
+            return
+
         v_des = -1*v if v_des<0 else v
         nretry = 2
         if not self.hw_valid:
@@ -677,6 +686,16 @@ class DynamixelHelloXL430(Device):
             self.logger.warning('Dynamixel not calibrated: %s' % self.name)
             print('Dynamixel not calibrated:', self.name)
             return
+
+
+        if self.in_collision_stop['pos'] and self.status['pos']<x_des:
+            self.logger.warning('move_to in collision. Motion disabled in direction %s for %s. Not executing move_to'%('pos',self.name))
+            return
+
+        if self.in_collision_stop['neg'] and self.status['pos']>x_des:
+            self.logger.warning('move_to in collision. Motion disabled in direction %s for %s. Not executing move_to'%('neg',self.name))
+            return
+
         if self.in_vel_mode:
             self.enable_pos()
         #print('Motion Params',v_des,a_des)
@@ -736,6 +755,19 @@ class DynamixelHelloXL430(Device):
 
                 if self.motor.last_comm_success:
                     cx=self.ticks_to_world_rad(x)
+
+                    if self.in_collision_stop['pos'] and self.status['pos'] < cx + x_des:
+                        self.logger.warning(
+                            'move_by in collision. Motion disabled in direction %s for %s. Not executing move_by' % (
+                            'pos', self.name))
+                        return
+
+                    if self.in_collision_stop['neg'] and self.status['pos'] > cx + x_des:
+                        self.logger.warning(
+                            'move_by in collision. Motion disabled in direction %s for %s. Not executing move_by' % (
+                            'neg', self.name))
+                        return
+
                     self.move_to(cx + x_des, v_des, a_des)
                 else:
                     self.logger.debug('Move_By comm failure on %s' % self.name)

--- a/body/stretch_body/dynamixel_hello_XL430.py
+++ b/body/stretch_body/dynamixel_hello_XL430.py
@@ -69,7 +69,6 @@ class DynamixelHelloXL430(Device):
             self.usb = usb
             if self.usb is None:
                 self.usb = self.params['usb_name']
-
             #Share bus resource amongst many XL430s
             self.motor = DynamixelXL430(dxl_id=self.params['id'],
                                         usb=self.usb,

--- a/body/stretch_body/end_of_arm.py
+++ b/body/stretch_body/end_of_arm.py
@@ -111,9 +111,10 @@ class EndOfArm(DynamixelXChain):
             motor = self.get_joint(jn)
             dx = 0.0
             if braked:
-                dx = self.params['k_brake_distance'][jn] * motor.get_braking_distance()
+                dx = self.params['collision_mgmt']['k_brake_distance'][jn] * motor.get_braking_distance()
             ret[j] = motor.status['pos'] + dx
         return ret
+
 
 
 

--- a/body/stretch_body/end_of_arm_tools.py
+++ b/body/stretch_body/end_of_arm_tools.py
@@ -64,7 +64,7 @@ class EOA_Wrist_DW3_Tool_NIL(EndOfArm):
             'joint_wrist_roll':'wrist_roll'}
     def stow(self):
         # Fold in wrist and gripper
-        print('--------- Stowing EOA_Wrist_DW3_Tool_NIL ----')
+        print('--------- Stowing %s ----'%self.name)
         self.move_to('wrist_pitch', self.params['stow']['wrist_pitch'])
         self.move_to('wrist_roll', self.params['stow']['wrist_roll'])
         self.move_to('wrist_yaw', self.params['stow']['wrist_yaw'])
@@ -88,7 +88,7 @@ class EOA_Wrist_DW3_Tool_SG3(EndOfArm):
 
     def stow(self):
         # Fold in wrist and gripper
-        print('--------- Stowing EOA_Wrist_DW3_Tool_SG3 ----')
+        print('--------- Stowing %s ----'%self.name)
         self.move_to('wrist_pitch', self.params['stow']['wrist_pitch'])
         self.move_to('wrist_roll', self.params['stow']['wrist_roll'])
         self.move_to('wrist_yaw', self.params['stow']['wrist_yaw'])

--- a/body/stretch_body/robot.py
+++ b/body/stretch_body/robot.py
@@ -298,6 +298,8 @@ class Robot(Device):
         self.collision.startup()
         if not self.params['use_collision_manager']: #Turn it off here but allow user to enable it via SW later
             self.disable_collision_mgmt()
+        else:
+            self.enable_collision_mgmt()
 
         # Register the signal handlers
         signal.signal(signal.SIGTERM, hello_utils.thread_service_shutdown)

--- a/body/stretch_body/robot.py
+++ b/body/stretch_body/robot.py
@@ -134,7 +134,7 @@ class SystemMonitorThread(threading.Thread):
         self.monitor_downrate_int = int(robot.params['rates']['SystemMonitorThread_monitor_downrate_int'])  # Step the monitor at every Nth iteration
         self.trace_downrate_int = int(robot.params['rates']['SystemMonitorThread_trace_downrate_int'])  # Step the trace at every Nth iteration
         self.sentry_downrate_int = int(robot.params['rates']['SystemMonitorThread_sentry_downrate_int']) # Step the sentry at every Nth iteration
-        self.collision_downrate_int = int(robot.params['rates']['SystemMonitorThread_collision_downrate_int'])  # Step the monitor at every Nth iteration
+        #self.collision_downrate_int = int(robot.params['rates']['SystemMonitorThread_collision_downrate_int'])  # Step the monitor at every Nth iteration
         self.trajectory_downrate_int = int(robot.params['rates']['SystemMonitorThread_nondxl_trajectory_downrate_int'])  # Update hardware with waypoint trajectory segments at every Nth iteration
 
         if self.robot.params['use_monitor']:

--- a/body/stretch_body/robot_collision.py
+++ b/body/stretch_body/robot_collision.py
@@ -5,7 +5,7 @@ import urchin as urdf_loader
 import meshio
 import numpy as np
 import time
-import playsound
+#import chime
 
 try:
     # works on ubunut 22.04
@@ -18,6 +18,89 @@ except AttributeError as e:
 
 # #######################################################################
 
+def line_box_sat_intersection(line_point1, line_point2, aabb_min, aabb_max):
+    """
+    Checks if a line segment intersects an AABB using the Separating Axis Theorem (SAT).
+
+    Args:
+        line_point1: np.array of shape (3,). First point of the line segment.
+        line_point2: np.array of shape (3,). Second point of the line segment.
+        aabb_min: np.array of shape (3,). Minimum corner of the AABB.
+        aabb_max: np.array of shape (3,). Maximum corner of the AABB.
+
+    Returns:
+        bool: True if the line intersects the AABB, False otherwise.
+    """
+
+    line_dir = line_point2 - line_point1
+
+    # Check separating axes along AABB's edges
+    for i in range(3):
+        # Project line segment onto axis
+        line_proj = np.dot(line_point1, np.eye(3)[i]) + np.dot(line_dir, np.eye(3)[i])
+        aabb_proj = np.array([aabb_min[i], aabb_max[i]])
+
+        # Check for overlap
+        if not (np.min(line_proj) <= np.max(aabb_proj) and np.max(line_proj) >= np.min(aabb_proj)):
+            return False  # No overlap on this axis
+
+    # Check separating axes along line direction
+    line_axis = line_dir / np.linalg.norm(line_dir)
+    aabb_proj = np.dot(aabb_min, line_axis), np.dot(aabb_max, line_axis)
+    line_proj = np.dot(line_point1, line_axis), np.dot(line_point1 + line_dir, line_axis)
+
+    # Check for overlap
+    if not (np.min(line_proj) <= np.max(aabb_proj) and np.max(line_proj) >= np.min(aabb_proj)):
+        return False  # No overlap on the line axis
+
+    return True  # No separating axis found, intersection exists
+
+
+def check_pts_in_AABB_cube(cube, pts):
+    """
+    Check if any of the 'points lie inside the cube
+    Parameters
+    ----------
+    cube: Array of points of cube (8x4)
+    pts: Array of points to check
+
+    Returns
+    -------
+    True/False
+    """
+    xmax = max(cube[:, 0])
+    xmin = min(cube[:, 0])
+    ymax = max(cube[:, 1])
+    ymin = min(cube[:, 1])
+    zmax = max(cube[:, 2])
+    zmin = min(cube[:, 2])
+
+    for p in pts:
+        inside = p[0] <= xmax and p[0] >= xmin and p[1] <= ymax and p[1] >= ymin and p[2] <= zmax and p[2] >= zmin
+        if inside:
+            return True
+    return False
+
+def check_ppd_edges_in_cube(cube,cube_edge,edge_indices):
+    if len(edge_indices)!=12:
+        print('Invalid PPD provided to check_ppd_edges_in_cube')
+        return False
+    aabb_min=np.array([min(cube[:, 0]),min(cube[:, 1]),min(cube[:, 2])],dtype=np.float32)
+    aabb_max = np.array([max(cube[:, 0]),max(cube[:, 1]),max(cube[:, 2])],dtype=np.float32)
+    print('EE',cube_edge)
+    for ei in edge_indices:
+        e0=cube_edge[ei][0][0:3]
+        e1=cube_edge[ei][1][0:3]
+        print('----',ei)
+        print('e0',e0)
+        print('e1', e1)
+        print('aabb_min', aabb_min)
+        print('aabb_max', aabb_max)
+        if line_box_sat_intersection(e0,e1, aabb_min, aabb_max):
+            return True
+    return False
+
+# #######################################################################
 
 class CollisionLink:
     def __init__(self,link_name,urdf,mesh_path,max_mesh_points):
@@ -29,28 +112,69 @@ class CollisionLink:
         self.points = np.hstack((pts, np.ones([pts.shape[0], 1], dtype=np.float32)))  # One extend to Nx4 array
         self.in_collision= False
         self.was_in_collision = False
-        self.is_xyz_cube=self.check_xyz_cube(self.points)
+        self.is_aabb=self.check_AABB(self.points)
         self.is_valid=True
         if pts.shape[0] > max_mesh_points:
             print('Incorrect size of points for link:', link_name, pts.shape)
             print('Ignoring collision link %s' % link_name)
             self.is_valid=False
         self.pose=None
+        self.edge_indices_ppd=self.find_edge_indices_PPD()
+
+
+    def is_ppd(self):
+        return self.points.shape[0]==8
 
     def set_pose(self,p):
         self.pose=p
 
     def pretty_print(self):
         print('-- CollisionLink %s --'%self.name)
-        print('XYZ Cube',self.is_xyz_cube)
+        print('AABB Cube',self.is_aabb)
         print('Is Valid', self.is_valid)
         print('In collision',self.in_collision)
         print('Was in collision',self.was_in_collision)
         print('Mesh size',self.points.shape)
 
-    def check_xyz_cube(self,pts):
+    def find_edge_indices_PPD(self):
         """
-        Check if points are aligned (roughly) to xyz and form a cube
+        Return the indices for each edge assuming the link is a parallelpiped (PPD)
+        """
+
+        triangles=self.mesh.cells_dict['triangle']
+
+        for t in triangles:
+            idx_pairs=[[0,1],[0,2],[1,2]]
+            edge_lens=[]
+            for ii in idx_pairs:
+                edge_lens.append(np.linalg.norm(self.points[ii[0]]-self.points[ii[2]]))
+            exterior_edges = np.array(idx_pairs)[np.argsort(np.array(edge_lens))][0:2] #indices of two shortest legs of triangle
+
+
+
+
+        px=self.points.shape[0]
+        # if not self.is_ppd():
+        #     return np.array([])
+        idx=[]
+        lens=[]
+        #Toss out really short edge as is a mesh file artifact
+
+        for i in range(px):
+            for j in range(i+1,px):
+                ll = np.linalg.norm(self.points[i] - self.points[j])
+                if ll>eps:
+                    idx.append([i,j])
+                    lens.append(ll)
+        #return 12 shortest lengths of all possible combinations
+        q= np.array(idx)[np.argsort(np.array(lens))][0:12]
+        lens.sort()
+        print('LENS',lens)
+        return q
+
+    def check_AABB(self,pts):
+        """
+        Check if points are axis aligned (roughly) and form a rectangular parallelpiped (eg AABB)
 
         Parameters
         ----------
@@ -74,27 +198,27 @@ class CollisionLink:
         return True
 
 class CollisionPair:
-    def __init__(self, link_pts,link_cube,motion_dir,joint_name):
+    def __init__(self, name,link_pts,link_cube,detect_as):
         self.in_collision=False
         self.was_in_collision=False
         self.link_cube=link_cube
         self.link_pts=link_pts
-        self.motion_dir=motion_dir
-        self.joint_name=joint_name
-        self.name_id='J_%s_LP_%s_LC_%s_DR_%s'%(joint_name,link_pts.name,link_cube.name,motion_dir)
-        self.is_valid=self.link_cube.is_valid and self.link_pts.is_valid and self.link_cube.is_xyz_cube
+        self.detect_as=detect_as
+        self.name=name
+        self.is_valid=self.link_cube.is_valid and self.link_pts.is_valid and self.link_cube.is_aabb
         if not self.is_valid:
             print('Dropping monitor of collision pair %s'%self.name_id)
 
     def pretty_print(self):
-        print('Collision pair: %s'%self.name_id)
+        print('-------- Collision Pair %s ----------------'%self.name_id.upper())
+        print('In collision',self.in_collision)
+        print('Was in collision',self.was_in_collision)
         print('Is Valid',self.is_valid)
-        print('--Link Cube--')
-        self.link_cube.pretty_print()
-        print('--Link Pts--')
-        self.link_pts.pretty_print()
-    def get_name_id(self):
-        return self.name_id
+        # print('--Link Cube--')
+        # self.link_cube.pretty_print()
+        # print('--Link Pts--')
+        # self.link_pts.pretty_print()
+
 
 class CollisionJoint:
     def __init__(self, joint_name,motor):
@@ -102,14 +226,17 @@ class CollisionJoint:
         self.motor=motor
         self.active_collisions=[]
         self.collision_pairs=[]
+        self.collision_dirs={}
         self.in_collision={'pos':False,'neg':False}
         self.was_in_collision = {'pos': False, 'neg': False}
-    def add_collision_pair(self,cp):
-        self.collision_pairs.append(cp)
+    def add_collision_pair(self,motion_dir, collision_pair):
+        self.collision_pairs.append(collision_pair)
+        self.collision_dirs[collision_pair.name]=motion_dir
     def pretty_print(self):
         print('-------Collision Joint: %s-----------------'%self.name)
         for cp in self.collision_pairs:
             cp.pretty_print()
+            print('Motion dir: %s'%self.collision_dirs[cp.name])
         print('--Active Collisions--')
         print(self.active_collisions)
         for ac in self.active_collisions:
@@ -123,7 +250,7 @@ class RobotCollisionMgmt(Device):
         It utilizes the Collision mesh for collision estimation.
         Given the Cartesian structure of Stretch we simplify the collision detection in order to achieve real-time speeds.
         We simplify the problem by assuming:
-        * One of the collision meshes ("cube") is a cube that is aligned with gravity (XYZ)
+        * One of the collision meshes ("cube") is a cube that is aligned with XYZ axis (eg AABB)
         * The other collision mesh ("pts") is simple shape of just a few points (eg, a cube, trapezoid, etc)<max_mesh_points
 
         The params define which links we want to monitor collisions between.
@@ -135,6 +262,7 @@ class RobotCollisionMgmt(Device):
         self.collision_joints = {}
         self.collision_links = {}
         self.collision_pairs = {}
+        #chime.theme('big-sur') #'material')#
         self.running=True
 
     def pretty_print(self):
@@ -161,26 +289,41 @@ class RobotCollisionMgmt(Device):
             self.urdf = None
             return
 
-        #Build dict of potential collisions_pairs for each joint
+        #Construct collision pairs
+        cp_dict = self.params[model_name]['collision_pairs']
+        cp_dict.update(self.robot.end_of_arm.params['collision_mgmt']['collision_pairs'])
+
+        for cp_name in cp_dict:
+            cp=cp_dict[cp_name] #Eg {'link_pts': 'link_head_tilt', 'link_cube': 'link_arm_l4','detect_as':'pts'}
+            if cp['link_pts'] not in self.collision_links:
+                self.collision_links[cp['link_pts']] = CollisionLink(cp['link_pts'], self.urdf, mesh_path,
+                                                                     self.params['max_mesh_points'])
+            if cp['link_cube'] not in self.collision_links:
+                self.collision_links[cp['link_cube']] = CollisionLink(cp['link_cube'], self.urdf, mesh_path,
+                                                                      self.params['max_mesh_points'])
+            self.collision_pairs[cp_name] = CollisionPair(name=cp_name,
+                                                          link_pts=self.collision_links[cp['link_pts']],
+                                                          link_cube=self.collision_links[cp['link_cube']],
+                                                          detect_as=cp['detect_as'])
+
+        #Assign collision pairs to each joint
         #Include those of standard robot body plus its defined tool
         # EG collision_joints={'lift':[{collision_1},{collision_2...}],'head_pan':[...]}
-        cj=self.params[model_name]
-        for tt in self.params[eoa_name]:
-            if tt in cj:
-                cj[tt]+=self.params[eoa_name][tt]
-            else:
-                cj[tt]=self.params[eoa_name][tt]
+        cj_dict=self.params[model_name]['joints']
+        eoa_cj_dict=self.robot.end_of_arm.params['collision_mgmt']['joints']
 
-        for joint_name in cj:
+        for tt in eoa_cj_dict:
+            if tt in cj_dict:
+                cj_dict[tt]+=eoa_cj_dict[tt]
+            else:
+                cj_dict[tt]=eoa_cj_dict[tt]
+
+        for joint_name in cj_dict:
             self.collision_joints[joint_name]=CollisionJoint(joint_name,self.get_joint_motor(joint_name))
-            for cp in cj[joint_name]: #eg cp={'motion_dir': 'neg', 'link_pts': 'link_lift', 'link_cube': 'base_link'}
-                if cp['link_pts'] not in self.collision_links:
-                    self.collision_links[cp['link_pts']]=CollisionLink(cp['link_pts'],self.urdf,mesh_path,self.params['max_mesh_points'])
-                if cp['link_cube'] not in self.collision_links:
-                    self.collision_links[cp['link_cube']]=CollisionLink(cp['link_cube'],self.urdf,mesh_path,self.params['max_mesh_points'])
-                p=CollisionPair(self.collision_links[cp['link_pts']],self.collision_links[cp['link_cube']],cp['motion_dir'],joint_name)
-                self.collision_pairs[p.get_name_id()]=p
-                self.collision_joints[joint_name].add_collision_pair(p)
+            cp_list = cj_dict[joint_name]
+            for cp in cp_list: #eg cp={'motion_dir': 'pos', 'collision_pair': 'link_head_tilt_TO_link_arm_l4'}
+                self.collision_joints[joint_name].add_collision_pair(motion_dir=cp['motion_dir'],
+                                                                     collision_pair=self.collision_pairs[cp['collision_pair']])
 
     def get_joint_motor(self,joint_name):
         if joint_name=='lift':
@@ -217,37 +360,46 @@ class RobotCollisionMgmt(Device):
         for link_name in self.collision_links:
             self.collision_links[link_name].was_in_collision =self.collision_links[link_name].in_collision
             self.collision_links[link_name].in_collision=False
-
         for joint_name in self.collision_joints:
             self.collision_joints[joint_name].active_collisions=[]
             self.collision_joints[joint_name].was_in_collision = self.collision_joints[joint_name].in_collision.copy()
             self.collision_joints[joint_name].in_collision = {'pos': False, 'neg': False}
 
-        # Test for collision between cube pairs
+        # Test for collisions across all collision pairs
         for pair_name in self.collision_pairs:
             cp=self.collision_pairs[pair_name]
             if cp.is_valid:
                 cp.was_in_collision=cp.in_collision
-                cp.in_collision=self.check_pts_in_cube(cube=cp.link_cube.pose,pts=cp.link_pts.pose)
-                if cp.in_collision:
-                    cj = self.collision_joints[cp.joint_name]
-                    cj.active_collisions.append(cp.get_name_id()) #Add collision to joint
-                    cj.in_collision[cp.motion_dir] = True
+                if cp.detect_as=='pts':
+                    cp.in_collision=check_pts_in_AABB_cube(cube=cp.link_cube.pose,pts=cp.link_pts.pose)
+                elif cp.detect_as=='edges':
+                    print('Checking', cp.name)
+                    cp.in_collision = check_ppd_edges_in_cube(cube=cp.link_cube.pose, cube_edge=cp.link_pts.pose,edge_indices=cp.link_pts.edge_indices_ppd)
+                else:
+                    cp.in_collision =False
+                    #cp.pretty_print()
+
                 #Propogate to links
                 self.collision_links[cp.link_cube.name].in_collision=self.collision_links[cp.link_cube.name].in_collision or cp.in_collision
                 self.collision_links[cp.link_pts.name].in_collision =self.collision_links[cp.link_pts.name].in_collision or cp.in_collision
 
-        #Update collision avoidance
+                # Beep on new collision
+                if not self.collision_pairs[pair_name].was_in_collision and self.collision_pairs[pair_name].in_collision:
+                    print('New collision pair event: %s'%pair_name)
+                    print('\a')
+                    #chime.warning()
+
+        #Now update joint state
         for joint_name in self.collision_joints:
+            cj = self.collision_joints[joint_name]
+            for cp in cj.collision_pairs:
+                if cp.in_collision:
+                    cj.active_collisions.append(cp.name) #Add collision to joint
+                    cj.in_collision[cj.collision_dirs[cp.name]] = True
+            #Finally, update the collision state for each joint
             self.collision_joints[joint_name].motor.step_collision_avoidance(self.collision_joints[joint_name].in_collision)
 
-        #Beep on new collision
-        #Note: subtle issue. Playing the beep can take a variable amount of time depending on sys resources
-        #Call it after we do the step_collision_avoidance so that the stop controller can be triggered as close to
-        #Collision detection as possible (otherwise the longer time can allow a collision in worst case conditions)
-        for pair_name in self.collision_pairs:
-            if not self.collision_pairs[pair_name].was_in_collision and self.collision_pairs[pair_name].in_collision:
-                playsound.playsound('/usr/share/sounds/ubuntu/stereo/message.ogg', block=False)
+
 
     def is_link_in_collsion(self,link_name):
         if self.urdf is None:
@@ -265,29 +417,6 @@ class RobotCollisionMgmt(Device):
         except KeyError: #Not all links will be monitored
             return False
 
-    def check_pts_in_cube(self,cube, pts):
-        """
-        Check if any of the 'from' points lie inside the 'into' cube
-        Parameters
-        ----------
-        cube_into: Array of points of cube (8x4)
-        pts_from: Array of points to check
-
-        Returns
-        -------
-        True/False
-        """
-        xmax = max(cube[:, 0])
-        xmin = min(cube[:, 0])
-        ymax = max(cube[:, 1])
-        ymin = min(cube[:, 1])
-        zmax = max(cube[:, 2])
-        zmin = min(cube[:, 2])
-        for p in pts:
-            inside = p[0] <= xmax and p[0] >= xmin and p[1] <= ymax and p[1] >= ymin and p[2] <= zmax and p[2] >= zmin
-            if inside:
-                return True
-        return False
 
     def get_joint_configuration(self,braked=False):
         """
@@ -295,11 +424,12 @@ class RobotCollisionMgmt(Device):
         """
         s = self.robot.get_status()
 
+        kbd = self.params[self.robot.params['model_name']]['k_brake_distance']
         if braked:
-            da=self.params['k_brake_distance']['arm']*self.robot.arm.get_braking_distance()/4.0
-            dl=self.params['k_brake_distance']['lift']*self.robot.lift.get_braking_distance()
-            dhp = self.params['k_brake_distance']['head_pan'] * self.robot.head.get_joint('head_pan').get_braking_distance()
-            dht = self.params['k_brake_distance']['head_tilt'] * self.robot.head.get_joint('head_tilt').get_braking_distance()
+            da=kbd['arm']*self.robot.arm.get_braking_distance()/4.0
+            dl=kbd['lift']*self.robot.lift.get_braking_distance()
+            dhp = kbd['head_pan'] * self.robot.head.get_joint('head_pan').get_braking_distance()
+            dht = kbd['head_tilt'] * self.robot.head.get_joint('head_tilt').get_braking_distance()
         else:
             da=0.0
             dl=0.0

--- a/body/stretch_body/robot_collision.py
+++ b/body/stretch_body/robot_collision.py
@@ -119,7 +119,7 @@ class CollisionLink:
             print('Ignoring collision link %s' % link_name)
             self.is_valid=False
         self.pose=None
-        self.edge_indices_ppd=self.find_edge_indices_PPD()
+        #self.edge_indices_ppd=self.find_edge_indices_PPD()
 
 
     def is_ppd(self):
@@ -372,9 +372,9 @@ class RobotCollisionMgmt(Device):
                 cp.was_in_collision=cp.in_collision
                 if cp.detect_as=='pts':
                     cp.in_collision=check_pts_in_AABB_cube(cube=cp.link_cube.pose,pts=cp.link_pts.pose)
-                elif cp.detect_as=='edges':
-                    print('Checking', cp.name)
-                    cp.in_collision = check_ppd_edges_in_cube(cube=cp.link_cube.pose, cube_edge=cp.link_pts.pose,edge_indices=cp.link_pts.edge_indices_ppd)
+                # elif cp.detect_as=='edges':
+                #     print('Checking', cp.name)
+                #     cp.in_collision = check_ppd_edges_in_cube(cube=cp.link_cube.pose, cube_edge=cp.link_pts.pose,edge_indices=cp.link_pts.edge_indices_ppd)
                 else:
                     cp.in_collision =False
                     #cp.pretty_print()

--- a/body/stretch_body/robot_collision.py
+++ b/body/stretch_body/robot_collision.py
@@ -263,7 +263,8 @@ class RobotCollisionMgmt(Device):
         self.collision_links = {}
         self.collision_pairs = {}
         #chime.theme('big-sur') #'material')#
-        self.running=True
+        self.running=False
+        self.urdf=None
 
     def pretty_print(self):
         for j in self.collision_joints:
@@ -282,11 +283,17 @@ class RobotCollisionMgmt(Device):
         urdf_name = pkg + '/%s/stretch_description_%s_%s.urdf' % (model_name, model_name, eoa_name)
         mesh_path = pkg + '/%s/' % (model_name)
 
+        if self.params[model_name]=={}:
+            #self.logger.warning('Collision parameters not present. Disabling collision system.')
+            self.running = False
+            return
+
         try:
             self.urdf = urdf_loader.URDF.load(urdf_name)
         except ValueError:
-            print('Unable to load URDF: %s' % urdf_name)
+            print('Unable to load URDF: %s. Disabling collision system.' % urdf_name)
             self.urdf = None
+            self.running = False
             return
 
         #Construct collision pairs

--- a/body/stretch_body/robot_params_RE1V0.py
+++ b/body/stretch_body/robot_params_RE1V0.py
@@ -151,11 +151,13 @@ nominal_params={
         'use_group_sync_read': 1,
         'retry_on_comm_failure': 1,
         'dxl_latency_timer': 64,
+        'baud':115200,
         'stow': {'wrist_yaw': 3.4}},
     'head':{
         'usb_name': '/dev/hello-dynamixel-head',
         'use_group_sync_read': 1,
         'retry_on_comm_failure': 1,
+        'baud': 115200,
         'dxl_latency_timer':64},
     'head_pan':{
         'range_pad_t': [50.0, -50.0],
@@ -164,6 +166,8 @@ nominal_params={
         'id': 11,
         'max_voltage_limit': 15,
         'min_voltage_limit': 11,
+        'baud': 115200,
+        'use_multiturn': 0,
         'motion': {
             'trajectory_vel_ctrl': 1,
             'trajectory_vel_ctrl_kP':1.5,
@@ -205,6 +209,7 @@ nominal_params={
         'id': 12,
         'max_voltage_limit': 15,
         'min_voltage_limit': 11,
+        'baud': 115200,
         'motion': {
             'trajectory_vel_ctrl': 1,
             'trajectory_vel_ctrl_kP':1.5,
@@ -447,7 +452,7 @@ nominal_params={
             'SystemMonitorThread_Hz': 15.0,
             'SystemMonitorThread_monitor_downrate_int': 2,
             'SystemMonitorThread_trace_downrate_int': 1,
-            'SystemMonitorThread_collision_downrate_int': 1,
+            #'SystemMonitorThread_collision_downrate_int': 1,
             'SystemMonitorThread_sentry_downrate_int': 1,
             'SystemMonitorThread_nondxl_trajectory_downrate_int': 2},
         'tool': 'tool_stretch_gripper',
@@ -477,6 +482,9 @@ nominal_params={
         'n_samples_per_file':100,
         'duration_limit_minutes':10.0
     },
+    'robot_collision_mgmt': {
+        'max_mesh_points': 48,
+        'RE1V0': {}},
     'robot_sentry':{
         'base_fan_control': 1,
         'base_max_velocity': 1,
@@ -492,6 +500,7 @@ nominal_params={
         'max_voltage_limit': 15,
         'min_grip_strength': -125,
         'min_voltage_limit': 11,
+        'baud': 115200,
         'gripper_conversion':'stretch_gripper_conversion',
         'motion':{
             'trajectory_vel_ctrl': 1,
@@ -544,6 +553,7 @@ nominal_params={
         'dxl_latency_timer': 64,
         'py_class_name': 'ToolNone',
         'py_module_name': 'stretch_body.end_of_arm_tools',
+        'baud': 115200,
         'stow': {'wrist_yaw': 3.4},
         'devices': {
             'wrist_yaw': {
@@ -555,6 +565,7 @@ nominal_params={
         'dxl_latency_timer': 64,
         'py_class_name': 'ToolStretchGripper',
         'py_module_name': 'stretch_body.end_of_arm_tools',
+        'baud': 115200,
         'stow': {'stretch_gripper': 0, 'wrist_yaw': 3.4},
         'devices': {
             'stretch_gripper': {
@@ -581,6 +592,7 @@ nominal_params={
         'id': 13,
         'max_voltage_limit': 15,
         'min_voltage_limit': 11,
+        'baud': 115200,
         'motion': {
             'trajectory_vel_ctrl': 1,
             'trajectory_vel_ctrl_kP': 1.5,

--- a/body/stretch_body/robot_params_RE2V0.py
+++ b/body/stretch_body/robot_params_RE2V0.py
@@ -461,24 +461,8 @@ nominal_params={
         'use_sentry': 1,
         'use_asyncio':1},
     'robot_collision_mgmt': {
-        'max_mesh_points': 36,
-        'k_brake_distance': {'lift': 0.75, 'arm': 0.125, 'wrist_yaw': 0.125, 'head_pan': 0.125, 'head_tilt': 0.125},
-        'RE2V0': {
-            'lift': [{'motion_dir': 'pos', 'link_pts': 'link_head_tilt', 'link_cube': 'link_arm_l4'}],
-            'arm': [{'motion_dir': 'neg', 'link_pts': 'link_arm_l0', 'link_cube': 'base_link'}],
-        },
-        'tool_stretch_gripper': {
-            'lift': [{'motion_dir': 'neg', 'link_pts': 'link_gripper', 'link_cube': 'base_link'},
-                     {'motion_dir': 'neg', 'link_pts': 'link_gripper_finger_left', 'link_cube': 'base_link'},
-                     {'motion_dir': 'neg', 'link_pts': 'link_gripper_finger_right', 'link_cube': 'base_link'},
-                     {'motion_dir': 'neg', 'link_pts': 'link_gripper_fingertip_left', 'link_cube': 'base_link'},
-                     {'motion_dir': 'neg', 'link_pts': 'link_gripper_fingertip_right', 'link_cube': 'base_link'}],
-            'arm': [{'motion_dir': 'neg', 'link_pts': 'link_gripper', 'link_cube': 'base_link'}],
-            'wrist_yaw': [{'motion_dir': 'pos', 'link_pts': 'link_gripper_finger_left', 'link_cube': 'base_link'},
-                          {'motion_dir': 'neg', 'link_pts': 'link_gripper_finger_right', 'link_cube': 'base_link'}]},
-        'tool_stretch_dex_wrist': {},
-        'tool_none': {},
-    },
+        'max_mesh_points': 48,
+        'RE2V0': {}},
     'robot_monitor':{
         'monitor_base_bump_event': 1,
         'monitor_base_cliff_event': 1,
@@ -495,6 +479,8 @@ nominal_params={
         'dynamixel_stop_on_runstop': 1,
         'stretch_gripper_overload': 1,
         'wrist_yaw_overload': 1,
+        'wrist_pitch_overload': 1,
+        'wrist_roll_overload': 1,
         'stepper_is_moving_filter': 1},
     'robot_trace':{
         'n_samples_per_file':100,
@@ -555,6 +541,68 @@ nominal_params={
                                       'closed_aperture_m':0.0,
                                       'open_robotis':70.0,
                                       'closed_robotis':0.0},
+    "eoa_wrist_dw3_tool_sg3": {
+        'py_class_name': 'EOA_Wrist_DW3_Tool_SG3',
+        'py_module_name': 'stretch_body.end_of_arm_tools',
+        'use_group_sync_read': 1,
+        'retry_on_comm_failure': 1,
+        'baud': 115200,
+        'dxl_latency_timer': 64,
+        'stow': {
+            'arm': 0.0,
+            'lift': 0.3,
+            'wrist_pitch': -0.52,
+            'wrist_roll': 0.0,
+            'wrist_yaw': 3.0,
+            'stretch_gripper': 0.0
+        },
+        'devices': {
+            'wrist_pitch': {
+                'py_class_name': 'WristPitch',
+                'py_module_name': 'stretch_body.wrist_pitch'
+            },
+            'wrist_roll': {
+                'py_class_name': 'WristRoll',
+                'py_module_name': 'stretch_body.wrist_roll'
+            },
+            'wrist_yaw': {
+                'py_class_name': 'WristYaw',
+                'py_module_name': 'stretch_body.wrist_yaw'
+            },
+            'stretch_gripper': {
+                'py_class_name': 'StretchGripper3',
+                'py_module_name': 'stretch_body.stretch_gripper',
+            }
+        }},
+    "eoa_wrist_dw3_tool_nil": {
+        'py_class_name': 'EOA_Wrist_DW3_Tool_NIL',
+        'py_module_name': 'stretch_body.end_of_arm_tools',
+        'use_group_sync_read': 1,
+        'retry_on_comm_failure': 1,
+        'baud': 115200,
+        'dxl_latency_timer': 64,
+        'wrist': 'eoaw_dw3',
+        'tool': 'eoat_nil',
+        'stow': {
+            'arm': 0.0,
+            'lift': 0.3,
+            'wrist_pitch': -0.52,
+            'wrist_roll': 0.0,
+            'wrist_yaw': 3.0
+        },
+        'devices': {
+            'wrist_pitch': {
+                'py_class_name': 'WristPitch',
+                'py_module_name': 'stretch_body.wrist_pitch'
+            },
+            'wrist_roll': {
+                'py_class_name': 'WristRoll',
+                'py_module_name': 'stretch_body.wrist_roll'
+            },
+            'wrist_yaw': {
+                'py_class_name': 'WristYaw',
+                'py_module_name': 'stretch_body.wrist_yaw'
+            }}},
     'tool_none': {
         'use_group_sync_read': 1,
         'retry_on_comm_failure': 1,
@@ -700,7 +748,7 @@ nominal_params={
         'pid': [400, 0, 200],
         'pwm_homing': [0, 0],
         'pwm_limit': 885,
-        'range_t': [650, 2048],
+        'range_t': [730, 2048],
         'req_calibration': 0,
         'return_delay_time': 0,
         'stall_backoff': 0.017,
@@ -714,7 +762,9 @@ nominal_params={
         'baud': 115200,
         'retry_on_comm_failure': 1,
         'disable_torque_on_stop': 0,
+        'float_on_stop': 1,
         'current_float_A': -0.13,
+        'current_limit_A': 2.5
     },
     "wrist_roll": {
         'flip_encoder_polarity': 0,
@@ -736,7 +786,7 @@ nominal_params={
         'pid': [800, 0, 0],
         'pwm_homing': [0, 0],
         'pwm_limit': 885,
-        'range_t': [0, 4095],
+        'range_t': [150, 3950],
         'req_calibration': 0,
         'return_delay_time': 0,
         'stall_backoff': 0.017,
@@ -749,7 +799,9 @@ nominal_params={
         'zero_t': 2048,
         'baud': 115200,
         'retry_on_comm_failure': 1,
-        'disable_torque_on_stop': 1,
+        'disable_torque_on_stop': 0,
+        'float_on_stop': 1,
         'current_float_A': 0.02,
-    }
+        'current_limit_A': 1.0
+    },
 }

--- a/body/stretch_body/robot_params_SE3.py
+++ b/body/stretch_body/robot_params_SE3.py
@@ -7,7 +7,7 @@ user_params_header='#User parameters\n' \
                    '#USE WITH CAUTION. IT IS POSSIBLE TO CAUSE UNSAFE BEHAVIOR OF THE ROBOT \n'
 
 user_params_template={
-    'robot': {'use_collision_manager': 1}} #Include this just as an example
+    'robot': {'use_collision_manager': 0}} #Include this just as an example
 
 # ###################### CONFIGURATION PARAMS #####################################################
 #Template for the generated file: stretch_configuration_params.yaml
@@ -445,7 +445,7 @@ nominal_params={
             'SystemMonitorThread_Hz': 15.0,
             'SystemMonitorThread_monitor_downrate_int': 2,
             'SystemMonitorThread_trace_downrate_int': 1,
-            'SystemMonitorThread_collision_downrate_int': 5,
+            #'SystemMonitorThread_collision_downrate_int': 5,
             'SystemMonitorThread_sentry_downrate_int': 1,
             'SystemMonitorThread_nondxl_trajectory_downrate_int': 2},
         'tool': 'eoa_wrist_dw3_tool_sg3',

--- a/body/stretch_body/robot_params_SE3.py
+++ b/body/stretch_body/robot_params_SE3.py
@@ -563,8 +563,8 @@ nominal_params={
             'collision_pairs': {
                 'link_wrist_pitch_TO_base_link': {'link_pts': 'link_wrist_pitch', 'link_cube': 'base_link','detect_as': 'pts'},
                 'link_wrist_yaw_bottom_TO_base_link': {'link_pts': 'link_wrist_yaw_bottom', 'link_cube': 'base_link','detect_as': 'pts'},
-                'link_gripper_finger_left_TO_base_link': {'link_pts': 'link_gripper_finger_left','link_cube': 'base_link', 'detect_as': 'edges'},
-                'link_gripper_finger_right_TO_base_link': {'link_pts': 'link_gripper_finger_right','link_cube': 'base_link', 'detect_as': 'edges'},
+                'link_gripper_finger_left_TO_base_link': {'link_pts': 'link_gripper_finger_left','link_cube': 'base_link', 'detect_as': 'pts'},
+                'link_gripper_finger_right_TO_base_link': {'link_pts': 'link_gripper_finger_right','link_cube': 'base_link', 'detect_as': 'pts'},
                 'link_gripper_fingertip_left_TO_base_link': {'link_pts': 'link_gripper_fingertip_left','link_cube': 'base_link', 'detect_as': 'pts'},
                 'link_gripper_fingertip_right_TO_base_link': {'link_pts': 'link_gripper_fingertip_right','link_cube': 'base_link', 'detect_as': 'pts'},
                 'link_gripper_s3_body_TO_link_arm_l0': {'link_pts': 'link_gripper_s3_body', 'link_cube': 'link_arm_l0','detect_as': 'pts'},

--- a/body/stretch_body/robot_params_SE3.py
+++ b/body/stretch_body/robot_params_SE3.py
@@ -532,18 +532,17 @@ nominal_params={
         'enable_runstop': 1,
         'disable_torque_on_stop': 1},
     'robot_collision_mgmt': {
-        'max_mesh_points': 36,
-        'k_brake_distance': {'lift': 0.75, 'arm': 0.125, 'wrist_yaw': 0.125, 'head_pan': 0.125, 'head_tilt': 0.125},
+        'max_mesh_points': 48,
         'SE3': {
-            'lift': [{'motion_dir': 'pos', 'link_pts': 'link_head_tilt', 'link_cube': 'link_arm_l4'}],
-            'arm': [{'motion_dir': 'neg', 'link_pts': 'link_arm_l0', 'link_cube': 'base_link'}],
-        },
-        'eoa_wrist_dw3_tool_nil': {
-            'lift': [{'motion_dir': 'neg', 'link_pts': 'link_wrist_pitch', 'link_cube': 'base_link'},
-                     {'motion_dir': 'neg', 'link_pts': 'link_wrist_roll', 'link_cube': 'base_link'},]},
-        'eoa_wrist_dw3_tool_sg3': {
-            'wrist_pitch': [{'motion_dir': 'pos', 'link_pts': 'link_gripper_s3_body', 'link_cube': 'link_arm_l0'}]}
-    },
+            'k_brake_distance': {'lift': 0.75, 'arm': 0.125, 'wrist_yaw': 0.125, 'head_pan': 0.125, 'head_tilt': 0.125},
+            'collision_pairs':{'link_head_tilt_TO_link_arm_l4':{'link_pts': 'link_head_tilt', 'link_cube': 'link_arm_l4','detect_as':'pts'},
+                               'link_arm_l0_TO_base_link':{'link_pts': 'link_arm_l0', 'link_cube': 'base_link','detect_as':'pts'}},
+
+            'joints':{
+                'lift': [{'motion_dir': 'pos', 'collision_pair': 'link_head_tilt_TO_link_arm_l4'},
+                         {'motion_dir': 'neg', 'collision_pair': 'link_arm_l0_TO_base_link'}],
+                'arm': [{'motion_dir': 'neg', 'collision_pair': 'link_arm_l0_TO_base_link'}]}
+    }},
     "eoa_wrist_dw3_tool_sg3": {
         'py_class_name': 'EOA_Wrist_DW3_Tool_SG3',
         'py_module_name': 'stretch_body.end_of_arm_tools',
@@ -559,7 +558,34 @@ nominal_params={
             'wrist_yaw': 3.0,
             'stretch_gripper':0.0
         },
-        'k_brake_distance':{'wrist_pitch':0.0,'wrist_yaw':0.0,'wrist_roll':0.0,'stretch_gripper':0.0},
+        'collision_mgmt': {
+            'k_brake_distance': {'wrist_pitch': 0.25, 'wrist_yaw': 0.25, 'wrist_roll': 0.25, 'stretch_gripper': 0.0},
+            'collision_pairs': {
+                'link_wrist_pitch_TO_base_link': {'link_pts': 'link_wrist_pitch', 'link_cube': 'base_link','detect_as': 'pts'},
+                'link_wrist_yaw_bottom_TO_base_link': {'link_pts': 'link_wrist_yaw_bottom', 'link_cube': 'base_link','detect_as': 'pts'},
+                'link_gripper_finger_left_TO_base_link': {'link_pts': 'link_gripper_finger_left','link_cube': 'base_link', 'detect_as': 'edges'},
+                'link_gripper_finger_right_TO_base_link': {'link_pts': 'link_gripper_finger_right','link_cube': 'base_link', 'detect_as': 'edges'},
+                'link_gripper_fingertip_left_TO_base_link': {'link_pts': 'link_gripper_fingertip_left','link_cube': 'base_link', 'detect_as': 'pts'},
+                'link_gripper_fingertip_right_TO_base_link': {'link_pts': 'link_gripper_fingertip_right','link_cube': 'base_link', 'detect_as': 'pts'},
+                'link_gripper_s3_body_TO_link_arm_l0': {'link_pts': 'link_gripper_s3_body', 'link_cube': 'link_arm_l0','detect_as': 'pts'},
+                'link_gripper_s3_body_TO_link_arm_l1': {'link_pts': 'link_gripper_s3_body', 'link_cube': 'link_arm_l1','detect_as': 'pts'}},
+            'joints': {'lift': [{'motion_dir': 'neg', 'collision_pair': 'link_wrist_pitch_TO_base_link'},
+                                {'motion_dir': 'neg', 'collision_pair': 'link_wrist_yaw_bottom_TO_base_link'},
+                                {'motion_dir': 'neg', 'collision_pair': 'link_gripper_finger_left_TO_base_link'},
+                                {'motion_dir': 'neg', 'collision_pair': 'link_gripper_finger_right_TO_base_link'},
+                                {'motion_dir': 'neg', 'collision_pair': 'link_gripper_fingertip_left_TO_base_link'},
+                                {'motion_dir': 'neg', 'collision_pair': 'link_gripper_fingertip_right_TO_base_link'}],
+                       'wrist_pitch': [{'motion_dir': 'neg', 'collision_pair': 'link_gripper_finger_left_TO_base_link'},
+                                       {'motion_dir': 'neg','collision_pair': 'link_gripper_finger_right_TO_base_link'},
+                                       {'motion_dir': 'neg','collision_pair': 'link_gripper_fingertip_left_TO_base_link'},
+                                       {'motion_dir': 'neg','collision_pair': 'link_gripper_fingertip_right_TO_base_link'},
+                                       {'motion_dir': 'pos', 'collision_pair': 'link_gripper_s3_body_TO_link_arm_l0'},
+                                       {'motion_dir': 'pos', 'collision_pair': 'link_gripper_s3_body_TO_link_arm_l1'}],
+                       'wrist_roll': [{'motion_dir': 'neg', 'collision_pair': 'link_gripper_s3_body_TO_link_arm_l1'},
+                                      {'motion_dir': 'pos', 'collision_pair': 'link_gripper_s3_body_TO_link_arm_l0'}],
+                       'wrist_yaw': [{'motion_dir': 'neg', 'collision_pair': 'link_gripper_s3_body_TO_link_arm_l0'},
+                                     {'motion_dir': 'pos', 'collision_pair': 'link_gripper_s3_body_TO_link_arm_l1'}]}},
+
         'devices': {
             'wrist_pitch': {
                 'py_class_name': 'WristPitch',
@@ -594,7 +620,12 @@ nominal_params={
             'wrist_roll': 0.0,
             'wrist_yaw': 3.0
         },
-        'k_brake_distance':{'wrist_pitch':0.0,'wrist_yaw':0.0,'wrist_roll':0.0},
+        'collision_mgmt': {
+            'k_brake_distance':{'wrist_pitch':0.0,'wrist_yaw':0.0,'wrist_roll':0.0},
+            'joints':{
+                'lift': [{'motion_dir': 'neg', 'link_pts': 'link_wrist_pitch', 'link_cube': 'base_link'},
+                         {'motion_dir': 'neg', 'link_pts': 'link_wrist_roll', 'link_cube': 'base_link'}, ]}},
+
         'devices': {
                     'wrist_pitch': {
                         'py_class_name': 'WristPitch',

--- a/tools/bin/stretch_robot_collision_visualizer.py
+++ b/tools/bin/stretch_robot_collision_visualizer.py
@@ -107,7 +107,8 @@ class CollisionVisualizer:
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Visualize Stretch collision system ')
-    parser.add_argument("--mesh", help="View actual mesh models", action="store_true")
+    #parser.add_argument("--mesh", help="View actual mesh models", action="store_true")
+    parser.add_argument('-g', "--gamepad", help="Use gamepad to control pose", action="store_true")
     args = parser.parse_args()
 
     r = stretch_body.robot.Robot()
@@ -119,9 +120,21 @@ if __name__ == "__main__":
     r.startup()
     if not r.is_homed():
         print('Warning. Visualization may be inaccurate because the robot has not been calibrated')
-        #exit()
+        # exit()
+
+    gamepad=None
+    if args.gamepad:
+        import stretch_body.gamepad_teleop
+        gamepad = stretch_body.gamepad_teleop.GamePadTeleop(robot_instance = False)
+        gamepad.startup(robot=r)
+
+
     viz = CollisionVisualizer(robot=r)
     viz.show()
     while viz.viewer.is_active:
         viz.update_pose()
+        if gamepad:
+            gamepad.step_mainloop(r)
     r.stop()
+    if gamepad:
+        gamepad.gamepad_controller.stop()

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -31,5 +31,5 @@ setuptools.setup(
                       'xmltodict', 'filelock',
                       'pyglet == 1.4.10; python_version < "3.0"', 'trimesh==3.6.38', 'urchin', # urdfpy ==> urchin
                       'pyyaml>=5.1', # required for yaml.FullLoader
-                      'hello-robot-stretch-body>=0.4.26']
+                      'hello-robot-stretch-body>=0.7.1']
 )


### PR DESCRIPTION
This PR updates some of the collision detection code and associated robot params. It

* Defines nominal collision detection params for SE3 tools
* Supports the DW3 on RE2 (for future hardware upgrades) by including those params in RE2V0
* Copies in WIP collision detection code. 
* Collision detection is working but in 'beta' still and still has areas of the DW3 workspace where collisions can occur. The majority of collisions are avoided however and the core collision system works reliability.

For the forthcoming release the collision system is turned off by default for all existing / new robots. However, users can turn on this experimental feature with:

robot.enable_collision_mgmt()

and back off with:

robot.disable_collision_mgmt()

When turned on, the expected behavior is that the joint motion will stop and the robot will beep just short of a collision. This is configured only for the SE3 tools (eoa_wrist_dw3_tool_sg3 and eoa_wrist_dw3_tool_nil). For other robot models / tools the system will not load.

This has been tested for RE1/RE2 as well (and confirmed that things don't break).


