### PR TITLE
Bugfix/arm homing

### DIFF
--- a/body/stretch_body/arm.py
+++ b/body/stretch_body/arm.py
@@ -23,5 +23,21 @@ class Arm(PrismaticJoint):
         return x/(self.params['chain_pitch']*self.params['chain_sprocket_teeth']/self.params['gr_spur']/(math.pi*2))
 
 
-    def home(self, end_pos=0.1,to_positive_stop=False, measuring=False):
-        return PrismaticJoint.home(self,end_pos=end_pos,to_positive_stop=to_positive_stop,measuring=measuring)
+    def home(self, end_pos=0.1,to_positive_stop=False, measuring=False,do_pull_status=True):
+        if self.params['use_adv_homing']:
+            success,log=PrismaticJoint.home(self,end_pos=0.0,to_positive_stop=True,measuring=True,do_pull_status=do_pull_status)
+            effort_max_1=max(log['dir_1']['effort_pct'])
+            effort_min_1 = min(log['dir_1']['effort_pct'])
+            effort_max_2 = max(log['dir_2']['effort_pct'])
+            effort_min_2 = min(log['dir_2']['effort_pct'])
+
+            print('Out',log['dir_1']['effort_pct'])
+            print(' ')
+            print('In', log['dir_2']['effort_pct'])
+            print(' ')
+            print('Out effort %f to %f / In effort %f to %f'%(effort_min_1,effort_max_1,effort_min_2,effort_max_2))
+
+
+        else:
+            success,log= PrismaticJoint.home(self,end_pos=end_pos,to_positive_stop=to_positive_stop,measuring=measuring,do_pull_status=do_pull_status)
+        return success

--- a/body/stretch_body/arm.py
+++ b/body/stretch_body/arm.py
@@ -25,19 +25,43 @@ class Arm(PrismaticJoint):
 
     def home(self, end_pos=0.1,to_positive_stop=False, measuring=False,do_pull_status=True):
         if self.params['use_adv_homing']:
-            success,log=PrismaticJoint.home(self,end_pos=0.0,to_positive_stop=True,measuring=True,do_pull_status=do_pull_status)
-            effort_max_1=max(log['dir_1']['effort_pct'])
-            effort_min_1 = min(log['dir_1']['effort_pct'])
-            effort_max_2 = max(log['dir_2']['effort_pct'])
-            effort_min_2 = min(log['dir_2']['effort_pct'])
+            print('---- Homing arm ---')
+            print('--Finding extension limit--')
+            success_pos,log_pos=self.home_single_ended(end_pos=0.4,to_positive_stop=True,measuring=False,do_pull_status=do_pull_status)
 
-            print('Out',log['dir_1']['effort_pct'])
-            print(' ')
-            print('In', log['dir_2']['effort_pct'])
-            print(' ')
-            print('Out effort %f to %f / In effort %f to %f'%(effort_min_1,effort_max_1,effort_min_2,effort_max_2))
+            if not success_pos:
+                print('Warning: Arm is having difficulty with extension homing. Contact Hello Robot support.')
+                return False
+
+            x_pos=log_pos['x_contact']
+            print('--Finding retraction limit--')
+            success_neg,log_neg = self.home_single_ended(end_pos=0.1, to_positive_stop=False, measuring=True,do_pull_status=do_pull_status)
+            x_neg=log_neg['x_contact']
+
+            if not success_neg:
+                print('Warning: Arm is having difficulty with retraction homing. Contact Hello Robot support.')
+                return False
+
+            print('--- Results ---')
+            measured_rom=abs(x_pos-x_neg)
+            print('Arm homed from %f to %f (m) for a range of %f'%(x_pos,x_neg,measured_rom))
+
+            if (x_neg>0.02 or measured_rom<0.48):
+                print('Warning: Arm is having difficulty with range of motion. Contact Hello Robot support.')
+                return False
+
+            self.params['range_m'][0] = x_neg
+            self.write_configuration_param_to_YAML('%s.range_m' % self.name, self.params['range_m'])
+            print('Arm successfully homed')
+            return True
+
+            # effort_max_pos = max(log_pos['data']['effort_pct'])
+            # effort_min_pos = min(log_pos['data']['effort_pct'])
+            # effort_max_neg = max(log_neg['data']['effort_pct'])
+            # effort_min_neg = min(log_neg['data']['effort_pct'])
+            # print('Extension effort min: %f max: %f '%(effort_min_pos,effort_max_pos))
+            # print('Retraction effort min: %f max: %f ' % (effort_min_neg, effort_max_neg))
 
 
         else:
