### PR TITLE
modify D term for roll when in float mode

### DIFF
--- a/body/stretch_body/wrist_roll.py
+++ b/body/stretch_body/wrist_roll.py
@@ -20,6 +20,12 @@ class WristRoll(DynamixelHelloXL430):
             self.enable_pos()
             self.enable_pos_current_ctrl(current_limit=self.params['current_float_A'])
             self.move_to(0.0)
+            # When using enable_pos_current_ctrl the PID values are reset to factory defaults
+            # The mass of the DW3 can cause vibrations with default D term (4700)
+            # Bump it here to stabilize oscillations
+            #https://emanual.robotis.com/docs/en/dxl/x/xm430-w350/#operating-mode
+            self.motor.set_D_gain(8000)
+
 
     def stop(self,close_port=True):
         if self.hw_valid and self.params['float_on_stop']:


### PR DESCRIPTION
Directly set D term for roll servo to avoid oscillations when in pos_current_ctrl mode. See comments in code.