### PR TITLE
Reset joint level collision states on disable

### DIFF
--- a/body/stretch_body/gamepad_teleop.py
+++ b/body/stretch_body/gamepad_teleop.py
@@ -31,7 +31,7 @@ customized such as manage_shutdown(), manage_fn_button() and setting precision_m
 """
 
 class GamePadTeleop(Device):
-    def __init__(self, robot_instance = True, print_dongle_status = True, lock=None, collision_mgmt=True):
+    def __init__(self, robot_instance = True, print_dongle_status = True, lock=None, collision_mgmt=False):
         """
         Main controller for Stretch's gamepad that ships with the robot.
 

--- a/body/stretch_body/robot_collision.py
+++ b/body/stretch_body/robot_collision.py
@@ -452,6 +452,10 @@ class RobotCollisionMgmt(Device):
 
     def disable(self):
         self.running=False
+        for j in self.collision_status.keys():
+            jm = self.get_joint_motor(j)
+            jm.step_collision_avoidance({'pos':False,'neg':False})
+            jm.forced_collision_stop_override = {'pos':False,'neg':False}
 
 class RobotCollisionCompute(Device):
     def __init__(self,name='robot_collision_mgmt'):

--- a/body/stretch_body/version.py
+++ b/body/stretch_body/version.py
@@ -3,4 +3,4 @@
 # 2) we can import it in setup.py for the same reason
 # 3) we can import it into your module
 
-__version__ = '0.7.19'
+__version__ = '0.7.20'

--- a/tools/bin/stretch_gamepad_teleop.py
+++ b/tools/bin/stretch_gamepad_teleop.py
@@ -6,6 +6,6 @@ from stretch_body.hello_utils import print_stretch_re_use
 print_stretch_re_use()
 
 if __name__ == "__main__":
-   gamepad_teleop = GamePadTeleop()
+   gamepad_teleop = GamePadTeleop(collision_mgmt=True)
    gamepad_teleop.startup()
    gamepad_teleop.mainloop()


### PR DESCRIPTION
This PR fixes a critical bug where disabling the self-collision detection in runtime was malfunctioning.