-            success,log= PrismaticJoint.home(self,end_pos=end_pos,to_positive_stop=to_positive_stop,measuring=measuring,do_pull_status=do_pull_status)
-        return success
+            return PrismaticJoint.home(self,end_pos=end_pos,to_positive_stop=to_positive_stop,measuring=measuring)

--- a/body/stretch_body/prismatic_joint.py
+++ b/body/stretch_body/prismatic_joint.py
@@ -677,32 +677,31 @@ class PrismaticJoint(Device):
         else:
             return delta1, delta2
 
-    def home(self,end_pos,to_positive_stop, measuring=False,do_pull_status=True):
+
+    def home(self,end_pos,to_positive_stop, measuring=False):
         """
         end_pos: position to end on
         to_positive_stop:
         -- True: Move to the positive direction stop and mark to range_m[1]
         -- False: Move to the negative direction stop and mark to range_m[0]
         measuring: After homing to stop, move to opposite stop and report back measured distance
-        do_pull_status: False if another thread is doing the pull_status in background
-        return success, logged data
+        return measured range-of-motion if measuring. Return None if not a valide measurement
         """
 
         hu.check_deprecated_contact_model_prismatic_joint(self,'home',None,None,None,None)
 
-        log = {'dir_1': None, 'dir_2': None, 'range_of_motion': 0}
-
         if not self.motor.hw_valid:
             self.logger.warning('Not able to home %s. Hardware not present' % self.name.capitalize())
-            return False,log
+            return None
+
 
         contact_thresh_neg = self.params['contact_models']['effort_pct']['contact_thresh_homing'][0]
         contact_thresh_pos = self.params['contact_models']['effort_pct']['contact_thresh_homing'][1]
 
+
         success = True
         print('Homing %s...' % self.name.capitalize())
-        if do_pull_status:
-            self.pull_status()
+        self.pull_status()
         prev_calibrated=self.motor.status['pos_calibrated']
         prev_guarded_mode = self.motor.gains['enable_guarded_mode']
         prev_sync_mode = self.motor.gains['enable_sync_mode']
@@ -711,8 +710,7 @@ class PrismaticJoint(Device):
 
         self.motor.reset_pos_calibrated()
         self.push_command()
-        if do_pull_status:
-            self.pull_status()
+        self.pull_status()
 
         if to_positive_stop:
             x_goal_1 = 5.0  # Well past the stop
@@ -724,11 +722,10 @@ class PrismaticJoint(Device):
         # Move to stop
         self.move_by(x_m=x_goal_1, contact_thresh_pos=contact_thresh_pos, contact_thresh_neg=contact_thresh_neg,req_calibration=False)
         self.push_command()
-        data_1=self.measure_until_contact(timeout=15.0,pull_status=do_pull_status)
-        data_2=None
-        if data_1['success']:
-            print('Hardstop detected at motor position (rad)', data_1['motor_pos'][-1])
-            x_dir_1 = data_1['pos'][-1]
+        if self.wait_for_contact(timeout=15.0):  # timeout=15.0):
+            self.pull_status()
+            print('Hardstop detected at motor position (rad)', self.motor.status['pos'])
+            x_dir_1 = self.status['pos']
             if to_positive_stop:
                 x = self.translate_m_to_motor_rad(self.params['range_m'][1] )
                 print('Marking %s position to %f (m)' % (self.name.capitalize(), self.params['range_m'][1]))
@@ -743,14 +740,14 @@ class PrismaticJoint(Device):
             # Second direction
             if measuring:
                 # Move to other direction
+                self.pull_status()
                 self.move_by(x_m=x_goal_2, contact_thresh_pos=contact_thresh_pos,contact_thresh_neg=contact_thresh_neg,req_calibration=False)
                 self.push_command()
-                data_2 = self.measure_until_contact(timeout=15.0, pull_status=do_pull_status)
-                if data_2['success']:
-                    print('Second hardstop detected at motor position (rad)', data_2['motor_pos'][-1])
+                if self.wait_for_contact(timeout=15.0):
+                    print('Second hardstop detected at motor position (rad)', self.motor.status['pos'])
                     time.sleep(1.0)
-                    #self.pull_status()
-                    x_dir_2 = data_2['pos'][-1] #self.status['pos']
+                    self.pull_status()
+                    x_dir_2 = self.status['pos']
                 else:
                     self.logger.warning('%s homing failed. Failed to detect contact' % self.name.capitalize())
                     success = False
