### PR TITLE
Fix failing Robot.wait_command() 

### DIFF
--- a/body/stretch_body/base.py
+++ b/body/stretch_body/base.py
@@ -101,10 +101,10 @@ class Base(Device):
             time.sleep(0.01)
         return False
 
-    def wait_while_is_moving(self,timeout=15.0):
+    def wait_while_is_moving(self,timeout=15.0, use_motion_generator=True):
         done = []
         def check_wait(wait_method):
-            done.append(wait_method(timeout))
+            done.append(wait_method(timeout,use_motion_generator))
         threads = []
         threads.append(threading.Thread(target=check_wait, args=(self.left_wheel.wait_while_is_moving,)))
         threads.append(threading.Thread(target=check_wait, args=(self.right_wheel.wait_while_is_moving,)))

--- a/body/stretch_body/dynamixel_X_chain.py
+++ b/body/stretch_body/dynamixel_X_chain.py
@@ -112,10 +112,10 @@ class DynamixelXChain(Device):
         self.port_handler.closePort()
         self.hw_valid = False
 
-    def wait_until_at_setpoint(self, timeout=15.0):
+    def wait_until_at_setpoint(self, timeout=15.0, use_motion_generator=True):
         at_setpoint = []
         def check_wait(wait_method):
-            at_setpoint.append(wait_method(timeout))
+            at_setpoint.append(wait_method(timeout,use_motion_generator))
         threads = []
         for motor in self.motors:
             threads.append(threading.Thread(target=check_wait, args=(self.motors[motor].wait_until_at_setpoint,)))

--- a/body/stretch_body/dynamixel_hello_XL430.py
+++ b/body/stretch_body/dynamixel_hello_XL430.py
@@ -384,7 +384,7 @@ class DynamixelHelloXL430(Device):
         self.params['zero_t']=x
         self.write_device_params(self.name, self.params)
 
-    def wait_until_at_setpoint(self,timeout=15.0):
+    def wait_until_at_setpoint(self,timeout=15.0, use_motion_generator=True):
         """Polls for moving status to wait until at commanded position goal
 
         Returns
@@ -394,8 +394,12 @@ class DynamixelHelloXL430(Device):
         """
         ts = time.time()
         while time.time() - ts < timeout:
-            if  self.motor.get_moving_status() & (1 << 1) == 0:
-                return True
+            if use_motion_generator:
+                if  self.motor.get_moving_status() & (1 << 1) == 0:
+                    return True
+            else:
+                if self.motor.is_moving() == False:
+                    return True
             time.sleep(0.1)
         return False
 

--- a/body/stretch_body/prismatic_joint.py
+++ b/body/stretch_body/prismatic_joint.py
@@ -567,8 +567,8 @@ class PrismaticJoint(Device):
     def wait_until_at_setpoint(self, timeout=15.0):
         return self.motor.wait_until_at_setpoint(timeout=timeout)
 
-    def wait_while_is_moving(self,timeout=15.0):
-        return self.motor.wait_while_is_moving(timeout=timeout)
+    def wait_while_is_moving(self,timeout=15.0, use_motion_generator=True):
+        return self.motor.wait_while_is_moving(timeout=timeout, use_motion_generator=use_motion_generator)
 
     def wait_for_contact(self, timeout=5.0):
         ts=time.time()

--- a/body/stretch_body/robot.py
+++ b/body/stretch_body/robot.py
@@ -328,24 +328,24 @@ class Robot(Device):
         self.collision_mgmt_thread = CollisionMonitorThread(self, target_rate_hz=100)
 
         if start_non_dxl_thread:
-            self.non_dxl_thread.setDaemon(True)
+            self.non_dxl_thread.daemon = True
             self.non_dxl_thread.start()
             ts = time.time()
             while not self.non_dxl_thread.first_status and time.time() - ts < 3.0:
                 time.sleep(0.01)
 
         if start_dxl_thread:
-            self.dxl_head_thread.setDaemon(True)
+            self.dxl_head_thread.daemon = True
             self.dxl_head_thread.start()
-            self.dxl_end_of_arm_thread.setDaemon(True)
+            self.dxl_end_of_arm_thread.daemon = True
             self.dxl_end_of_arm_thread.start()
 
         if start_sys_mon_thread:
-            self.sys_thread.setDaemon(True)
+            self.sys_thread.daemon = True
             self.sys_thread.start()
 
         if start_sys_mon_thread and self.collision_mgmt_thread:
-            self.collision_mgmt_thread.setDaemon(True)
+            self.collision_mgmt_thread.daemon = True
             self.collision_mgmt_thread.start()
 
         return success
@@ -689,7 +689,7 @@ class Robot(Device):
     def start_event_loop(self):
         self.async_event_loop = asyncio.new_event_loop()
         self.event_loop_thread = threading.Thread(target=self._event_loop, name='AsyncEvenLoopThread')
-        self.event_loop_thread.setDaemon(True)
+        self.event_loop_thread.daemon = True
         self.event_loop_thread.start()
         
     def _event_loop(self):

--- a/body/stretch_body/robot.py
+++ b/body/stretch_body/robot.py
@@ -445,7 +445,7 @@ class Robot(Device):
     def disable_collision_mgmt(self):
         self.collision.disable()
 
-    def wait_command(self, timeout=15.0):
+    def wait_command(self, timeout=15.0, use_motion_generator=True):
         """Pause program execution until all motion complete.
 
         Queuing up motion and pushing it to the hardware with
@@ -469,7 +469,7 @@ class Robot(Device):
         timeout = max(0.0, timeout - 0.1)
         done = []
         def check_wait(wait_method):
-            done.append(wait_method(timeout))
+            done.append(wait_method(timeout, use_motion_generator))
         start = time.time()
         threads = []
         threads.append(threading.Thread(target=check_wait, args=(self.base.wait_while_is_moving,)))

--- a/body/stretch_body/stepper.py
+++ b/body/stretch_body/stepper.py
@@ -472,7 +472,7 @@ class StepperBase(Device):
         self._dirty_command=True
 
 
-    def wait_while_is_moving(self,timeout=15.0):
+    def wait_while_is_moving(self,timeout=15.0, use_motion_generator=True):
         """
         Poll until is moving flag is false
         Return True if success
@@ -480,10 +480,11 @@ class StepperBase(Device):
         """
         ts = time.time()
         self.pull_status()
-        while self.status['is_moving_filtered'] and time.time() - ts < timeout:
+        s = 'is_mg_moving' if use_motion_generator else 'is_moving_filtered'
+        while self.status[s] and time.time() - ts < timeout:
             time.sleep(0.1)
             self.pull_status()
-        return not self.status['is_moving_filtered']
+        return not self.status[s]
 
     def wait_until_at_setpoint(self,timeout=15.0):
         """

