### PR TITLE
Avoid shell collision during homing

### DIFF
--- a/body/stretch_body/robot_params_SE3.py
+++ b/body/stretch_body/robot_params_SE3.py
@@ -271,7 +271,7 @@ SE3_eoa_wrist_dw3_tool_sg3={
         'stow': {
             'arm': 0.0,
             'lift': 0.3,
-            'wrist_pitch': -0.52,
+            'wrist_pitch': -0.62,
             'wrist_roll': 0.0,
             'wrist_yaw': 3.0,
             'stretch_gripper':0.0
@@ -387,7 +387,7 @@ SE3_eoa_wrist_dw3_tool_nil={
         'stow': {
             'arm': 0.0,
             'lift': 0.3,
-            'wrist_pitch': -0.52,
+            'wrist_pitch': -0.62,
             'wrist_roll': 0.0,
             'wrist_yaw': 3.0
         },


### PR DESCRIPTION
This PR lowers the pitch angle to avoid collision between the top of the D405 and bottom of the D435 during homing.
![before_after_small](https://github.com/hello-robot/stretch_body/assets/64861565/031ed0ae-fce8-4310-ae7d-d1afb05e3c3e)