@@ -774,13 +771,101 @@ class PrismaticJoint(Device):
         if measuring and prev_calibrated:
             self.motor.set_pos_calibrated()
         self.push_command()
-        log['dir_1'] = data_1
-        log['dir_2'] = data_2
         if success:
             if measuring:
-                rom=abs(x_dir_1 - x_dir_2)
-                print('%s range measuring successful: %f (m)' % (self.name.capitalize(), rom))
-                log['range']=rom
+                print('%s range measuing successful: %f (m)' % (self.name.capitalize(), abs(x_dir_1 - x_dir_2)))
+                return abs(x_dir_1 - x_dir_2)
             else:
                 print('%s homing successful' % self.name.capitalize())
-        return success,log
+        return None
+
+    def home_single_ended(self,end_pos,to_positive_stop, measuring=False,do_pull_status=True):
+        """
+        This is a newer, simpler homing procedure that is more flexible for doing recalibration.
+        It will eventually replace the orginal home() procedure.
+
+        end_pos: position to move to on completion, None means don't move
+        to_positive_stop:
+        -- True: Move to the positive direction stop and set home position to range_m[1]
+        -- False: Move to the negative direction stop and set home position to range_m[0]
+        measuring: True if just making measurements and don't want to actual set the home position
+        do_pull_status: True if need to do pull_status (instead of robot thread)
+        return success, logged data
+        """
+
+        hu.check_deprecated_contact_model_prismatic_joint(self,'home',None,None,None,None)
+
+        log = {'data': None, 'x_contact': 0}
+
+        if not self.motor.hw_valid:
+            self.logger.warning('Not able to home %s. Hardware not present' % self.name.capitalize())
+            return False,log
+
+        contact_thresh_neg = self.params['contact_models']['effort_pct']['contact_thresh_homing'][0]
+        contact_thresh_pos = self.params['contact_models']['effort_pct']['contact_thresh_homing'][1]
+
+        self.pull_status()
+        prev_calibrated=self.motor.status['pos_calibrated']
+        prev_guarded_mode = self.motor.gains['enable_guarded_mode']
+        prev_sync_mode = self.motor.gains['enable_sync_mode']
+        self.motor.enable_guarded_mode()
+        self.motor.disable_sync_mode()
+
+        self.motor.reset_pos_calibrated()
+        self.push_command()
+        self.pull_status()
+
+        if to_positive_stop:
+            x_goal_1 = 5.0  # Well past the stop
+            xm=self.params['range_m'][1]
+        else:
+            x_goal_1 = -5.0
+            xm = self.params['range_m'][0]
+        xmr = self.translate_m_to_motor_rad(xm)
+
+        # Move to stop
+        self.move_by(x_m=x_goal_1, contact_thresh_pos=contact_thresh_pos, contact_thresh_neg=contact_thresh_neg,req_calibration=False)
+        self.push_command()
+        time.sleep(0.5)
+        log['data']=self.measure_until_contact(timeout=15.0,pull_status=do_pull_status)
+        if log['data']['success']:
+            time.sleep(0.5) #Time to settle
+            if not measuring:
+                print('Hardstop detected at motor position %f (rad)' % xmr)
+                print('Setting %s home position to %f (m)' % (self.name.capitalize(), xm))
+                self.motor.mark_position(xmr)
+                self.motor.set_pos_calibrated()
+                self.push_command()
+                log['x_contact']=xm
+            else:
+                self.pull_status()
+                log['x_contact'] = self.status['pos']
+        else:
+            self.logger.warning('%s homing failed. Failed to detect contact' % self.name.capitalize())
+
+        #Move to final position
+        if log['data']['success'] and end_pos is not None:
+            self.motor.disable_guarded_mode() #Turn it off for this move to ensure it doesn't get stuck at hardstop
+            self.push_command()
+            print('Moving to finish position %f...'%end_pos)
+            self.move_to(x_m=end_pos, req_calibration=False)
+            self.push_command()
+            time.sleep(0.5)
+            if not self.motor.wait_until_at_setpoint():
+                self.logger.warning('%s failed to reach final position' % self.name.capitalize())
+                log['data']['success']= False
+            self.motor.enable_guarded_mode()
+
+
+        # Restore previous modes
+        if not prev_guarded_mode:
+            self.motor.disable_guarded_mode()
+        if prev_sync_mode:
+            self.motor.enable_sync_mode()
+        if measuring and prev_calibrated:
+            self.motor.set_pos_calibrated()
+        self.push_command()
+
+        if log['data']['success'] and measuring:
+            print('%s homing successful' % self.name.capitalize())
+        return log['data']['success'],log

