### PR TITLE
Introduce `stretch_configure_tool.py`

### DIFF
--- a/body/stretch_body/robot_params.py
+++ b/body/stretch_body/robot_params.py
@@ -154,6 +154,12 @@ class RobotParams:
         if level in level_names and handler in cls._robot_params['logging']['handlers']:
             cls._robot_params['logging']['handlers'][handler]['level'] = level
 
+    @classmethod
+    def set_logging_formatter(cls, formatter, handler='console_handler'):
+        formatter_names = ["default_console_formatter", "brief_console_formatter", "default_file_formatter"]
+        if formatter in formatter_names and handler in cls._robot_params['logging']['handlers']:
+            cls._robot_params['logging']['handlers'][handler]['formatter'] = formatter
+
 # For Reference, the parameter loading organization prior to release of RE2
 # class RobotParams:
 #     """Build the parameter dictionary that is available as stretch_body.Device().robot_params.

--- a/tools/bin/stretch_configure_tool.py
+++ b/tools/bin/stretch_configure_tool.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+
+import stretch_body.hello_utils as hu
+hu.print_stretch_re_use()
+
+import argparse
+import stretch_body.robot as robot
+
+parser=argparse.ArgumentParser(description='Check that all robot hardware is present and reporting sane values')
+parser.add_argument('-v', "--verbose", help="Prints more information", action="store_true")
+args=parser.parse_args()
+

