### PR TITLE
Parameterize RP Lidar baudrate 

### DIFF
--- a/body/stretch_body/robot_params_RE1V0.py
+++ b/body/stretch_body/robot_params_RE1V0.py
@@ -807,7 +807,8 @@ nominal_params={
         'accel_single_tap_thresh': 50,
         'ana_LPF': 10.0}},
     'respeaker': {'usb_name': '/dev/hello-respeaker'},
-    'lidar': {'usb_name': '/dev/hello-lrf'},
+    'lidar': {'usb_name': '/dev/hello-lrf',
+              'baud':115200},
     'stretch_gamepad':{
         'enable_fn_button': 0,
         'function_cmd':'',

--- a/body/stretch_body/robot_params_RE2V0.py
+++ b/body/stretch_body/robot_params_RE2V0.py
@@ -812,7 +812,8 @@ nominal_params={
         'ana_LPF': 10.0},
         'accel_gravity_scale': 1.0},
     'respeaker': {'usb_name': '/dev/hello-respeaker'},
-    'lidar': {'usb_name': '/dev/hello-lrf'},
+    'lidar': {'usb_name': '/dev/hello-lrf',
+              'baud':115200},
     'stretch_gamepad':{
         'enable_fn_button': 0,
         'function_cmd':'',

--- a/body/stretch_body/robot_params_SE3.py
+++ b/body/stretch_body/robot_params_SE3.py
@@ -957,7 +957,8 @@ nominal_params={
         'ana_LPF': 10.0,
         'accel_gravity_scale': 1.0}},
     'respeaker': {'usb_name': '/dev/hello-respeaker'},
-    'lidar': {'usb_name': '/dev/hello-lrf'},
+    'lidar': {'usb_name': '/dev/hello-lrf',
+              'baud':115200},
     'stretch_gamepad':{
         'enable_fn_button': 0,
         'function_cmd':'',

--- a/tools/bin/stretch_rp_lidar_jog.py
+++ b/tools/bin/stretch_rp_lidar_jog.py
@@ -22,7 +22,7 @@ args=parser.parse_args()
 try:
     lidar_dev = Device('lidar')
     lidar_usb = lidar_dev.params['usb_name']
-    lidar = RPLidar(lidar_usb,baudrate=115200)
+    lidar = RPLidar(lidar_usb,baudrate=lidar_dev.params['baud'])
 except RPLidarException:
     print ('RPLidar not present')
     exit()

--- a/tools/bin/stretch_system_check.py
+++ b/tools/bin/stretch_system_check.py
@@ -187,7 +187,7 @@ def are_sensors_ready():
     try:
         lidar_dev = stretch_body.device.Device('lidar')
         lidar_usb = lidar_dev.params['usb_name']
-        lidar = rplidar.RPLidar(lidar_usb, baudrate=115200)
+        lidar = rplidar.RPLidar(lidar_usb, baudrate=lidar_dev.params['baud'])
         lidar.stop_motor()
     except rplidar.RPLidarException:
         return False, False, "missing lidar"


### PR DESCRIPTION
This PR introduces the new parameter, `lidar.baud`, which can be used to set the RP lidar model-supported baud rate instead of hard coding. The main reason for this PR is to support the use of the A2 RP-lidar in Stretch, which requires a 256000 baud setting compared to the A1 RP-lidar, which requires 115200. 