### PR TITLE
Robot process protection for multi-user setup

### DIFF
--- a/body/stretch_body/hello_utils.py
+++ b/body/stretch_body/hello_utils.py
@@ -681,9 +681,8 @@ def acquire_body_filelock():
         #    changed to limit write privileges. We use chmod to enable all users to write to the file.
         if filelock_path.owner() == whoami:
             filelock_path.chmod(0o777)
-        print('Another process is already using Stretch. Try running "stretch_free_robot_process.py"')
-        return False
-    return True
+        return False, file_lock
+    return True, file_lock
 
 def free_body_filelock():
     whoami = pwd.getpwuid(os.getuid()).pw_name

--- a/body/stretch_body/hello_utils.py
+++ b/body/stretch_body/hello_utils.py
@@ -669,17 +669,17 @@ def acquire_body_filelock():
         file_lock.acquire(timeout=1)
         # 2. If we acquire the lock as the file's owner, the lock's permissions will have changed
         #    to limit write privileges. We use chmod to enable all users to write to the file.
-        if filelock_path.owner() == whoami:
+        if filelock_path.owner() == whoami or whoami == "root":
             filelock_path.chmod(0o777)
         # 3. Write this process's PID to a file so this process can be freed by others.
         with open(str(pid_file), 'w') as f:
             f.write(str(os.getpid()))
-        if pid_file.owner() == whoami:
+        if pid_file.owner() == whoami or whoami == "root":
             pid_file.chmod(0o777)
     except Timeout:
         # 4. If we failed to acquire the lock as the file's owner, the lock's permissions will have
         #    changed to limit write privileges. We use chmod to enable all users to write to the file.
-        if filelock_path.owner() == whoami:
+        if filelock_path.owner() == whoami or whoami == "root":
             filelock_path.chmod(0o777)
         return False, file_lock
     return True, file_lock
@@ -697,12 +697,12 @@ def free_body_filelock():
         file_lock.release()
         # 2. If we acquire the lock as the file's owner, the lock's permissions will have changed
         #    to limit write privileges. We use chmod to enable all users to write to the file.
-        if filelock_path.owner() == whoami:
+        if filelock_path.owner() == whoami or whoami == "root":
             filelock_path.chmod(0o777)
     except Timeout:
         # 3. If we failed to acquire the lock as the file's owner, the lock's permissions will have
         #    changed to limit write privileges. We use chmod to enable all users to write to the file.
-        if filelock_path.owner() == whoami:
+        if filelock_path.owner() == whoami or whoami == "root":
             filelock_path.chmod(0o777)
         with open(pid_file, 'r') as f:
             tokill_pid = int(f.read())

--- a/body/stretch_body/hello_utils.py
+++ b/body/stretch_body/hello_utils.py
@@ -713,7 +713,7 @@ def free_body_filelock():
                 os.kill(tokill_pid, signal.SIGTERM)
                 time.sleep(0.2)
                 os.kill(tokill_pid, signal.SIGTERM)
-            except:
+            except PermissionError:
                 # 5. os.kill will fail to kill PIDs not owned by this user. Root user can kill anything.
                 return False
     return True

--- a/body/stretch_body/hello_utils.py
+++ b/body/stretch_body/hello_utils.py
@@ -716,4 +716,6 @@ def free_body_filelock():
             except PermissionError:
                 # 5. os.kill will fail to kill PIDs not owned by this user. Root user can kill anything.
                 return False
+            except ProcessLookupError:
+                pass
     return True

--- a/body/stretch_body/robot.py
+++ b/body/stretch_body/robot.py
@@ -287,7 +287,7 @@ class Robot(Device):
         bool
             true if startup of robot succeeded
         """
-        did_acquire = hello_utils.acquire_body_filelock()
+        did_acquire, self._file_lock = hello_utils.acquire_body_filelock()
         if not did_acquire:
             print('Another process is already using Stretch. Try running "stretch_free_robot_process.py"')
             return False
@@ -356,6 +356,7 @@ class Robot(Device):
         Cleanly stops down motion and communication
         """
         self.logger.debug('---- Shutting down robot ----')
+        self._file_lock.release()
         if self.non_dxl_thread:
             if self.non_dxl_thread.running:
                 self.non_dxl_thread.shutdown_flag.set()

--- a/tools/bin/stretch_free_robot_process.py
+++ b/tools/bin/stretch_free_robot_process.py
@@ -1,23 +1,8 @@
 #!/usr/bin/env python3
-import os
-import signal
-import time
-from filelock import FileLock, Timeout
+from stretch_body.hello_utils import free_body_filelock
 
-pid_file = "/tmp/stretch_body_robot_pid.txt"
-file_lock = FileLock(f"{pid_file}.lock")
-try:
-    file_lock.acquire(timeout=1)
-    file_lock.release()
-except Timeout:
-    with open(pid_file, 'r') as f:
-        tokill_pid = int(f.read())
-        # send SIGTERM a few times some processes (e.g. ipython)
-        # try to stall on exit
-        os.kill(tokill_pid, signal.SIGTERM)
-        time.sleep(0.2)
-        os.kill(tokill_pid, signal.SIGTERM)
-        time.sleep(0.2)
-        os.kill(tokill_pid, signal.SIGTERM)
-finally:
+did_free = free_body_filelock()
+if did_free:
     print('Done!')
