### PR TITLE
Stretch Pro gripper naming and Configure tool update

### DIFF
--- a/body/stretch_body/robot_params_SE3.py
+++ b/body/stretch_body/robot_params_SE3.py
@@ -73,7 +73,7 @@ configuration_params_template={
 # Eg, which joints and tools and versions of hardware are present
 
 
-SE3_stretch_gripper_SG3_xm430={
+SE3_stretch_gripper_SG3_pro={
         'range_pad_t': [100.0, -100.0],
         'flip_encoder_polarity': 0,
         'gr': 1.0,
@@ -437,9 +437,9 @@ SE3_eoa_wrist_dw3_tool_sg3={
             }
     }}
 
-SE3_eoa_wrist_dw3_tool_sg3_xm430 = copy.deepcopy(SE3_eoa_wrist_dw3_tool_sg3)
-SE3_eoa_wrist_dw3_tool_sg3_xm430['devices']['stretch_gripper']['device_params'] = 'SE3_stretch_gripper_SG3_xm430'
-SE3_eoa_wrist_dw3_tool_sg3_xm430['devices']['stretch_gripper']['py_class_name'] = 'StretchGripper3xm430'
+SE3_eoa_wrist_dw3_tool_sg3_pro = copy.deepcopy(SE3_eoa_wrist_dw3_tool_sg3)
+SE3_eoa_wrist_dw3_tool_sg3_pro['devices']['stretch_gripper']['device_params'] = 'SE3_stretch_gripper_SG3_pro'
+SE3_eoa_wrist_dw3_tool_sg3_pro['devices']['stretch_gripper']['py_class_name'] = 'StretchGripper3Pro'
 
 SE3_eoa_wrist_dw3_tool_nil={
         'py_class_name': 'EOA_Wrist_DW3_Tool_NIL',
@@ -575,11 +575,11 @@ nominal_params={
     #Each EOA will get expanded at runtime into its full parameter dictionary
     # Eg, supported_eoa.tool_none --> adds the wrist_yaw param dict to nominal_params
     # Add all formally supported EOA to this list
-    'supported_eoa': ['eoa_wrist_dw3_tool_nil','eoa_wrist_dw3_tool_sg3', 'eoa_wrist_dw3_tool_tablet_12in', 'eoa_wrist_dw3_tool_sg3_xm430'],
+    'supported_eoa': ['eoa_wrist_dw3_tool_nil','eoa_wrist_dw3_tool_sg3', 'eoa_wrist_dw3_tool_tablet_12in', 'eoa_wrist_dw3_tool_sg3_pro'],
     'eoa_wrist_dw3_tool_nil': SE3_eoa_wrist_dw3_tool_nil,
     'eoa_wrist_dw3_tool_sg3': SE3_eoa_wrist_dw3_tool_sg3,
     'eoa_wrist_dw3_tool_tablet_12in': SE3_eoa_wrist_dw3_tool_tablet_12in,
-    'eoa_wrist_dw3_tool_sg3_xm430': SE3_eoa_wrist_dw3_tool_sg3_xm430,
+    'eoa_wrist_dw3_tool_sg3_pro': SE3_eoa_wrist_dw3_tool_sg3_pro,
     'arm':{
         'usb_name': '/dev/hello-motor-arm',
         'use_vel_traj': 1,

--- a/body/stretch_body/robot_params_SE3.py
+++ b/body/stretch_body/robot_params_SE3.py
@@ -73,7 +73,7 @@ configuration_params_template={
 # Eg, which joints and tools and versions of hardware are present
 
 
-SE3_stretch_gripper_SG3_v2={
+SE3_stretch_gripper_SG3_xm430={
         'range_pad_t': [100.0, -100.0],
         'flip_encoder_polarity': 0,
         'gr': 1.0,
@@ -437,9 +437,9 @@ SE3_eoa_wrist_dw3_tool_sg3={
             }
     }}
 
-SE3_eoa_wrist_dw3_tool_sg3_v2 = copy.deepcopy(SE3_eoa_wrist_dw3_tool_sg3)
-SE3_eoa_wrist_dw3_tool_sg3_v2['devices']['stretch_gripper']['device_params'] = 'SE3_stretch_gripper_SG3_v2'
-SE3_eoa_wrist_dw3_tool_sg3_v2['devices']['stretch_gripper']['py_class_name'] = 'StretchGripper3v2'
+SE3_eoa_wrist_dw3_tool_sg3_xm430 = copy.deepcopy(SE3_eoa_wrist_dw3_tool_sg3)
+SE3_eoa_wrist_dw3_tool_sg3_xm430['devices']['stretch_gripper']['device_params'] = 'SE3_stretch_gripper_SG3_xm430'
+SE3_eoa_wrist_dw3_tool_sg3_xm430['devices']['stretch_gripper']['py_class_name'] = 'StretchGripper3xm430'
 
 SE3_eoa_wrist_dw3_tool_nil={
         'py_class_name': 'EOA_Wrist_DW3_Tool_NIL',
@@ -575,11 +575,11 @@ nominal_params={
     #Each EOA will get expanded at runtime into its full parameter dictionary
     # Eg, supported_eoa.tool_none --> adds the wrist_yaw param dict to nominal_params
     # Add all formally supported EOA to this list
-    'supported_eoa': ['eoa_wrist_dw3_tool_nil','eoa_wrist_dw3_tool_sg3', 'eoa_wrist_dw3_tool_tablet_12in', 'eoa_wrist_dw3_tool_sg3_v2'],
+    'supported_eoa': ['eoa_wrist_dw3_tool_nil','eoa_wrist_dw3_tool_sg3', 'eoa_wrist_dw3_tool_tablet_12in', 'eoa_wrist_dw3_tool_sg3_xm430'],
     'eoa_wrist_dw3_tool_nil': SE3_eoa_wrist_dw3_tool_nil,
     'eoa_wrist_dw3_tool_sg3': SE3_eoa_wrist_dw3_tool_sg3,
     'eoa_wrist_dw3_tool_tablet_12in': SE3_eoa_wrist_dw3_tool_tablet_12in,
-    'eoa_wrist_dw3_tool_sg3_v2': SE3_eoa_wrist_dw3_tool_sg3_v2,
+    'eoa_wrist_dw3_tool_sg3_xm430': SE3_eoa_wrist_dw3_tool_sg3_xm430,
     'arm':{
         'usb_name': '/dev/hello-motor-arm',
         'use_vel_traj': 1,

--- a/body/stretch_body/robot_params_SE3.py
+++ b/body/stretch_body/robot_params_SE3.py
@@ -77,7 +77,7 @@ SE3_stretch_gripper_SG3_pro={
         'range_pad_t': [100.0, -100.0],
         'flip_encoder_polarity': 0,
         'gr': 1.0,
-        'id': 14,
+        'id': 17,
         'max_voltage_limit': 15,
         'min_grip_strength': -125,
         'min_voltage_limit': 11,

--- a/body/stretch_body/robot_params_SE3.py
+++ b/body/stretch_body/robot_params_SE3.py
@@ -121,7 +121,7 @@ SE3_stretch_gripper_SG3_pro={
         'use_multiturn': 1,
         'use_pos_current_ctrl':0,
         'use_current_homing': 1,
-        'current_homing_limit_A': 0.18,
+        'current_homing_limit_A': 0.15,
         'current_limit_A': 1,
         'retry_on_comm_failure': 1,
         'baud': 115200,

--- a/body/stretch_body/stretch_gripper.py
+++ b/body/stretch_body/stretch_gripper.py
@@ -104,7 +104,7 @@ class StretchGripper3(StretchGripper):
     def __init__(self, chain=None, usb=None):
         StretchGripper.__init__(self, chain, usb,'stretch_gripper')
 
-class StretchGripper3v2(StretchGripper, DynamixelHelloXL430):
+class StretchGripper3xm430(StretchGripper, DynamixelHelloXL430):
     """
         Wrapper for version 3.5 XM430-W350 gripper
     """

--- a/body/stretch_body/stretch_gripper.py
+++ b/body/stretch_body/stretch_gripper.py
@@ -104,7 +104,7 @@ class StretchGripper3(StretchGripper):
     def __init__(self, chain=None, usb=None):
         StretchGripper.__init__(self, chain, usb,'stretch_gripper')
 
-class StretchGripper3xm430(StretchGripper, DynamixelHelloXL430):
+class StretchGripper3Pro(StretchGripper, DynamixelHelloXL430):
     """
         Wrapper for version 3.5 XM430-W350 gripper
     """

--- a/tools/bin/stretch_configure_tool.py
+++ b/tools/bin/stretch_configure_tool.py
@@ -30,7 +30,10 @@ logging.getLogger().setLevel(logging.CRITICAL)
 def is_wrist_present():
     return exists('/dev/hello-dynamixel-wrist')
 
+present_dxl_model_id_map = {}
+
 def how_many_dxl_on_wrist_chain():
+    global present_dxl_model_id_map
     from stretch_body.dynamixel_XL430 import DynamixelXL430, DynamixelCommError
     cli_device.logger.debug("Scanning wrist dxl chain for motors...")
     nfound = 0
@@ -44,6 +47,7 @@ def how_many_dxl_on_wrist_chain():
                     continue
                 if not m.do_ping(verbose=False):
                     continue
+                present_dxl_model_id_map[dxl_id] = m.dxl_model_name
                 m.stop()
                 nfound += 1
         except DynamixelCommError:
@@ -104,6 +108,13 @@ def does_tool_need_to_change():
     # check if the existing hardware, d405 present, matches the current tool
     if d405_present != expected_d405_present:
         cli_device.logger.info(f"""But the gripper camera {"should" if expected_d405_present else "shouldn't"} be present""")
+        return True
+
+    # Check if SG3's gripper dxl id to detect pro gripper
+    pro_gripper_id = 17
+    if pro_gripper_id in present_dxl_model_id_map.keys():
+        cli_device.logger.info(f"The Stretch Gripper dxl id set to {present_dxl_model_id_map[pro_gripper_id]}")
+        cli_device.logger.info("Done!")
         return True
 
     cli_device.logger.info("Which seems correct based on the hardware connected to your robot")

--- a/tools/bin/stretch_configure_tool.py
+++ b/tools/bin/stretch_configure_tool.py
@@ -93,7 +93,7 @@ def does_tool_need_to_change():
         'eoa_wrist_dw3_tool_nil': (3, True),
         'eoa_wrist_dw3_tool_sg3': (4, True),
         'eoa_wrist_dw3_tool_tablet_12in': (3, True),
-        'eoa_wrist_dw3_tool_sg3_xm430': (4, True),
+        'eoa_wrist_dw3_tool_sg3_pro': (4, True),
     }
     expected_num_wrist_dxls, expected_d405_present = tool_numdxls_d405_map.get(stretch_tool, (-1, False))
     if num_wrist_dxls != expected_num_wrist_dxls:
@@ -122,7 +122,7 @@ def determine_what_tool_is_correct():
         1: ['tool_none'],
         2: ['tool_stretch_gripper'],
         3: ['eoa_wrist_dw3_tool_nil', 'eoa_wrist_dw3_tool_tablet_12in'],
-        4: ['tool_stretch_dex_wrist', 'eoa_wrist_dw3_tool_sg3', 'eoa_wrist_dw3_tool_sg3_xm430']
+        4: ['tool_stretch_dex_wrist', 'eoa_wrist_dw3_tool_sg3', 'eoa_wrist_dw3_tool_sg3_pro']
     }
     numdxls_match = numdxls_tool_map.get(num_wrist_dxls, [])
     cli_device.logger.debug(f"These tools match based on {num_wrist_dxls} number of wrist dxls: {Fore.YELLOW + str(numdxls_match) + Style.RESET_ALL}")
@@ -132,7 +132,7 @@ def determine_what_tool_is_correct():
     # filter by d405 present
     d405_tool_map = {
         False: ['tool_none', 'tool_stretch_gripper', 'tool_stretch_dex_wrist', 'eoa_wrist_dw3_tool_nil'],
-        True: ['eoa_wrist_dw3_tool_sg3','eoa_wrist_dw3_tool_tablet_12in', 'eoa_wrist_dw3_tool_sg3_xm430'],
+        True: ['eoa_wrist_dw3_tool_sg3','eoa_wrist_dw3_tool_tablet_12in', 'eoa_wrist_dw3_tool_sg3_pro'],
     }
     d405_match = d405_tool_map.get(d405_present, [])
     cli_device.logger.debug(f"These tools match based on present={d405_present} gripper camera: {Fore.YELLOW + str(d405_match) + Style.RESET_ALL}")
@@ -221,7 +221,7 @@ def configure_tool(target_tool_name):
             'eoa_wrist_dw3_tool_nil': 0.75,
             'eoa_wrist_dw3_tool_tablet_12in': 0.75,
             'eoa_wrist_dw3_tool_sg3': 0.75,
-            'eoa_wrist_dw3_tool_sg3_xm430': 0.75,
+            'eoa_wrist_dw3_tool_sg3_pro': 0.75,
         }
         feedforward_value = tool_feedforward_map.get(target_tool_name, 0.8)
         cli_device.logger.debug(f'For model={stretch_model} and tool={target_tool_name}, choosing i_feedforward={feedforward_value}')
@@ -239,7 +239,7 @@ def configure_tool(target_tool_name):
             'eoa_wrist_dw3_tool_nil': 1.8,
             'eoa_wrist_dw3_tool_tablet_12in': 1.8,
             'eoa_wrist_dw3_tool_sg3': 1.8,
-            'eoa_wrist_dw3_tool_sg3_xm430': 1.8,
+            'eoa_wrist_dw3_tool_sg3_pro': 1.8,
         }
         feedforward_value = tool_feedforward_map.get(target_tool_name, 1.9)
         cli_device.logger.debug(f'For model={stretch_model} and tool={target_tool_name}, choosing i_feedforward={feedforward_value}')

--- a/tools/bin/stretch_configure_tool.py
+++ b/tools/bin/stretch_configure_tool.py
@@ -93,6 +93,7 @@ def does_tool_need_to_change():
         'eoa_wrist_dw3_tool_nil': (3, True),
         'eoa_wrist_dw3_tool_sg3': (4, True),
         'eoa_wrist_dw3_tool_tablet_12in': (3, True),
+        'eoa_wrist_dw3_tool_sg3_xm430': (4, True),
     }
     expected_num_wrist_dxls, expected_d405_present = tool_numdxls_d405_map.get(stretch_tool, (-1, False))
     if num_wrist_dxls != expected_num_wrist_dxls:
@@ -121,7 +122,7 @@ def determine_what_tool_is_correct():
         1: ['tool_none'],
         2: ['tool_stretch_gripper'],
         3: ['eoa_wrist_dw3_tool_nil', 'eoa_wrist_dw3_tool_tablet_12in'],
-        4: ['tool_stretch_dex_wrist', 'eoa_wrist_dw3_tool_sg3']
+        4: ['tool_stretch_dex_wrist', 'eoa_wrist_dw3_tool_sg3', 'eoa_wrist_dw3_tool_sg3_xm430']
     }
     numdxls_match = numdxls_tool_map.get(num_wrist_dxls, [])
     cli_device.logger.debug(f"These tools match based on {num_wrist_dxls} number of wrist dxls: {Fore.YELLOW + str(numdxls_match) + Style.RESET_ALL}")
@@ -131,7 +132,7 @@ def determine_what_tool_is_correct():
     # filter by d405 present
     d405_tool_map = {
         False: ['tool_none', 'tool_stretch_gripper', 'tool_stretch_dex_wrist', 'eoa_wrist_dw3_tool_nil'],
-        True: ['eoa_wrist_dw3_tool_sg3','eoa_wrist_dw3_tool_tablet_12in'],
+        True: ['eoa_wrist_dw3_tool_sg3','eoa_wrist_dw3_tool_tablet_12in', 'eoa_wrist_dw3_tool_sg3_xm430'],
     }
     d405_match = d405_tool_map.get(d405_present, [])
     cli_device.logger.debug(f"These tools match based on present={d405_present} gripper camera: {Fore.YELLOW + str(d405_match) + Style.RESET_ALL}")
@@ -220,6 +221,7 @@ def configure_tool(target_tool_name):
             'eoa_wrist_dw3_tool_nil': 0.75,
             'eoa_wrist_dw3_tool_tablet_12in': 0.75,
             'eoa_wrist_dw3_tool_sg3': 0.75,
+            'eoa_wrist_dw3_tool_sg3_xm430': 0.75,
         }
         feedforward_value = tool_feedforward_map.get(target_tool_name, 0.8)
         cli_device.logger.debug(f'For model={stretch_model} and tool={target_tool_name}, choosing i_feedforward={feedforward_value}')
@@ -237,6 +239,7 @@ def configure_tool(target_tool_name):
             'eoa_wrist_dw3_tool_nil': 1.8,
             'eoa_wrist_dw3_tool_tablet_12in': 1.8,
             'eoa_wrist_dw3_tool_sg3': 1.8,
+            'eoa_wrist_dw3_tool_sg3_xm430': 1.8,
         }
         feedforward_value = tool_feedforward_map.get(target_tool_name, 1.9)
         cli_device.logger.debug(f'For model={stretch_model} and tool={target_tool_name}, choosing i_feedforward={feedforward_value}')


### PR DESCRIPTION
- This PR updates the name of the xm430 gripper to `eoa_wrist_dw3_tool_sg3_pro`.
- This PR also modifies the `stretch_configure_tool.py` which now identifies Stretch Pro gripper with DXL ID set to `13`.