### PR TITLE
Bugfix/gamepad teleop dexwrist ctrl

### DIFF
--- a/body/stretch_body/gamepad_teleop.py
+++ b/body/stretch_body/gamepad_teleop.py
@@ -208,10 +208,10 @@ class GamePadTeleop(Device):
                 print("Switch D-Pad to Head Control")
                 self.do_single_beep(robot)
                 self.skip_x_button = True
-            self.time_since_dexwrist_switch = time.time()
+            self.time_since_dexwrist_switch = time.perf_counter()
         # skip x button press for 1 second after a toggle 
         if self.skip_x_button:
-            if (time.time() - self.time_since_dexwrist_switch) > 1:
+            if (time.perf_counter() - self.time_since_dexwrist_switch) > 1:
                 self.skip_x_button = False
 
             

--- a/body/stretch_body/gamepad_teleop.py
+++ b/body/stretch_body/gamepad_teleop.py
@@ -211,7 +211,7 @@ class GamePadTeleop(Device):
             self.time_since_dexwrist_switch = time.time()
         # skip x button press for 1 second after a toggle 
         if self.skip_x_button:
-            if (self.time_since_dexwrist_switch - time.time()) > 1:
+            if (time.time() - self.time_since_dexwrist_switch) > 1:
                 self.skip_x_button = False
 
             

--- a/body/stretch_body/gamepad_teleop.py
+++ b/body/stretch_body/gamepad_teleop.py
@@ -211,7 +211,7 @@ class GamePadTeleop(Device):
             self.time_since_dexwrist_switch = time.perf_counter()
         # skip x button press for 1 second after a toggle 
         if self.skip_x_button:
-            if (time.perf_counter() - self.time_since_dexwrist_switch) > 1:
+            if (time.perf_counter() - self.time_since_dexwrist_switch) > 0.5:
                 self.skip_x_button = False
 
             

--- a/body/stretch_body/gamepad_teleop.py
+++ b/body/stretch_body/gamepad_teleop.py
@@ -208,9 +208,10 @@ class GamePadTeleop(Device):
                 print("Switch D-Pad to Head Control")
                 self.do_single_beep(robot)
                 self.skip_x_button = True
-        # skip x button press by N cycles after a toggle 
+            self.time_since_dexwrist_switch = time.time()
+        # skip x button press for 1 second after a toggle 
         if self.skip_x_button:
-            if self._i % 10 == 0:
+            if (self.time_since_dexwrist_switch - time.time()) > 1:
                 self.skip_x_button = False
 
             


### PR DESCRIPTION
The gamepad D-pad can switch between controlling the head pitch and pan, and the dexwrist pitch and roll with the X button. After the button is pressed it is disabled for a time to prevent rapid toggles while holding the button. When the disable is measured in loop increments the time of disable can be inconsistent and cause occasional double toggles.

This PR changes the measure of disable time from loop iterations to a difference of two measures of `time.perf_counter()`.