### PR TITLE
Fix xbox teleop for nil tool

### DIFF
--- a/tools/bin/stretch_xbox_controller_teleop.py
+++ b/tools/bin/stretch_xbox_controller_teleop.py
@@ -580,6 +580,11 @@ def main():
             use_stretch_gripper_mapping = False
             use_dex_wrist_mapping = True
 
+        if robot.end_of_arm.name == 'eoa_wrist_dw3_tool_nil':
+            use_head_mapping = False
+            use_stretch_gripper_mapping = False
+            use_dex_wrist_mapping = True
+
         do_double_beep(robot)
 
         while True:


### PR DESCRIPTION
Xbox teleop currently fails when attempting to use it with dw3_tool_nil since there is no case handler for that tool. This is a quick fix for that.