--- a/body/test/test_wait_command.py
+++ b/body/test/test_wait_command.py
@@ -1,0 +1,57 @@
+import unittest
+from stretch_body import robot as rb
+import copy
+
+class TestRobotMovement(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.robot = rb.Robot()
+        cls.robot.startup()
+        cls.robot.home()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.robot.stop()  # Assuming there's a stop method to safely shutdown the robot
+
+    def test_movement_accuracy(self):
+        lift_inc = 0.4
+        arm_inc = 0.3
+        base_inc = 0.5
+        wrist_inc = 0.5
+
+        self.robot.pull_status()
+        status_before = copy.deepcopy(self.robot.status)
+
+        self.robot.base.translate_by(base_inc)
+        self.robot.lift.move_by(lift_inc, 0.05)
+        self.robot.arm.move_by(arm_inc, 0.05)
+        self.robot.end_of_arm.move_by('wrist_yaw', wrist_inc, 0.05)
+        self.robot.end_of_arm.move_by('wrist_pitch', wrist_inc, 0.05)
+        self.robot.end_of_arm.move_by('wrist_roll', wrist_inc, 0.05)
+        self.robot.push_command()
+        self.robot.wait_command()
+
+        self.robot.pull_status()
+        status_after = copy.deepcopy(self.robot.status)
+
+        errors = {}
+        errors['base'] = abs(status_after['base']['x'] - status_before['base']['x'])
+        errors['lift'] = abs(status_after['lift']['pos'] - status_before['lift']['pos'])
+        errors['arm'] = abs(status_after['arm']['pos'] - status_before['arm']['pos'])
+        errors['wrist_yaw'] = abs(status_after['end_of_arm']['wrist_yaw']['pos'] - status_before['end_of_arm']['wrist_yaw']['pos'])
+        errors['wrist_pitch'] = abs(status_after['end_of_arm']['wrist_pitch']['pos'] - status_before['end_of_arm']['wrist_pitch']['pos'])
+        errors['wrist_roll'] = abs(status_after['end_of_arm']['wrist_roll']['pos'] - status_before['end_of_arm']['wrist_roll']['pos'])
+
+        print("Set Point Errors:")
+        print(errors)
+
+        self.assertAlmostEqual(errors['base'], base_inc, 2,"base movement error exceeds tolerance")
+        self.assertAlmostEqual(errors['lift'], lift_inc, 2,"lift movement error exceeds tolerance")
+        self.assertAlmostEqual(errors['arm'], arm_inc, 2,"arm movement error exceeds tolerance")
+        self.assertAlmostEqual(errors['wrist_yaw'], wrist_inc, 1,"wrist_yaw movement error exceeds tolerance")
+        self.assertAlmostEqual(errors['wrist_pitch'], wrist_inc, 1,"wrist_pitch movement error exceeds tolerance")
+        self.assertAlmostEqual(errors['wrist_roll'], wrist_inc, 1,"wrist_roll movement error exceeds tolerance")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/body/test/test_wait_command.py
+++ b/body/test/test_wait_command.py
@@ -11,7 +11,7 @@ class TestRobotMovement(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.robot.stop()  # Assuming there's a stop method to safely shutdown the robot
+        cls.robot.stop() 
 
     def test_movement_accuracy(self):
         lift_inc = 0.4
@@ -29,6 +29,7 @@ class TestRobotMovement(unittest.TestCase):
         self.robot.end_of_arm.move_by('wrist_pitch', wrist_inc, 0.05)
         self.robot.end_of_arm.move_by('wrist_roll', wrist_inc, 0.05)
         self.robot.push_command()
+        
         self.robot.wait_command()
 
         self.robot.pull_status()


### PR DESCRIPTION
This PR fixes the issue with the `Robot.wait_command()`, which polls until all the joints have stopped after executing motion on multiple robot joints using `Robot.push_command()`. 
- As stated in this issue  https://github.com/hello-robot/stretch_body/issues/321 previously, the wait command fails to poll until all the robot joints have completed the motion and returns too quickly or inaccurately. The reason for this issue was because of using `is_moving` / `is_moving_filter` boolean status flag to poll. `is_moving` is generated by applying velocity thresholds, which was observed to be very noisy irrespective of the applying smoothing filter which further added in-accuracy.
- The above issue is fixed using the `is_moving_mg` boolean flag instead, which is set by the stepper firmware's motion generator handle when the motor tracks a command. This works reliably and aligns well with the expected use case of `Robot.wait_command()`.
- This PR also introduces the new argument `use_motion_generator` to the `Robot.wait_command()` set to True by default. If users want to use velocity thresholds instead of motion generators to poll, they can set this argument to false. (This might be helpful in niche cases where a user wants to poll until back-driving the robot is completed)
- Run the test script [test_wait_command.py](https://github.com/hello-robot/stretch_body/blob/bugfix/wait_command/body/test/test_wait_command.py) which will validate the working of the Robot.wait_command().