### PR TITLE
Fix for reject waypoint trajectories mismatch joints

### DIFF
--- a/body/stretch_body/dynamixel_X_chain.py
+++ b/body/stretch_body/dynamixel_X_chain.py
@@ -129,10 +129,10 @@ class DynamixelXChain(Device):
                 return True
         return False
 
-    def follow_trajectory(self, v_r=None, a_r=None, req_calibration=False, move_to_start_point=True):
+    def follow_trajectory(self, v_r=None, a_r=None, move_to_start_point=True):
         success = True
         for motor in self.motors:
-            success = success and self.motors[motor].follow_trajectory(v_r, a_r, req_calibration, move_to_start_point)
+            success = success and self.motors[motor].follow_trajectory(v_r, a_r, move_to_start_point)
         return success
 
     def update_trajectory(self):

--- a/body/stretch_body/dynamixel_hello_XL430.py
+++ b/body/stretch_body/dynamixel_hello_XL430.py
@@ -973,6 +973,10 @@ class DynamixelHelloXL430(Device):
             if not self.wait_until_at_setpoint():
                 self.logger.warning('Dynamixel unable to reach starting point')
                 return False
+        else:
+            if not np.isclose(self.trajectory[0].position, self.status['pos'], atol=self.params['distance_tol']):
+                self.logger.warning("Can't start joint traj: first waypoint doesn't match current position")
+                return False
 
         # start trajectory
         self._waypoint_ts = time.time()

--- a/body/stretch_body/dynamixel_hello_XL430.py
+++ b/body/stretch_body/dynamixel_hello_XL430.py
@@ -914,7 +914,7 @@ class DynamixelHelloXL430(Device):
         else:
             return max(0,self.trajectory.waypoints[-1].time - self.get_trajectory_ts())
 
