### PR TITLE
Remove playsound

### DIFF
--- a/body/setup.py
+++ b/body/setup.py
@@ -32,6 +32,6 @@ setuptools.setup(
                       'hello-robot-stretch-tool-share>=0.3.3', # defines other Stretch end effectors
                       'hello-robot-stretch-factory>=0.3.5','hello-robot-stretch-body-tools>=0.4.2',
                       'hello-robot-stretch-urdf>=0.0.19',
-                      'aioserial', 'meshio','numpy-stl','playsound', 'pyrender', 'chime'
+                      'aioserial', 'meshio','numpy-stl', 'pyrender', 'chime'
                       ]
 )


### PR DESCRIPTION
## What this does

This removes the `playsound` package dependency as it is not used and is causing issues when trying to install stretch_body (see https://github.com/TaylorSMarks/playsound/issues/143 and https://github.com/TaylorSMarks/playsound/issues/145). Additionally, it is not maintained anymore.