### PR TITLE
Dynamixel Watchdog Bug Fixes

### DIFF
--- a/body/stretch_body/dynamixel_hello_XL430.py
+++ b/body/stretch_body/dynamixel_hello_XL430.py
@@ -490,7 +490,7 @@ class DynamixelHelloXL430(Device):
 
         if self.in_vel_mode:
             # disable watchdog if a set_velocity() command is not passed above 3s
-            if self._prev_set_vel_ts:
+            if self._prev_set_vel_ts and self.watchdog_enabled:
                 if time.time() - self._prev_set_vel_ts >=3:
                     wd_error=self.motor.get_watchdog_error()
                     self.disable_torque()

--- a/body/stretch_body/dynamixel_hello_XL430.py
+++ b/body/stretch_body/dynamixel_hello_XL430.py
@@ -673,9 +673,9 @@ class DynamixelHelloXL430(Device):
         if self.motor.dxl_model_name=='XM540-W270' or self.motor.dxl_model_name=='XM430-W350':
             if current_limit is None:
                 current_limit =self.params['current_limit_A']
-            if self.in_vel_mode:
-                self.enable_pos()
             self.motor.disable_torque()
+            if self.in_vel_mode:
+                self.motor.enable_pos()
             self.motor.set_current_limit(self.current_to_ticks(current_limit))
             self.motor.enable_pos_current()
             self.enable_torque()

--- a/body/stretch_body/dynamixel_hello_XL430.py
+++ b/body/stretch_body/dynamixel_hello_XL430.py
@@ -801,6 +801,9 @@ class DynamixelHelloXL430(Device):
             return
         try:
             self.motor.disable_torque()
+            if self.watchdog_enabled:
+                self.motor.disable_watchdog()
+                self.watchdog_enabled = False
             if self.params['use_multiturn']:
                 self.motor.enable_multiturn()
             elif self.params['use_pos_current_ctrl']:

--- a/body/stretch_body/wrist_roll.py
+++ b/body/stretch_body/wrist_roll.py
@@ -17,6 +17,7 @@ class WristRoll(DynamixelHelloXL430):
         """
         #Put joint in float around zero on exit
         if self.hw_valid and self.params['float_on_stop']:
+            self.enable_pos()
             self.enable_pos_current_ctrl(current_limit=self.params['current_float_A'])
             self.move_to(0.0)
 


### PR DESCRIPTION
This PR fixes a few critical bugs with Dynamixel's velocity control and Watchdog Mechanism. 
- If the watchdog is triggered (1s after a vel cmd), the sentry checks for the last vel cmd called and disables the watchdog if more than 3s passes to re-enable the motor that will need enabling/disabling torque. The enabling/disabling torque was repetitively from the sentry loop once a velocity command was executed without checking if the watchdog was already enabled to proceed. This fixed the inconsistent missing of velocity commands given at different intervals and also the robust use of position/velocity commands sequentially.   I used this[ test script](https://gist.github.com/hello-fazil/2cf776b5f0d00a9649d70704a46c6b28) to supply velocity/position commands sequentially at different interval times and check if they behave sanely with the watchdog mechanism working in the background.