### PR TITLE
Bugfix/collision mgmt exit

### DIFF
--- a/body/stretch_body/robot.py
+++ b/body/stretch_body/robot.py
@@ -377,6 +377,7 @@ class Robot(Device):
             if self.collision_mgmt_thread.running:
                 self.collision_mgmt_thread.shutdown_flag.set()
                 self.collision_mgmt_thread.join(1)
+                self.collision.stop()
         for k in self.devices:
             if self.devices[k] is not None:
                 self.logger.debug('Shutting down %s'%k)

--- a/body/stretch_body/robot_collision.py
+++ b/body/stretch_body/robot_collision.py
@@ -12,8 +12,6 @@ from stretch_body.robot_params import RobotParams
 import multiprocessing
 import signal
 import ctypes
-import pyrender
-import trimesh
 import sys
 
 ENABLE_COLLISION_VISUALIZER = False
@@ -27,6 +25,10 @@ except AttributeError as e:
     # works on ubuntu 20.04
     import importlib_resources
     str(importlib_resources.files("stretch_body"))
+
+if ENABLE_COLLISION_VISUALIZER:
+    import pyrender
+    import trimesh
 
 # #######################################################################
 

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -11,7 +11,7 @@ stretch_scripts=[f for f in ex_scripts if isfile(f)]
 
 setuptools.setup(
     name="hello-robot-stretch-body-tools",
-    version="0.7.10",
+    version="0.7.11",
     author="Hello Robot Inc",
     author_email="support@hello-robot.com",
     description="Stretch Body Tools",


### PR DESCRIPTION
This PR makes changes to handle the exit of the Collision compute child process cleanly. It also additionally solves the https://github.com/hello-robot/stretch_body/issues/323 by not importing pyrender and trimesh, which are only required for internal debugging.