+else:
+    print('Failed because robot is being used by another user. To force kill the process, try running "sudo -E env PATH=$PATH stretch_free_robot_process.py"')

--- a/tools/bin/stretch_robot_battery_check.py
+++ b/tools/bin/stretch_robot_battery_check.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 from __future__ import print_function
-import stretch_body.pimu as pimu
+import stretch_body.robot as robot
 from colorama import Fore, Back, Style
 import argparse
+import sys
 import stretch_body.hello_utils as hu
 hu.print_stretch_re_use()
 
@@ -19,12 +20,12 @@ def val_in_range(val_name, val,vmin, vmax):
 
 # #####################################################
 
-p=pimu.Pimu()
-if not p.startup():
-    exit()
-p.pull_status()
-val_in_range('Voltage',p.status['voltage'], vmin=p.config['low_voltage_alert'], vmax=14.0)
-val_in_range('Current',p.status['current'], vmin=0.1, vmax=p.config['high_current_alert'])
-val_in_range('CPU Temp',p.status['cpu_temp'], vmin=15, vmax=80)
+r=robot.Robot()
+if not r.startup():
+    sys.exit(1)
+r.pimu.pull_status()
+val_in_range('Voltage',r.pimu.status['voltage'], vmin=r.pimu.config['low_voltage_alert'], vmax=14.0)
+val_in_range('Current',r.pimu.status['current'], vmin=0.1, vmax=r.pimu.config['high_current_alert'])
+val_in_range('CPU Temp',r.pimu.status['cpu_temp'], vmin=15, vmax=80)
 print(Style.RESET_ALL)
-p.stop()
+r.stop()

--- a/tools/bin/stretch_robot_battery_check.py
+++ b/tools/bin/stretch_robot_battery_check.py
@@ -26,6 +26,6 @@ if not r.startup():
 r.pimu.pull_status()
 val_in_range('Voltage',r.pimu.status['voltage'], vmin=r.pimu.config['low_voltage_alert'], vmax=14.0)
 val_in_range('Current',r.pimu.status['current'], vmin=0.1, vmax=r.pimu.config['high_current_alert'])
-val_in_range('CPU Temp',r.pimu.status['cpu_temp'], vmin=15, vmax=80)
+# val_in_range('CPU Temp',r.pimu.status['cpu_temp'], vmin=15, vmax=80)
 print(Style.RESET_ALL)
 r.stop()

--- a/tools/bin/stretch_robot_home.py
+++ b/tools/bin/stretch_robot_home.py
@@ -113,7 +113,6 @@ background_process = multiprocessing.Process(target=fetch_updates_in_background)
 
 r=robot.Robot()
 if not r.startup():
-    r.logger.error('Failed to startup connection to robot')
     sys.exit(1)
 if r.pimu.status['runstop_event']:
     r.logger.error('Cannot home while run-stopped')

--- a/tools/bin/stretch_robot_keyboard_teleop.py
+++ b/tools/bin/stretch_robot_keyboard_teleop.py
@@ -4,6 +4,7 @@ import sys, tty, termios
 import stretch_body.robot as hello_robot
 from stretch_body.hello_utils import *
 import argparse
+import sys
 print_stretch_re_use()
 
 
@@ -12,7 +13,8 @@ args=parser.parse_args()
 
 
 robot=hello_robot.Robot()
-robot.startup()
+if not robot.startup():
+    sys.exit(1)
 
 small_move_m=.01
 large_move_m=0.1

--- a/tools/bin/stretch_system_check.py
+++ b/tools/bin/stretch_system_check.py
@@ -6,6 +6,7 @@ hu.print_stretch_re_use()
 import os
 import sh
 import re
+import sys
 import apt
 import git
 import yaml
@@ -68,8 +69,11 @@ if args.verbose:
     print(Fore.LIGHTBLUE_EX + 'Batch = ' + Fore.CYAN + stretch_batch)
 print(Fore.LIGHTBLUE_EX + 'Serial Number = ' + Fore.CYAN + stretch_serial_no)
 # create robot instance
+print(Style.RESET_ALL)
 r=robot.Robot()
-r.startup()
+if not r.startup():
+    sys.exit(1)
+
 r.monitor.logger.setLevel('WARN')
 
 # ###################  HARDWARE  ######################


### PR DESCRIPTION
This PR robot process protection to multi-user setup. Currently, if you have an ongoing connection to the robot, and attempt to launch another application that needs to connect to the USB hardware, the second attempt will *not* connect and will let the user know that an ongoing connection already exists. This is because only one connection to the hardware can safely communicate at a time. Therefore, this protects the first connection from experiencing dropouts or interruptions. The warning also informs the user that they can kill the first connection using the `stretch_free_robot_process.py` CLI.

All of the above protections work well on single user set-ups, which is the default Stretch ships with. However, it's common in developer teams that are sharing the robot to want to create multiple Unix users on the robot. This PR enables all of the same protections and CLIs that worked previously to now work with multi-user setups.