### PR TITLE
DW3  Float mode on exit with Velocity control bugfix

### DIFF
--- a/body/stretch_body/dynamixel_hello_XL430.py
+++ b/body/stretch_body/dynamixel_hello_XL430.py
@@ -673,6 +673,8 @@ class DynamixelHelloXL430(Device):
         if self.motor.dxl_model_name=='XM540-W270' or self.motor.dxl_model_name=='XM430-W350':
             if current_limit is None:
                 current_limit =self.params['current_limit_A']
+            if self.in_vel_mode:
+                self.enable_pos()
             self.motor.disable_torque()
             self.motor.set_current_limit(self.current_to_ticks(current_limit))
             self.motor.enable_pos_current()

--- a/body/stretch_body/dynamixel_hello_XL430.py
+++ b/body/stretch_body/dynamixel_hello_XL430.py
@@ -245,6 +245,10 @@ class DynamixelHelloXL430(Device):
         Device.stop(self)
         self._waypoint_ts, self._waypoint_vel, self._waypoint_accel = None, None, None
         if self.hw_valid:
+            if self.watchdog_enabled:
+                self.disable_torque()
+                self.motor.disable_watchdog()
+                self.enable_torque()
             if self.params['disable_torque_on_stop']:
                 self.disable_torque()
             self.motor.stop(close_port)

--- a/body/stretch_body/wrist_pitch.py
+++ b/body/stretch_body/wrist_pitch.py
@@ -39,6 +39,9 @@ class WristPitch(DynamixelHelloXL430):
         """
         i=self.motor.get_current()
         self.disable_torque()
+        if self.watchdog_enabled:
+            self.motor.disable_watchdog()
+            self.watchdog_enabled = False
         self.motor.enable_current()
         self.enable_torque()
         self.motor.set_goal_current(i)#self.current_to_ticks(self.params['current_float_A']))


### PR DESCRIPTION
This PR fixes the issue mentioned in #268 where the Wrist Pitch and Wrist Roll joints do not enter the float mode after exiting the Gamepad teleop. 
- The issue was that the watchdog was enabled during the exit due to velocity control, causing the motor to stop. 
- The enable_pos_current_ctrl() was also not working after velocity control, which was solved by ensuring the regular position control was enabled before enabling the current pos control.