### PR TITLE
Fix importlib import in robot_collision.py

### DIFF
--- a/body/stretch_body/robot_collision.py
+++ b/body/stretch_body/robot_collision.py
@@ -21,7 +21,7 @@ try:
     # works on ubunut 22.04
     import importlib.resources as importlib_resources
     str(importlib_resources.files("stretch_body"))
-except AttributeError as e:
+except AttributeError, ModuleNotFoundError as e:
     # works on ubuntu 20.04
     import importlib_resources
     str(importlib_resources.files("stretch_body"))


### PR DESCRIPTION
This fixes an uncaught ModuleNotFoundError exception while importing importlib resources.