### PR TITLE
Change matplotlib backend to Tkinter in scope library 

### DIFF
--- a/body/stretch_body/scope.py
+++ b/body/stretch_body/scope.py
@@ -1,4 +1,6 @@
 from __future__ import print_function
+import matplotlib
+matplotlib.use('TkAgg')
 from matplotlib.widgets import Slider, Button
 import matplotlib.pyplot as plt
 import matplotlib.animation as animation


### PR DESCRIPTION
Changing the matplotlib's backend from the default Qt to Tkinter resolves the issue described in issue #284 . Additionally, this also seems to fix issue #262.