### PR TITLE
drop lift vel/accel to default for gamepad

### DIFF
--- a/body/stretch_body/gamepad_joints.py
+++ b/body/stretch_body/gamepad_joints.py
@@ -201,9 +201,9 @@ class CommandLift:
         self.params = RobotParams().get_params()[1]['lift']
         self.dead_zone = 0.0001
         self._prev_set_vel_ts = None
-        self.max_linear_vel = self.params['motion']['max']['vel_m']
+        self.max_linear_vel = self.params['motion']['default']['vel_m']
         self.precision_mode = False
-        self.acc = self.params['motion']['max']['accel_m']
+        self.acc = self.params['motion']['default']['accel_m']
         
         # Precision mode params
         self.start_pos = None

--- a/body/stretch_body/version.py
+++ b/body/stretch_body/version.py
@@ -3,4 +3,4 @@
 # 2) we can import it in setup.py for the same reason
 # 3) we can import it into your module
 
-__version__ = '0.7.8'
+__version__ = '0.7.9'


### PR DESCRIPTION
This PR lowers the lift velocity for SE3 such during gamepad teleop in order to avoid false positive contact events