### PR TITLE
Fix Dxl moving at Max Velocity or Acceleration when set close to Zero

### DIFF
--- a/body/stretch_body/dynamixel_XL430.py
+++ b/body/stretch_body/dynamixel_XL430.py
@@ -707,6 +707,10 @@ class DynamixelXL430():
     def set_profile_velocity(self,v):
         if not self.hw_valid:
             return
+        if abs(v)<1:
+        # Dxls assumes Zero ticks/s as infinite/max velocity which is counterintutive
+        # Therefore setting a zero will assign to the lowest possible velocity 1 ticks/s
+            v = 1
         with self.pt_lock:
             with DelayedKeyboardInterrupt():
                 dxl_comm_result, dxl_error =   self.packet_handler.write4ByteTxRx(self.port_handler, self.dxl_id, XL430_ADDR_PROFILE_VELOCITY, int(v))
@@ -715,6 +719,10 @@ class DynamixelXL430():
     def set_profile_acceleration(self, a):
         if not self.hw_valid:
             return
+        if abs(a)<1:
+        # Dxls assumes Zero ticks/s^2 as infinite/max acceleration which is counterintutive
+        # Therefore setting a zero will assign to the lowest possible acceleration 1 ticks/s^2
+            a = 1
         with self.pt_lock:
             with DelayedKeyboardInterrupt():
                 dxl_comm_result, dxl_error = self.packet_handler.write4ByteTxRx(self.port_handler, self.dxl_id,XL430_ADDR_PROFILE_ACCELERATION, int(a))


### PR DESCRIPTION
This PR fixes issue #252, where a close-to-zero profile velocity or acceleration is set. Converting close to zero rad/s or rad/s^3  into motor units would produce a Zero integer value, which will be assumed as an infinite profile velocity or acceleration. 
References:
https://emanual.robotis.com/docs/en/dxl/x/xl430-w250/#profile-velocity
https://emanual.robotis.com/docs/en/dxl/x/xl430-w250/#profile-acceleration

To avoid this counterintuitive and unexpected behavior, the profile velocity or acceleration will be set to the lowest value, one tick/s or 1 tick/s^2.