-    def follow_trajectory(self, v_r=None, a_r=None, req_calibration=True, move_to_start_point=True):
+    def follow_trajectory(self, v_r=None, a_r=None, move_to_start_point=True):
         """Starts executing a waypoint trajectory
 
         `self.trajectory` must be populated with a valid trajectory before calling
@@ -926,8 +926,6 @@ class DynamixelHelloXL430(Device):
             velocity limit for trajectory in radians per second
         a_r : float
             acceleration limit for trajectory in radians per second squared
-        req_calibration : bool
-            whether to allow motion prior to homing
         move_to_start_point : bool
             whether to move to the trajectory's start to avoid a jump, this
             time to move doesn't count against the trajectory's timeline
@@ -936,10 +934,9 @@ class DynamixelHelloXL430(Device):
         if not self.hw_valid:
             self.logger.warning('Dynamixel connection to hardware not valid')
             return False
-        if req_calibration:
-            if not self.is_calibrated:
-                self.logger.warning('Dynamixel not homed')
-                return False
+        if self.params['req_calibration'] and not self.is_calibrated:
+            self.logger.warning('Dynamixel not homed')
+            return False
         if self._waypoint_ts is not None:
             self.logger.error('Dynamixel waypoint trajectory already active')
             return False

--- a/body/stretch_body/prismatic_joint.py
+++ b/body/stretch_body/prismatic_joint.py
@@ -5,6 +5,7 @@ from stretch_body.trajectories import PrismaticTrajectory
 import stretch_body.hello_utils as hu
 import time
 import sys
+import numpy as np
 
 
 class PrismaticJoint(Device):
@@ -480,8 +481,10 @@ class PrismaticJoint(Device):
             if prev_sync_mode:
                 self.motor.enable_sync_mode()
                 self.push_command()
-            #print('WAIT')
-            #time.sleep(2.0)
+        else:
+            if not np.isclose(self.trajectory[0].position, self.status['pos'], atol=self.params['distance_tol']):
+                self.logger.warning("Can't start joint traj: first waypoint doesn't match current position")
+                return False
 
         self.traj_guarded_event=self.motor.status['guarded_event']
         # start trajectory

--- a/body/stretch_body/robot.py
+++ b/body/stretch_body/robot.py
@@ -508,6 +508,15 @@ class Robot(Device):
 
         success = success and self.end_of_arm.follow_trajectory(move_to_start_point=move_to_start_point)
         success = success and self.head.follow_trajectory(move_to_start_point=move_to_start_point)
+
+        # TODO: HACK! We need a way to queue waypoint trajectories to
+        # joints before starting execution. Currently, each joint's
+        # `follow_trajectory` does both. If arm's traj is valid and
+        # starts executing, but lift's traj isn't, the arm doesn't
+        # know that the lift didn't start and keeps going.
+        if not success:
+            self.stop_trajectory()
+
         return success
 
     def stop_trajectory(self):

--- a/body/stretch_body/robot.py
+++ b/body/stretch_body/robot.py
@@ -490,10 +490,10 @@ class Robot(Device):
                self.head.is_trajectory_active()
 
 
-    def follow_trajectory(self):
+    def follow_trajectory(self, move_to_start_point=False):
         success = True
-        success = success and self.arm.follow_trajectory(move_to_start_point=False)
-        success = success and self.lift.follow_trajectory(move_to_start_point=False)
+        success = success and self.arm.follow_trajectory(move_to_start_point=move_to_start_point)
+        success = success and self.lift.follow_trajectory(move_to_start_point=move_to_start_point)
         success = success and self.base.follow_trajectory()
 
         # Check if need to do a motor sync by looking at if there's been a pimu sync signal sent
@@ -506,8 +506,8 @@ class Robot(Device):
         if self.pimu.ts_last_motor_sync is None or sync_required:
             self.pimu.trigger_motor_sync()
 
-        success = success and self.end_of_arm.follow_trajectory(move_to_start_point=False)
-        success = success and self.head.follow_trajectory(move_to_start_point=False)
+        success = success and self.end_of_arm.follow_trajectory(move_to_start_point=move_to_start_point)
+        success = success and self.head.follow_trajectory(move_to_start_point=move_to_start_point)
         return success
 
     def stop_trajectory(self):

--- a/body/stretch_body/robot_params_RE1V0.py
+++ b/body/stretch_body/robot_params_RE1V0.py
@@ -131,7 +131,8 @@ RE1V0_stretch_gripper={
         'retry_on_comm_failure': 1,
         'baud': 115200,
         'enable_runstop': 1,
-        'disable_torque_on_stop': 1}
+        'disable_torque_on_stop': 1,
+        'distance_tol': 0.015}
 
 RE1V0_wrist_yaw={
     'device_info': "Standard wrist yaw shipped with original RE1",
@@ -177,7 +178,8 @@ RE1V0_wrist_yaw={
     'baud': 115200,
     'enable_runstop': 1,
     'disable_torque_on_stop': 1,
-    'range_pad_t': [100.0, -100.0]}
+    'range_pad_t': [100.0, -100.0],
+    'distance_tol': 0.015}
 
 #Brought in from tool_share for DexWrist "2"
 RE1V0_wrist_pitch_DW2={
@@ -218,7 +220,8 @@ RE1V0_wrist_pitch_DW2={
         'disable_torque_on_stop': 0,
         'float_on_stop': 1,
         'current_float_A': -0.13,
-        'current_limit_A': 2.5
+        'current_limit_A': 2.5,
+        'distance_tol': 0.03
     }
 
 RE1V0_wrist_roll_DW2={
@@ -259,7 +262,8 @@ RE1V0_wrist_roll_DW2={
         'disable_torque_on_stop': 0,
         'float_on_stop': 1,
         'current_float_A': 0.04,
-        'current_limit_A': 1.0
+        'current_limit_A': 1.0,
+        'distance_tol': 0.015
     }
 
 # ######### EndOfArm Defn ##############
@@ -397,7 +401,8 @@ nominal_params={
                 'vel_m': 0.3,
                 'accel_m': 0.5},
                 'vel_brakezone_factor': 0.03},
-        'set_safe_velocity': 1},
+        'set_safe_velocity': 1,
+        'distance_tol': 0.008},
     'base':{
         'usb_name_left_wheel': '/dev/hello-motor-left-wheel',
         'usb_name_right_wheel': '/dev/hello-motor-right-wheel',
@@ -496,7 +501,8 @@ nominal_params={
         'stall_max_effort': 20.0,
         'stall_backoff': 0.017,
         'stall_max_time': 1.0,
-        'stall_min_vel': 0.1},
+        'stall_min_vel': 0.1,
+        'distance_tol': 0.15},
     'head_tilt':{
         'range_pad_t': [50.0, -50.0],
         'flip_encoder_polarity': 1,
@@ -542,7 +548,8 @@ nominal_params={
         'stall_backoff': 0.017,
         'stall_max_effort': 20.0,
         'stall_max_time': 1.0,
-        'stall_min_vel': 0.1},
+        'stall_min_vel': 0.1,
+        'distance_tol': 0.52},
     'hello-motor-arm':{
         'gains':{
             'effort_LPF': 10.0,
@@ -719,7 +726,8 @@ nominal_params={
                 'accel_m': 0.3},
             'vel_brakezone_factor': 0.02},
         'set_safe_velocity': 1,
-        'pinion_t': 12},
+        'pinion_t': 12,
+        'distance_tol': 0.015},
     'pimu':{
       'usb_name': '/dev/hello-pimu',
       'base_fan_off': 70,

--- a/body/stretch_body/robot_params_RE2V0.py
+++ b/body/stretch_body/robot_params_RE2V0.py
@@ -127,7 +127,8 @@ RE2V0_stretch_gripper={
         'enable_runstop': 1,
         'disable_torque_on_stop': 1,
         'range_t': [0, 8022],
-        'zero_t': 5212}
+        'zero_t': 5212,
+        'distance_tol': 0.015}
 
 RE2V0_wrist_yaw={
     'device_info': "Standard wrist yaw shipped with original RE2",
@@ -175,7 +176,8 @@ RE2V0_wrist_yaw={
     'disable_torque_on_stop': 1,
     'range_pad_t': [100.0, -100.0],
     'range_t': [0,9340],
-    'zero_t': 7005}
+    'zero_t': 7005,
+    'distance_tol': 0.015}
 
 #Brought in from tool_share for DexWrist "2"
 RE2V0_wrist_pitch_DW2={
@@ -216,7 +218,8 @@ RE2V0_wrist_pitch_DW2={
         'disable_torque_on_stop': 0,
         'float_on_stop': 1,
         'current_float_A': -0.13,
-        'current_limit_A': 2.5
+        'current_limit_A': 2.5,
+        'distance_tol': 0.03
     }
 
 RE2V0_wrist_roll_DW2={
@@ -257,7 +260,8 @@ RE2V0_wrist_roll_DW2={
         'disable_torque_on_stop': 0,
         'float_on_stop': 1,
         'current_float_A': 0.04,
-        'current_limit_A': 1.0
+        'current_limit_A': 1.0,
+        'distance_tol': 0.015
     }
 
 # ######### EndOfArm Defn ##############
@@ -397,7 +401,8 @@ nominal_params={
                 'vel_m': 0.4,
                 'accel_m': 0.4},
         'vel_brakezone_factor': 0.03},
-        'set_safe_velocity': 1},
+        'set_safe_velocity': 1,
+        'distance_tol': 0.008},
     'base':{
         'usb_name_left_wheel': '/dev/hello-motor-left-wheel',
         'usb_name_right_wheel': '/dev/hello-motor-right-wheel',
@@ -498,7 +503,8 @@ nominal_params={
         'stall_min_vel': 0.1,
         'range_pad_t':[50.0,-50.0],
         'range_t': [0, 3827],
-        'zero_t': 1250},
+        'zero_t': 1250,
+        'distance_tol': 0.15},
     'head_tilt':{
         'flip_encoder_polarity': 1,
         'gr': 1.0,
@@ -546,7 +552,8 @@ nominal_params={
         'stall_min_vel': 0.1,
         'range_pad_t': [50.0, -50.0],
         'range_t': [1775,3150],
-        'zero_t': 2048},
+        'zero_t': 2048,
+        'distance_tol': 0.52},
     'hello-motor-arm':{
         'gains':{
             'effort_LPF': 10.0,
@@ -723,7 +730,8 @@ nominal_params={
               'vel_m': 0.15},
         'vel_brakezone_factor': 0.01},
         'set_safe_velocity': 1,
-          'pinion_t': 12},
+        'pinion_t': 12,
+        'distance_tol': 0.015},
     'pimu':{
       'usb_name': '/dev/hello-pimu',
       'base_fan_off': 70,

--- a/body/stretch_body/robot_params_SE3.py
+++ b/body/stretch_body/robot_params_SE3.py
@@ -124,7 +124,8 @@ SE3_stretch_gripper_SG3={
         'enable_runstop': 1,
         'disable_torque_on_stop': 1,
         'range_t': [0, 9102],
-        'zero_t': 3279}
+        'zero_t': 3279,
+        'distance_tol': 0.015}
 
 SE3_wrist_yaw_DW3={
         'flip_encoder_polarity': 1,
@@ -171,7 +172,8 @@ SE3_wrist_yaw_DW3={
         'disable_torque_on_stop': 1,
         'range_pad_t': [100.0, -100.0],
         'range_t': [0,9340],
-        'zero_t': 7136}
+        'zero_t': 7136,
+        'distance_tol': 0.015}
 
 SE3_wrist_pitch_DW3={
         'flip_encoder_polarity': 1,
@@ -210,7 +212,8 @@ SE3_wrist_pitch_DW3={
         'disable_torque_on_stop': 0,
         'float_on_stop': 1,
         'current_float_A': -0.13,
-        'current_limit_A': 2.5
+        'current_limit_A': 2.5,
+        'distance_tol': 0.03
     }
 
 SE3_wrist_roll_DW3={
@@ -250,7 +253,8 @@ SE3_wrist_roll_DW3={
         'disable_torque_on_stop': 0,
         'float_on_stop': 0,
         'current_float_A': 0.04,
-        'current_limit_A': 1.0}
+        'current_limit_A': 1.0,
+        'distance_tol': 0.015}
 
 SE3_wrist_roll_DW3_tablet = SE3_wrist_roll_DW3
 SE3_wrist_roll_DW3_tablet['float_on_stop'] = 0
@@ -540,8 +544,9 @@ nominal_params={
             'trajectory_max': {
                 'vel_m': 0.4,
                 'accel_m': 0.4},
-                'vel_brakezone_factor': 0.03},
-                'set_safe_velocity': 1},
+            'vel_brakezone_factor': 0.03},
+            'set_safe_velocity': 1,
+            'distance_tol': 0.008},
     'base':{
         'usb_name_left_wheel': '/dev/hello-motor-left-wheel',
         'usb_name_right_wheel': '/dev/hello-motor-right-wheel',
@@ -642,7 +647,8 @@ nominal_params={
         'stall_min_vel': 0.1,
         'range_pad_t':[50.0,-50.0],
         'range_t': [0, 3827],
-        'zero_t': 1250},
+        'zero_t': 1250,
+        'distance_tol': 0.15},
     'head_tilt':{
         'flip_encoder_polarity': 1,
         'gr': 1.0,
@@ -688,7 +694,8 @@ nominal_params={
         'stall_max_effort': 20.0,
         'stall_max_time': 1.0,
         'stall_min_vel': 0.1,
-        'range_pad_t': [50.0, -50.0]},
+        'range_pad_t': [50.0, -50.0],
+        'distance_tol': 0.52},
     'hello-motor-arm':{
         'gains':{
             'effort_LPF': 10.0,
@@ -865,7 +872,8 @@ nominal_params={
               'vel_m': 0.15},
         'vel_brakezone_factor': 0.01},
         'set_safe_velocity': 1,
-          'pinion_t': 12},
+        'pinion_t': 12,
+        'distance_tol': 0.015},
     'pimu':{
       'usb_name': '/dev/hello-pimu',
       'base_fan_off': 70,

--- a/body/test/test_arm.py
+++ b/body/test/test_arm.py
@@ -154,3 +154,21 @@ class TestArm(unittest.TestCase):
         self.assertAlmostEqual(a.status['pos'], 0.15, places=2)
 
         a.stop()
+
+    def test_reject_invalid_first_waypoint(self):
+        print('\nUnittest: test_reject_invalid_first_waypoint')
+        a = stretch_body.arm.Arm()
+        a.motor.disable_sync_mode()
+        self.assertTrue(a.startup(threaded=True))
+        if not a.motor.status['pos_calibrated']:
+            self.fail('test requires arm to be homed')
+
+        a.move_to(0.0)
+        a.push_command()
+        a.wait_until_at_setpoint()
+
+        a.trajectory.add(0, 0.1) # 0.1m discrepancy between first waypoint and current joint pos
+        a.trajectory.add(3, 0.2)
+        self.assertFalse(a.follow_trajectory(move_to_start_point=False))
+
+        a.stop()

--- a/body/test/test_dynamixel_hello_XL430.py
+++ b/body/test/test_dynamixel_hello_XL430.py
@@ -345,3 +345,17 @@ class TestDynamixelHelloXL430(unittest.TestCase):
         print('Measured',measured_traveled_distance)
         self.assertTrue(np.isclose(measured_traveled_distance, expected_traveled_distance, atol=0.3))
         s.stop()
+
+    def test_reject_invalid_first_waypoint(self):
+        print('\nUnittest: test_reject_invalid_first_waypoint')
+        s = stretch_body.dynamixel_hello_XL430.DynamixelHelloXL430(name="wrist_pitch")
+        self.assertTrue(s.startup(threaded=True))
+
+        s.move_to(0.0)
+        s.wait_until_at_setpoint()
+
+        s.trajectory.add(0, 0.25) # 0.25rad discrepancy between first waypoint and current joint pos
+        s.trajectory.add(3, 0.45)
+        self.assertFalse(s.follow_trajectory(move_to_start_point=False))
+
+        s.stop()

--- a/body/test/test_lift.py
+++ b/body/test/test_lift.py
@@ -137,3 +137,21 @@ class TestLift(unittest.TestCase):
         self.assertAlmostEqual(l.status['pos'], 0.25, places=2)
 
         l.stop()
+
+    def test_reject_invalid_first_waypoint(self):
+        print('\nUnittest: test_reject_invalid_first_waypoint')
+        l = stretch_body.lift.Lift()
+        l.motor.disable_sync_mode()
+        self.assertTrue(l.startup(threaded=True))
+        if not l.motor.status['pos_calibrated']:
+            self.fail('test requires lift to be homed')
+
+        l.move_to(0.4)
+        l.push_command()
+        l.wait_until_at_setpoint()
+
+        l.trajectory.add(0, 0.5) # 0.1m discrepancy between first waypoint and current joint pos
+        l.trajectory.add(3, 0.6)
+        self.assertFalse(l.follow_trajectory(move_to_start_point=False))
+
+        l.stop()

--- a/body/test/test_robot.py
+++ b/body/test/test_robot.py
@@ -218,3 +218,21 @@ class TestRobot(unittest.TestCase):
         time.sleep(26)
 
         r.stop()
+
+    def test_reject_invalid_first_waypoint(self):
+        print('\nUnittest: test_reject_invalid_first_waypoint')
+        r = stretch_body.robot.Robot()
+        r.arm.motor.disable_sync_mode()
+        r.startup()
+        r.stow()
+        time.sleep(1)
+
+        r.end_of_arm.get_joint('wrist_yaw').trajectory.add(0, 3.14) # 0.14rad discrepancy between first waypoint and current joint pos (3.0)
+        r.end_of_arm.get_joint('wrist_yaw').trajectory.add(6, 2.14)
+        r.end_of_arm.get_joint('wrist_yaw').trajectory.add(12, 3.14)
+        r.arm.trajectory.add(0, 0)
+        r.arm.trajectory.add(6, 0.1)
+        r.arm.trajectory.add(12, 0.0)
+        self.assertFalse(r.follow_trajectory(move_to_start_point=False))
+
+        r.stop()

--- a/docs/robot_parameters.md
+++ b/docs/robot_parameters.md
@@ -14,8 +14,8 @@ A boolean to toggle the use of Asyncio for coordination serial communication wit
 
 A boolean to toggle the use of the collision manager, which prevents self-collisions between the robot's arm and body. For example, this can be helpful for novice users during gamepad teleop because they can figure out the controls without fear of teleoperating the robot into collisions.
 
-| Parameter         | Default Value |
-|-------------------|---------------|
+| Parameter                   | Default Value |
+|-----------------------------|---------------|
 | robot.use_collision_manager | `0`           |
 
 ### params
@@ -59,18 +59,18 @@ This parameter changes how a particular joint behaves when the robot is runstopp
 
 The Dynamixel joints on the robot handle runstop differently than the stepper joints do. Whereas the stepper joints receive a hardware pulse whenever the runstop button is pressed, the Dynamixel joints don't. When Stretch Body is running, a sentry monitors the runstop through the pimu and calls `disable_torque()` / `enable_torque()` on the dxl joints as needed. For stepper joints, this parameter gives you control over whether the stepper PCB respects the hardware pulse. For dxl joints, this parameter gives you control over whether the sentry will turn on/off torque of a joint in response to the runstop state.
 
-| Parameter                     | Default Value |
-|-------------------------------|---------------|
-| head_pan.enable_runstop        | `1`          |
-| head_tilt.enable_runstop       | `1`           |
-| stretch_gripper.enable_runstop | `1`           |
-| wrist_yaw.enable_runstop       | `1`           |
-| wrist_pitch.enable_runstop     | `1`           |
-| wrist_roll.enable_runstop      | `1`           |
-| hello-motor-arm.gains.enable_runstop | `1` |
-| hello-motor-lift.gains.enable_runstop | `1` |
-| hello-motor-left-wheel.gains.enable_runstop | `1` |
-| hello-motor-right-wheel.gains.enable_runstop | `1` |
+| Parameter                                    | Default Value |
+|----------------------------------------------|---------------|
+| head_pan.enable_runstop                      | `1`           |
+| head_tilt.enable_runstop                     | `1`           |
+| stretch_gripper.enable_runstop               | `1`           |
+| wrist_yaw.enable_runstop                     | `1`           |
+| wrist_pitch.enable_runstop                   | `1`           |
+| wrist_roll.enable_runstop                    | `1`           |
+| hello-motor-arm.gains.enable_runstop         | `1`           |
+| hello-motor-lift.gains.enable_runstop        | `1`           |
+| hello-motor-left-wheel.gains.enable_runstop  | `1`           |
+| hello-motor-right-wheel.gains.enable_runstop | `1`           |
 
 To disable the sentry, there's also the `robot_sentry.dynamixel_stop_on_runstop` parameter. To disable the hardware pulses, there's also the `pimu.config.stop_at_runstop` parameter. To disabling logging when runstop is enabled/disabled, there's also the `robot_monitor.monitor_runstop`.
 
@@ -84,17 +84,32 @@ There’s a simple tool to calibrate these values. `REx_calibrate_gravity_comp.p
 
 A boolean to toggle whether a sentry monitors the gripper servo for risk of "overloading", a hardware protection state the servo goes into when it cannot provide the torque being asked for, and backs off the commands to reduce the amount of torque being asked for. In effect, this sentry enables the gripper to keep its grip on objects without overloading.
 
-| Parameter         | Default Value |
-|-------------------|---------------|
+| Parameter                             | Default Value |
+|---------------------------------------|---------------|
 | robot_sentry.stretch_gripper_overload | `1`           |
 
 ### base_max_velocity
 
 A boolean to toggle whether a sentry monitors the robot's center of mass and limits max allowable speed of the mobile base to prevent unstable behavior resulting from fast motion paired with a high center of mass. Disabling this safety feature means the base will not limit its speed and will travel at the speed you've commanded it.
 
-| Parameter         | Default Value |
-|-------------------|---------------|
+| Parameter                      | Default Value |
+|--------------------------------|---------------|
 | robot_sentry.base_max_velocity | `1`           |
+
+### distance_tol
+
+A tolerance within which the first waypoint of a splined trajectory must be of the joint's current position when `follow_trajectory(move_to_first_point=False)`, or the trajectory won't start execution.
+
+| Parameter                    | Default Value |
+|------------------------------|---------------|
+| head_pan.distance_tol        | `0.15`        |
+| head_tilt.distance_tol       | `0.52`        |
+| stretch_gripper.distance_tol | `0.015`       |
+| wrist_yaw.distance_tol       | `0.015`       |
+| wrist_pitch.distance_tol     | `0.03`        |
+| wrist_roll.distance_tol      | `0.015`       |
+| arm.distance_tol             | `0.008`       |
+| lift.distance_tol            | `0.015`       |
 
 ## Parameters for Command Line Tools
 


### PR DESCRIPTION
When a joint is setting up execution of a waypoint trajectory, it will move to the first point of the trajectory using `move_to()` if `follow_trajectory(move_to_first_point=True)`. `move_to_first_point` defaults to true. But it takes some time for the joint to reach the first point. With motion planning, you often incoporate the joint's initial position into the optimization. Furthermore, for model predictive control, you want the robot to start tracking the trajectory immediately. So you'd set `move_to_first_point=False`.

There is an bug where the user-provided trajectory's first waypoint has a position that doesn't match the joint's actual position. In this bug, the trajectory is still accepted and the joint begins servo-ing fast to track the trajectory. Often, servo-ing fast causes the motor's current draw to spike and this trips motor protection filters at the low level. To the user, this looks like the joint jerks forward and suddenly stops. In this fix, we check that the first waypoint's position is within tolerance of the actual position of the joint, and reject the trajectory if it is not.

Part of the reason for this bug is that the firmware was handling this check in `TrajectoryManager.is_segment_valid()`, but that logic was [eventually commented out](https://github.com/hello-robot/stretch_firmware/blob/dac1a3aa8bd415e1a3b8f2337553becebfd66351/arduino/hello_stepper/TrajectoryManager.cpp#L187-L191) because the extra computational time of the check caused communication with the uC to stutter.

Added two additional fixes while writing unit tests:
 - `req_calibration` shouldn't be an argument of Dynamixels. It's part of the parameters
 - Trajectories are cancelled if any joint reports issue with initiating tracking.

## Testing
Use `python3 -m unittest test.test_robot`. Tested on 3004.