--- a/tools/bin/stretch_configure_tool.py
+++ b/tools/bin/stretch_configure_tool.py
@@ -6,6 +6,7 @@ stretch_body.robot_params.RobotParams.set_logging_formatter("brief_console_forma
 import stretch_body.hello_utils as hu
 hu.print_stretch_re_use()
 
+import sys
 import logging
 import argparse
 import stretch_body.device
@@ -51,10 +52,12 @@ def is_d405_present():
 cli_device.logger.info('Loading...')
 robot_device = stretch_body.device.Device(name='robot')
 stretch_tool = robot_device.params.get('tool', '')
-supported_tools = robot_device.robot_params.get('supported_eoa', [])
+# supported_tools = robot_device.robot_params.get('supported_eoa', []) # TODO
+supported_tools = ['tool_none', 'tool_stretch_gripper', 'tool_stretch_dex_wrist', 'eoa_wrist_dw3_tool_nil', 'eoa_wrist_dw3_tool_sg3']
 # num_wrist_dxls = how_many_dxl_on_wrist_chain() # TODO
 num_wrist_dxls = 4
-d405_present = is_d405_present()
+# d405_present = is_d405_present() # TODO
+d405_present = True
 
 def does_tool_need_to_change():
     cli_device.logger.info(f'Your software is currently configured for the {Fore.CYAN + stretch_tool + Style.RESET_ALL} tool')
@@ -88,8 +91,51 @@ def does_tool_need_to_change():
     cli_device.logger.info("Not changing anything. Exiting.")
     return False
 
-does_tool_need_to_change()
-# print(stretch_tool)
-# print(supported_tools)
-# print(num_wrist_dxls)
-# print(d405_present)
+def determine_what_tool_is_correct():
+    cli_device.logger.info('Determining what tool is correct for your robot...')
+
+    # start with the supported list
+    matches = supported_tools
+    cli_device.logger.debug(f"Starting with the supported tools for your model: {Fore.CYAN + str(matches) + Style.RESET_ALL}")
+
+    # filter by num dxls
+    numdxls_tool_map = {
+        1: ['tool_none'],
+        2: ['tool_stretch_gripper'],
+        3: ['eoa_wrist_dw3_tool_nil'],
+        4: ['tool_stretch_dex_wrist', 'eoa_wrist_dw3_tool_sg3']
+    }
+    numdxls_match = numdxls_tool_map.get(num_wrist_dxls, [])
+    cli_device.logger.debug(f"These tools match based on {num_wrist_dxls} number of wrist dxls: {Fore.CYAN + str(numdxls_match) + Style.RESET_ALL}")
+    matches = list(set(matches) & set(numdxls_match))
+    cli_device.logger.debug(f"Filtering based on this brings the matches to: {Fore.CYAN + str(matches) + Style.RESET_ALL}")
+
+    # filter by d405 present
+    d405_tool_map = {
+        False: ['tool_none', 'tool_stretch_gripper', 'tool_stretch_dex_wrist'],
+        True: ['eoa_wrist_dw3_tool_nil', 'eoa_wrist_dw3_tool_sg3'],
+    }
+    d405_match = d405_tool_map.get(d405_present, [])
+    cli_device.logger.debug(f"These tools match based on present={d405_present} gripper camera: {Fore.CYAN + str(d405_match) + Style.RESET_ALL}")
+    matches = list(set(matches) & set(d405_match))
+    cli_device.logger.debug(f"Filtering based on this brings the matches to: {Fore.CYAN + str(matches) + Style.RESET_ALL}")
+
+    if len(matches) == 0:
+        cli_device.logger.info('Unable to find any tool that matches the hardware connected to your robot. Contact Hello Robot support for help.')
+        cli_device.logger.info("Not changing anything. Exiting.")
+        sys.exit(1)
+    elif len(matches) > 1:
+        cli_device.logger.info('Found multiple possible tools that could work:')
+        for i, match in enumerate(matches):
+            cli_device.logger.info(f'    {i}) {match}')
+        user_select = int(input('Select one. If unsure, Ctrl C to exit & contact Hello Robot support. Input #: '))
+        if user_select >= len(matches):
+            cli_device.logger.info('Invalid selection. Exiting...')
+            sys.exit(1)
+        return matches[user_select]
+    else:
+        return matches[0]
+
+if does_tool_need_to_change():
+    target_tool_name = determine_what_tool_is_correct()
+    print(target_tool_name)

--- a/tools/bin/stretch_configure_tool.py
+++ b/tools/bin/stretch_configure_tool.py
@@ -58,7 +58,7 @@ def is_d405_present():
 
 def run_cmd(cmdstr):
     cli_device.logger.debug(f'Executing command: {cmdstr}')
-    returncode = os.system(cmdstr)
+    returncode = os.system(cmdstr + ' > /dev/null 2>&1')
     if (returncode != 0):
         cli_device.logger.info(f"ERROR executing {cmdstr}")
         sys.exit(1)

--- a/tools/bin/stretch_configure_tool.py
+++ b/tools/bin/stretch_configure_tool.py
@@ -1,12 +1,26 @@
 #!/usr/bin/env python3
+import stretch_body.robot_params
+stretch_body.robot_params.RobotParams.set_logging_level("DEBUG")
+stretch_body.robot_params.RobotParams.set_logging_formatter("brief_console_formatter")
 
 import stretch_body.hello_utils as hu
 hu.print_stretch_re_use()
 
+import logging
 import argparse
-import stretch_body.robot as robot
+import stretch_body.device
 
-parser=argparse.ArgumentParser(description='Check that all robot hardware is present and reporting sane values')
+parser=argparse.ArgumentParser(description="Configure Stretch's software for the attached tool")
 parser.add_argument('-v', "--verbose", help="Prints more information", action="store_true")
 args=parser.parse_args()
+
+cli_device = stretch_body.device.Device(name='stretch_configure_tool.py', req_params=False)
+cli_device.logger.setLevel('DEBUG' if args.verbose else 'INFO')
+
+from colorama import Fore, Back, Style
+cli_device.logger.debug('hey debug')
+cli_device.logger.info(Fore.RED + 'hey info')
+cli_device.logger.warning(Fore.CYAN + 'hey warning')
+cli_device.logger.error('hey error')
+cli_device.logger.critical('hey critical')
 

--- a/tools/bin/stretch_configure_tool.py
+++ b/tools/bin/stretch_configure_tool.py
@@ -9,6 +9,7 @@ hu.print_stretch_re_use()
 import logging
 import argparse
 import stretch_body.device
+from colorama import Fore, Back, Style
 
 parser=argparse.ArgumentParser(description="Configure Stretch's software for the attached tool")
 parser.add_argument('-v', "--verbose", help="Prints more information", action="store_true")
@@ -16,11 +17,79 @@ args=parser.parse_args()
 
 cli_device = stretch_body.device.Device(name='stretch_configure_tool.py', req_params=False)
 cli_device.logger.setLevel('DEBUG' if args.verbose else 'INFO')
+logging.getLogger().setLevel(logging.CRITICAL)
 
-from colorama import Fore, Back, Style
-cli_device.logger.debug('hey debug')
-cli_device.logger.info(Fore.RED + 'hey info')
-cli_device.logger.warning(Fore.CYAN + 'hey warning')
-cli_device.logger.error('hey error')
-cli_device.logger.critical('hey critical')
+def how_many_dxl_on_wrist_chain():
+    from stretch_body.dynamixel_XL430 import DynamixelXL430, DynamixelCommError
+    cli_device.logger.debug("Scanning wrist dxl chain for motors...")
+    nfound = 0
+    for dxl_id in range(25):
+        try:
+            baud = DynamixelXL430.identify_baud_rate(dxl_id, '/dev/hello-dynamixel-wrist')
+            if baud != -1:
+                m = DynamixelXL430(dxl_id, '/dev/hello-dynamixel-wrist', baud=baud)
+                m.startup()
+                if not m.hw_valid:
+                    continue
+                if not m.do_ping(verbose=False):
+                    continue
+                m.stop()
+                nfound += 1
+        except DynamixelCommError:
+            continue
+    return nfound
 
+def is_d405_present():
+    import pyrealsense2 as rs
+    rs_cameras = [{'name': device.get_info(rs.camera_info.name), 'serial_number': device.get_info(rs.camera_info.serial_number)}
+        for device in rs.context().devices]
+    for rs_cam in rs_cameras:
+        if 'D405' in rs_cam['name']:
+            return True
+    return False
+
+cli_device.logger.info('Loading...')
+robot_device = stretch_body.device.Device(name='robot')
+stretch_tool = robot_device.params.get('tool', '')
+supported_tools = robot_device.robot_params.get('supported_eoa', [])
+# num_wrist_dxls = how_many_dxl_on_wrist_chain() # TODO
+num_wrist_dxls = 4
+d405_present = is_d405_present()
+
+def does_tool_need_to_change():
+    cli_device.logger.info(f'Your software is currently configured for the {Fore.CYAN + stretch_tool + Style.RESET_ALL} tool')
+
+    # check if current tool is supported
+    if stretch_tool not in supported_tools:
+        cli_device.logger.info(f"But {Fore.CYAN + stretch_tool + Style.RESET_ALL} isn't a supported tool for your robot")
+        cli_device.logger.debug(f"The supported tools for your robot are: {Fore.CYAN + str(supported_tools) + Style.RESET_ALL}")
+        return True
+
+    # check if the existing hardware, num dxls, matches the current tool
+    tool_numdxls_d405_map = {
+        'tool_none': (1, False),
+        'tool_stretch_gripper': (2, False),
+        'tool_stretch_dex_wrist': (4, False),
+        'eoa_wrist_dw3_tool_nil': (3, True),
+        'eoa_wrist_dw3_tool_sg3': (4, True),
+    }
+    expected_num_wrist_dxls, expected_d405_present = tool_numdxls_d405_map.get(stretch_tool, (-1, False))
+    if num_wrist_dxls != expected_num_wrist_dxls:
+        cli_device.logger.info(f"But the wrist chain has the wrong number of motors")
+        cli_device.logger.debug(f"Num Dxls: {num_wrist_dxls}, Expected Num Dxls: {expected_num_wrist_dxls}")
+        return True
+
+    # check if the existing hardware, d405 present, matches the current tool
+    if d405_present != expected_d405_present:
+        cli_device.logger.info(f"""But the gripper camera {"should" if expected_d405_present else "shouldn't"} be present""")
+        return True
+
+    cli_device.logger.info("Which seems correct based on the hardware connected to your robot")
+    cli_device.logger.info("Not changing anything. Exiting.")
+    return False
+
+does_tool_need_to_change()
+# print(stretch_tool)
+# print(supported_tools)
+# print(num_wrist_dxls)
+# print(d405_present)

--- a/tools/bin/stretch_system_check.py
+++ b/tools/bin/stretch_system_check.py
@@ -45,17 +45,28 @@ device = stretch_body.device.Device(name='robot', req_params=False)
 stretch_serial_no = device.params.get('serial_no', '')
 stretch_model = device.params.get('model_name', '')
 stretch_batch = device.params.get('batch_name', '')
+stretch_tool = device.params.get('tool', '')
 if stretch_model == "SE3":
     print(Fore.LIGHTBLUE_EX + 'Model = ' + Fore.CYAN + 'Stretch 3')
 elif stretch_model == "RE2V0":
     print(Fore.LIGHTBLUE_EX + 'Model = ' + Fore.CYAN + 'Stretch 2')
 elif stretch_model == "RE1V0":
     print(Fore.LIGHTBLUE_EX + 'Model = ' + Fore.CYAN + 'Stretch RE1')
+if stretch_tool == "tool_none":
+    print(Fore.LIGHTBLUE_EX + 'Tool = ' + Fore.CYAN + 'None')
+elif stretch_tool == "tool_stretch_gripper":
+    print(Fore.LIGHTBLUE_EX + 'Tool = ' + Fore.CYAN + 'Standard Gripper')
+elif stretch_tool == "tool_stretch_dex_wrist":
+    print(Fore.LIGHTBLUE_EX + 'Tool = ' + Fore.CYAN + 'DexWrist 2 w/ Gripper')
+elif stretch_tool == "eoa_wrist_dw3_tool_nil":
+    print(Fore.LIGHTBLUE_EX + 'Tool = ' + Fore.CYAN + 'DexWrist 3 w/ no attached tool')
+elif stretch_tool == "eoa_wrist_dw3_tool_sg3":
+    print(Fore.LIGHTBLUE_EX + 'Tool = ' + Fore.CYAN + 'DexWrist 3 w/ Gripper')
+else:
+    print(Fore.LIGHTBLUE_EX + 'Tool = ' + Fore.CYAN + stretch_tool)
 if args.verbose:
     print(Fore.LIGHTBLUE_EX + 'Batch = ' + Fore.CYAN + stretch_batch)
 print(Fore.LIGHTBLUE_EX + 'Serial Number = ' + Fore.CYAN + stretch_serial_no)
-
-print(Fore.LIGHTBLUE_EX + 'Tool= '+Fore.CYAN + device.params.get('tool', ''))
 # create robot instance
 r=robot.Robot()
 r.startup()
@@ -110,16 +121,16 @@ def are_actuators_ready():
     for chain in [r.end_of_arm, r.head]:
         for mk in chain.motors.keys():
             if chain.motors[mk].params['req_calibration'] and not chain.motors[mk].motor.is_calibrated():
-                return False, "robot not homed"
+                return False, "robot not homed, run stretch_robot_home.py"
 
     # Check hello steppers homed
     for stepper in [r.lift.motor, r.arm.motor]:
         if not stepper.status['pos_calibrated']:
-            return False, "robot not homed"
+            return False, "robot not homed, run stretch_robot_home.py"
 
     # Check robot agrees everything homed
     if not r.is_homed():
-        return False, "robot not homed"
+        return False, "robot not homed, run stretch_robot_home.py"
 
     # Check hello steppers' self recognized type matches SDK's expectation
     if 'stepper_type' in r.lift.motor.board_info and r.lift.motor.board_info['stepper_type'] != 0:


### PR DESCRIPTION
This PR introduces a new CLI called `stretch_configure_tool.py`. It eliminates a pain point around changing the `robot.tool` parameter and updating the URDF (and exported URDF). The CLI does 3 things:

 1. Check if tool needs to change
       - It compares the tool against the supported tools for that model
       - It checks that the hardware visible matches what it would expect for the tool
       - ![Screenshot from 2024-02-20 05-19-22](https://github.com/hello-robot/stretch_body/assets/64861565/7140babe-97d2-492a-82ed-22ccc76f60dd)
 2. If the tool does need to change, it intelligently determines what tool should be configured
       - Filters by the supported tools
       - Filters by the visible hardware
       - If ambiguity remains, it prompts the user to select a tool:
       - ![Screenshot from 2024-02-20 02-04-08](https://github.com/hello-robot/stretch_body/assets/64861565/70bcfb64-e1b4-40e2-bd97-f8f216ab3279)
 3. Configures the new tool
       - Changes the robot parameters in `stretch_configuration_params.yaml` (robot.tool and i_feedforward)
       - Updates the calibrated URDF in ROS. Builds off Stretch URDF.
       - Exports the calibrated URDF to Python
       - ![Screenshot from 2024-02-20 05-19-52](https://github.com/hello-robot/stretch_body/assets/64861565/cb0351dd-42dd-4735-a043-80dbd7eb2a6e)

This tool supports all three models, all officially supported tools, Ubuntu 20.04 and 22.04.