--- a/body/stretch_body/robot_params_SE3.py
+++ b/body/stretch_body/robot_params_SE3.py
@@ -75,7 +75,7 @@ nominal_params={
         'chain_sprocket_teeth': 10,
         'gr_spur': 3.875,
         'i_feedforward': 0,
-        'calibration_range_bounds':[0.514, 0.525],
+        'calibration_range_bounds':[0.50, 0.525],
         'use_adv_homing': 1,
         'contact_models':{
             'effort_pct': {'contact_thresh_calibration_margin':10.0,'contact_thresh_max': [-90.0, 90.0]}},
@@ -243,7 +243,7 @@ nominal_params={
         'range_pad_t': [50.0, -50.0]},
     'hello-motor-arm':{
         'gains':{
-            'effort_LPF': 10.0,
+            'effort_LPF': 1.0,
             'enable_guarded_mode': 1,
             'enable_runstop': 1,
             'enable_sync_mode': 1,
@@ -280,7 +280,7 @@ nominal_params={
         'rated_current': 2.8},
     'hello-motor-left-wheel':{
         'gains':{
-            'effort_LPF': 2.0,
+            'effort_LPF': 1.0,
             'enable_guarded_mode': 0,
             'enable_runstop': 1,
             'enable_sync_mode': 1,
@@ -317,7 +317,7 @@ nominal_params={
         'rated_current': 2.8},
     'hello-motor-lift':{
             'gains':{
-            'effort_LPF': 2.0,
+            'effort_LPF': 1.0,
             'enable_guarded_mode': 1,
             'enable_runstop': 1,
             'enable_sync_mode': 1,
@@ -354,7 +354,7 @@ nominal_params={
         'rated_current': 2.8},
     'hello-motor-right-wheel':{
         'gains':{
-            'effort_LPF': 2.0,
+            'effort_LPF': 1.0,
             'enable_guarded_mode': 0,
             'enable_runstop': 1,
             'enable_sync_mode': 1,

--- a/body/stretch_body/robot_params_SE3.py
+++ b/body/stretch_body/robot_params_SE3.py
@@ -20,7 +20,7 @@ configuration_params_template={
         'contact_models':{
             'effort_pct':{
                 'contact_thresh_default':[-55.0, 55.0],
-                'contact_thresh_homing':[-55.0, 55.0]}},
+                'contact_thresh_homing':[-75.0, 75.0]}},
         'range_m':[0.0,0.52]},
     'lift': {
         'contact_models':{

--- a/body/stretch_body/robot_params_SE3.py
+++ b/body/stretch_body/robot_params_SE3.py
@@ -76,6 +76,7 @@ nominal_params={
         'gr_spur': 3.875,
         'i_feedforward': 0,
         'calibration_range_bounds':[0.514, 0.525],
+        'use_adv_homing': 1,
         'contact_models':{
             'effort_pct': {'contact_thresh_calibration_margin':10.0,'contact_thresh_max': [-90.0, 90.0]}},
         'motion':{
@@ -393,6 +394,7 @@ nominal_params={
         'use_vel_traj': 1,
         'force_N_per_A': 75.0,  # Legacy
         'calibration_range_bounds': [1.094, 1.106],
+        'use_adv_homing': 0,
         'contact_models': {
             'effort_pct':{
                 'contact_thresh_calibration_margin': 10.0,

--- a/tools/bin/stretch_arm_home.py
+++ b/tools/bin/stretch_arm_home.py
@@ -5,7 +5,7 @@ import stretch_body.hello_utils as hu
 hu.print_stretch_re_use()
 
 import argparse
-parser=argparse.ArgumentParser(description='Calibrate arm position by movint to hardstop')
+parser=argparse.ArgumentParser(description='Calibrate arm position by moving to hardstop')
 args=parser.parse_args()
 
 a=arm.Arm()


### PR DESCRIPTION
This provides a new homing method for the arm. It is enabled with the param use_adv_homing. 

The new advanced homing routine works by
* First moving the arm to the full extent
* Marking this position as the range_m[1] value
* Retracting to the zero position
* Updates the new range_m[0] value (in Yaml) to the final resting position

This approach allows for a more graceful handling of bad homing due to the tendency of older arms to not fully retract. In this case, the arm will still function but its lower bound will be set to something >0 (which is the ideal case, previously assumed).

If the measured range in homing is too far out of spec then the homing will still fail and the user is asked to contact support.