### PR TITLE
Pinocchio requires lower numpy version

### DIFF
--- a/body/setup.py
+++ b/body/setup.py
@@ -19,7 +19,7 @@ setuptools.setup(
         "Operating System :: OS Independent",
         "License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)"
     ],
-    install_requires=['numpy==1.26.4', 'scipy', 'matplotlib', 'ipython', 'pandas', 'sympy', 'nose',
+    install_requires=['numpy>=1.24', 'scipy', 'matplotlib', 'ipython', 'pandas', 'sympy', 'nose',
                       'inputs', 'drawnow', 'rplidar-roboticia', 'snakeviz', 'pyusb', 'SpeechRecognition', 'pixel-ring',
                       'click', 'cma', 'colorama', 'filelock',
                       'scikit-image', 'open3d', 'pyrealsense2', 'pathlib', 'psutil', 'gitpython', 'urchin', 'urdf_parser_py', # urdfpy ==> urchin

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -25,7 +25,7 @@ setuptools.setup(
         "Operating System :: OS Independent",
         "License :: OSI Approved :: Apache Software License"
     ],
-    install_requires=['numpy==1.26.4', 'scipy', 'matplotlib', 'ipython', 'pandas', 'sympy', 'nose', 'sh', 'packaging',
+    install_requires=['numpy>=1.24', 'scipy', 'matplotlib', 'ipython', 'pandas', 'sympy', 'nose', 'sh', 'packaging',
                       'inputs', 'drawnow', 'rplidar-roboticia', 'snakeviz', 'pyusb', 'SpeechRecognition', 'pixel-ring',
                       'click', 'cma', 'opencv-contrib-python', 'colorama', 'scikit-image', 'open3d', 'pyrealsense2', 'gitpython',
                       'xmltodict', 'filelock', 'pyaudio',


### PR DESCRIPTION
Using the latest 1.x version of numpy (1.26.4) is not possible with Pinoochio, a dependency of Web Teleop, because it depends on cmeel-boost, which depends on numpy 1.24.x. In a previous PR, we increased the numpy version from 1.23.x to make trimesh happy. To keep both happy, this commit pins on >=1.24

Follow up to PR #348 