### PR TITLE
Features/improve dw3 collision mgmt

### DIFF
--- a/body/stretch_body/dynamixel_hello_XL430.py
+++ b/body/stretch_body/dynamixel_hello_XL430.py
@@ -440,9 +440,9 @@ class DynamixelHelloXL430(Device):
         in_collision: {'pos': False, 'neg': False},etc
         """
 
-        if in_collision['pos'] and in_collision['neg']:
-            print('Invalid IN_COLLISION for joint %s'%self.name)
-            return
+        # if in_collision['pos'] and in_collision['neg']:
+        #     print('Invalid IN_COLLISION for joint %s'%self.name)
+        #     return
 
         for dir in ['pos','neg']:
             if in_collision[dir] and not self.in_collision_stop[dir]:

--- a/body/stretch_body/end_of_arm.py
+++ b/body/stretch_body/end_of_arm.py
@@ -111,7 +111,10 @@ class EndOfArm(DynamixelXChain):
             motor = self.get_joint(jn)
             dx = 0.0
             if braked:
-                dx = self.params['collision_mgmt']['k_brake_distance'][jn] * motor.get_braking_distance()
+                try:
+                    dx = self.params['collision_mgmt']['k_brake_distance'][jn] * motor.get_braking_distance()
+                except KeyError:
+                    dx=0
             ret[j] = motor.status['pos'] + dx
         return ret
 

--- a/body/stretch_body/prismatic_joint.py
+++ b/body/stretch_body/prismatic_joint.py
@@ -587,9 +587,9 @@ class PrismaticJoint(Device):
         in_collision: {'pos': False, 'neg': False},etc
         """
 
-        if in_collision['pos'] and in_collision['neg']:
-            print('Invalid IN_COLLISION for joint %s'%self.name)
-            return
+        # if in_collision['pos'] and in_collision['neg']:
+        #     print('Invalid IN_COLLISION for joint %s'%self.name)
+        #     return
 
         for dir in ['pos','neg']:
             if in_collision[dir] and not self.in_collision_stop[dir]:

--- a/body/stretch_body/robot_params_RE1V0.py
+++ b/body/stretch_body/robot_params_RE1V0.py
@@ -276,6 +276,10 @@ RE1V0_tool_none={
     'py_class_name': 'ToolNone',
     'py_module_name': 'stretch_body.end_of_arm_tools',
     'stow': {'wrist_yaw': 3.4},
+    'collision_mgmt': {
+        'k_brake_distance': {},
+        'collision_pairs': {},
+        'joints': {}},
     'devices': {
         'wrist_yaw': {
             'py_class_name': 'WristYaw',
@@ -291,6 +295,10 @@ RE1V0_tool_stretch_gripper={
     'py_class_name': 'ToolStretchGripper',
     'py_module_name': 'stretch_body.end_of_arm_tools',
     'stow': {'stretch_gripper': 0, 'wrist_yaw': 3.4},
+    'collision_mgmt': {
+        'k_brake_distance': {},
+        'collision_pairs': {},
+        'joints': {}},
     'devices': {
         'stretch_gripper': {
             'py_class_name': 'StretchGripper',
@@ -320,6 +328,10 @@ RE1V0_tool_stretch_dex_wrist={
         'wrist_roll': 0.0,
         'wrist_yaw': 3.0
     },
+    'collision_mgmt': {
+        'k_brake_distance': {},
+        'collision_pairs': {},
+        'joints': {}},
     'devices': {
         'stretch_gripper': {
             'py_class_name': 'StretchGripper',
@@ -769,13 +781,25 @@ nominal_params={
     },
     'robot_collision_mgmt': {
         'max_mesh_points': 48,
-        'RE1V0': {}},
-    'robot_sentry':{
+        'RE1V0': {
+            'k_brake_distance': {'lift': 0.75, 'arm': 0.125, 'wrist_yaw': 0.125, 'head_pan': 0.125, 'head_tilt': 0.125},
+            'collision_pairs': {
+                'link_head_tilt_TO_link_arm_l4': {'link_pts': 'link_head_tilt', 'link_cube': 'link_arm_l4',
+                                                  'detect_as': 'pts'},
+                'link_arm_l0_TO_base_link': {'link_pts': 'link_arm_l0', 'link_cube': 'base_link', 'detect_as': 'pts'}},
+            'joints': {
+                'lift': [{'motion_dir': 'pos', 'collision_pair': 'link_head_tilt_TO_link_arm_l4'},
+                         {'motion_dir': 'neg', 'collision_pair': 'link_arm_l0_TO_base_link'}],
+                'arm': [{'motion_dir': 'neg', 'collision_pair': 'link_arm_l0_TO_base_link'}]}
+        }},
+    'robot_sentry': {
         'base_fan_control': 1,
         'base_max_velocity': 1,
         'dynamixel_stop_on_runstop': 1,
         'stretch_gripper_overload': 1,
         'wrist_yaw_overload': 1,
+        'wrist_pitch_overload': 1,
+        'wrist_roll_overload': 1,
         'stepper_is_moving_filter': 1},
     'wacc':{
         'usb_name': '/dev/hello-wacc',

--- a/body/stretch_body/robot_params_RE2V0.py
+++ b/body/stretch_body/robot_params_RE2V0.py
@@ -270,6 +270,10 @@ RE2V0_tool_none={
     'py_class_name': 'ToolNone',
     'py_module_name': 'stretch_body.end_of_arm_tools',
     'stow': {'wrist_yaw': 3.4},
+    'collision_mgmt': {
+        'k_brake_distance': {},
+        'collision_pairs': {},
+        'joints': {}},
     'devices': {
         'wrist_yaw': {
             'py_class_name': 'WristYaw',
@@ -285,6 +289,10 @@ RE2V0_tool_stretch_gripper={
     'py_class_name': 'ToolStretchGripper',
     'py_module_name': 'stretch_body.end_of_arm_tools',
     'stow': {'stretch_gripper': 0, 'wrist_yaw': 3.4},
+    'collision_mgmt': {
+        'k_brake_distance': {},
+        'collision_pairs': {},
+        'joints': {}},
     'devices': {
         'stretch_gripper': {
             'py_class_name': 'StretchGripper',
@@ -306,6 +314,10 @@ RE2V0_tool_stretch_dex_wrist={
     'retry_on_comm_failure': 1,
     'baud': 115200,
     'dxl_latency_timer': 64,
+    'collision_mgmt': {
+        'k_brake_distance': {},
+        'collision_pairs': {},
+        'joints': {}},
     'stow': {
         'arm': 0.0,
         'lift': 0.2,
@@ -751,7 +763,17 @@ nominal_params={
         'use_asyncio':1},
     'robot_collision_mgmt': {
         'max_mesh_points': 48,
-        'RE2V0': {}},
+        'RE2V0': {
+            'k_brake_distance': {'lift': 0.75, 'arm': 0.125, 'wrist_yaw': 0.125, 'head_pan': 0.125, 'head_tilt': 0.125},
+            'collision_pairs': {
+                'link_head_tilt_TO_link_arm_l4': {'link_pts': 'link_head_tilt', 'link_cube': 'link_arm_l4',
+                                                  'detect_as': 'pts'},
+                'link_arm_l0_TO_base_link': {'link_pts': 'link_arm_l0', 'link_cube': 'base_link', 'detect_as': 'pts'}},
+            'joints': {
+                'lift': [{'motion_dir': 'pos', 'collision_pair': 'link_head_tilt_TO_link_arm_l4'},
+                         {'motion_dir': 'neg', 'collision_pair': 'link_arm_l0_TO_base_link'}],
+                'arm': [{'motion_dir': 'neg', 'collision_pair': 'link_arm_l0_TO_base_link'}]}
+        }},
     'robot_monitor':{
         'monitor_base_bump_event': 1,
         'monitor_base_cliff_event': 1,

--- a/body/stretch_body/robot_params_SE3.py
+++ b/body/stretch_body/robot_params_SE3.py
@@ -272,6 +272,8 @@ SE3_eoa_wrist_dw3_tool_sg3={
         'collision_mgmt': {
             'k_brake_distance': {'wrist_pitch': 0.25, 'wrist_yaw': 0.25, 'wrist_roll': 0.25, 'stretch_gripper': 0.0},
             'collision_pairs': {
+                'link_gripper_fingertip_left_TO_link_lift': {'link_pts': 'link_gripper_fingertip_left', 'link_cube': 'link_lift','detect_as': 'pts'},
+                'link_gripper_s3_body_TO_base_link': {'link_pts': 'link_gripper_s3_body', 'link_cube': 'base_link','detect_as': 'pts'},
                 'link_wrist_pitch_TO_base_link': {'link_pts': 'link_wrist_pitch', 'link_cube': 'base_link','detect_as': 'pts'},
                 'link_wrist_yaw_bottom_TO_base_link': {'link_pts': 'link_wrist_yaw_bottom', 'link_cube': 'base_link','detect_as': 'pts'},
                 'link_gripper_finger_left_TO_base_link': {'link_pts': 'link_gripper_finger_left','link_cube': 'base_link', 'detect_as': 'pts'},
@@ -280,13 +282,15 @@ SE3_eoa_wrist_dw3_tool_sg3={
                 'link_gripper_fingertip_right_TO_base_link': {'link_pts': 'link_gripper_fingertip_right','link_cube': 'base_link', 'detect_as': 'pts'},
                 'link_gripper_s3_body_TO_link_arm_l0': {'link_pts': 'link_gripper_s3_body', 'link_cube': 'link_arm_l0','detect_as': 'pts'},
                 'link_gripper_s3_body_TO_link_arm_l1': {'link_pts': 'link_gripper_s3_body', 'link_cube': 'link_arm_l1','detect_as': 'pts'}},
-            'joints': {'lift': [{'motion_dir': 'neg', 'collision_pair': 'link_wrist_pitch_TO_base_link'},
+            'joints': {'lift': [{'motion_dir': 'neg', 'collision_pair': 'link_gripper_s3_body_TO_base_link'},
+                                {'motion_dir': 'neg', 'collision_pair': 'link_wrist_pitch_TO_base_link'},
                                 {'motion_dir': 'neg', 'collision_pair': 'link_wrist_yaw_bottom_TO_base_link'},
                                 {'motion_dir': 'neg', 'collision_pair': 'link_gripper_finger_left_TO_base_link'},
                                 {'motion_dir': 'neg', 'collision_pair': 'link_gripper_finger_right_TO_base_link'},
                                 {'motion_dir': 'neg', 'collision_pair': 'link_gripper_fingertip_left_TO_base_link'},
                                 {'motion_dir': 'neg', 'collision_pair': 'link_gripper_fingertip_right_TO_base_link'}],
-                       'wrist_pitch': [{'motion_dir': 'neg', 'collision_pair': 'link_gripper_finger_left_TO_base_link'},
+                       'wrist_pitch': [{'motion_dir': 'neg', 'collision_pair': 'link_gripper_s3_body_TO_base_link'},
+                                       {'motion_dir': 'neg', 'collision_pair': 'link_gripper_finger_left_TO_base_link'},
                                        {'motion_dir': 'neg','collision_pair': 'link_gripper_finger_right_TO_base_link'},
                                        {'motion_dir': 'neg','collision_pair': 'link_gripper_fingertip_left_TO_base_link'},
                                        {'motion_dir': 'neg','collision_pair': 'link_gripper_fingertip_right_TO_base_link'},
@@ -294,7 +298,10 @@ SE3_eoa_wrist_dw3_tool_sg3={
                                        {'motion_dir': 'pos', 'collision_pair': 'link_gripper_s3_body_TO_link_arm_l1'}],
                        'wrist_roll': [{'motion_dir': 'neg', 'collision_pair': 'link_gripper_s3_body_TO_link_arm_l1'},
                                       {'motion_dir': 'pos', 'collision_pair': 'link_gripper_s3_body_TO_link_arm_l0'}],
-                       'wrist_yaw': [{'motion_dir': 'neg', 'collision_pair': 'link_gripper_s3_body_TO_link_arm_l0'},
+                       'wrist_yaw': [{'motion_dir': 'pos', 'collision_pair': 'link_gripper_fingertip_left_TO_link_lift'},
+                                     {'motion_dir': 'neg', 'collision_pair': 'link_gripper_finger_right_TO_base_link'},
+                                     {'motion_dir': 'pos', 'collision_pair': 'link_gripper_finger_left_TO_base_link'},
+                                     {'motion_dir': 'neg', 'collision_pair': 'link_gripper_s3_body_TO_link_arm_l0'},
                                      {'motion_dir': 'pos', 'collision_pair': 'link_gripper_s3_body_TO_link_arm_l1'}]}},
 
         'devices': {
@@ -338,10 +345,12 @@ SE3_eoa_wrist_dw3_tool_nil={
             'wrist_yaw': 3.0
         },
         'collision_mgmt': {
-            'k_brake_distance':{'wrist_pitch':0.0,'wrist_yaw':0.0,'wrist_roll':0.0},
-            'joints':{
-                'lift': [{'motion_dir': 'neg', 'link_pts': 'link_wrist_pitch', 'link_cube': 'base_link'},
-                         {'motion_dir': 'neg', 'link_pts': 'link_wrist_roll', 'link_cube': 'base_link'}, ]}},
+            'k_brake_distance': {'wrist_pitch': 0.25, 'wrist_yaw': 0.25, 'wrist_roll': 0.25},
+            'collision_pairs': {
+                'link_wrist_pitch_TO_base_link': {'link_pts': 'link_wrist_pitch', 'link_cube': 'base_link','detect_as': 'pts'},
+                'link_wrist_yaw_bottom_TO_base_link': {'link_pts': 'link_wrist_yaw_bottom', 'link_cube': 'base_link','detect_as': 'pts'}},
+            'joints': {'lift': [{'motion_dir': 'neg', 'collision_pair': 'link_wrist_pitch_TO_base_link'},
+                                {'motion_dir': 'neg', 'collision_pair': 'link_wrist_yaw_bottom_TO_base_link'}]}},
 
         'devices': {
             'wrist_pitch': {

--- a/body/stretch_body/version.py
+++ b/body/stretch_body/version.py
@@ -3,4 +3,4 @@
 # 2) we can import it in setup.py for the same reason
 # 3) we can import it into your module
 
-__version__ = '0.7.5'
+__version__ = '0.7.6'


### PR DESCRIPTION
This PR 

* adds a few new collision test cases for the DW3
* permits the case of collisions in both pos and neg direction for a joint
* stubs out collision dictionaries for RE1/2

Tested nominally for RE1/RE2/SE3 - confirmed nothing breaks.