### PR TITLE
Bugfix/nan values

### DIFF
--- a/body/stretch_body/dynamixel_hello_XL430.py
+++ b/body/stretch_body/dynamixel_hello_XL430.py
@@ -6,6 +6,7 @@ import time
 from stretch_body.hello_utils import *
 import termios
 import numpy
+import math
 
 class DynamixelCommErrorStats(Device):
     def __init__(self, name, logger):
@@ -571,6 +572,9 @@ class DynamixelHelloXL430(Device):
                     raise DynamixelCommError
 
     def set_velocity(self,v_des,a_des=None):
+        if  True in [self.check_nan_value(d) for d in (v_des, a_des)]:
+            self.logger.warning('Received NaN value. dropping the command.')
+            return
         if self.was_runstopped:
             return
         if not self.watchdog_enabled:
@@ -683,7 +687,16 @@ class DynamixelHelloXL430(Device):
         else:
             self.logger.warning('Joint %s does not support POS_CURRENT_CTRL: %s' % self.name)
 
+    def check_nan_value(self,x):
+        try:
+            return math.isnan(x)
+        except TypeError:
+            return False
+        
     def move_to(self,x_des, v_des=None, a_des=None):
+        if  True in [self.check_nan_value(d) for d in (x_des, v_des, a_des)]:
+            self.logger.warning('Received NaN value. dropping the command.')
+            return
         if self.was_runstopped:
             return
         nretry = 2
@@ -748,6 +761,9 @@ class DynamixelHelloXL430(Device):
 
 
     def move_by(self,x_des, v_des=None, a_des=None):
+        if  True in [self.check_nan_value(d) for d in (x_des, v_des, a_des)]:
+            self.logger.warning('Received NaN value. dropping the command.')
+            return
         if self.was_runstopped:
             return
         if not self.hw_valid:

--- a/body/stretch_body/stepper.py
+++ b/body/stretch_body/stepper.py
@@ -7,6 +7,7 @@ import threading
 import sys
 import time
 import array as arr
+import math
 
 
 
@@ -406,13 +407,22 @@ class StepperBase(Device):
         self.gains['enable_guarded_mode'] = 0
         self._dirty_gains = 1
 
-
+    def check_nan_value(self,x):
+        try:
+            return math.isnan(x)
+        except TypeError:
+            return False
 
     # ######################################################################
     #Primary interface to controlling the stepper
     #YAML defaults are used if values not provided
     #This allows user to override defaults every control cycle and then easily revert to defaults
     def set_command(self,mode=None, x_des=None, v_des=None, a_des=None,i_des=None, stiffness=None,i_feedforward=None, i_contact_pos=None, i_contact_neg=None  ):
+        
+        if  True in [self.check_nan_value(d) for d in (x_des, v_des, a_des, i_des, stiffness, i_feedforward, i_contact_pos, i_contact_neg)]:
+            self.logger.warning('Received NaN value. dropping the command.')
+            return
+        
         if mode is not None:
             self._command['mode'] = mode
 


### PR DESCRIPTION
This PR adds a filter to drop motion commands when a Nan value is set to any of the motion command's values. Sending a Nan value to a stepper or dynamixel motor causes the joints to move to their limits in unpredictable ways, which this PR solves.